### PR TITLE
Fix footer: update master\u2192main branch refs and set fallback image src

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ If you use `ToQUBO.jl` in your work, we kindly ask you to include the following 
 <div align="center">
     <a href="https://github.com/JuliaQUBO/QUBO.jl">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/refs/heads/master/docs/src/assets/logo-collaboration-dark.png">
-      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/refs/heads/master/docs/src/assets/logo-collaboration-light.png">
-      <img alt="QUBO.jl Collaboration" src="">
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/refs/heads/main/docs/src/assets/logo-collaboration-dark.png">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/refs/heads/main/docs/src/assets/logo-collaboration-light.png">
+      <img alt="QUBO.jl Collaboration" src="https://raw.githubusercontent.com/JuliaQUBO/QUBO.jl/refs/heads/main/docs/src/assets/logo-collaboration-light.png">
     </picture> 
     </a>
 </div>


### PR DESCRIPTION
## Summary

Fixes the `<picture>` block in the README footer (lines 157–161):

- Updates both `srcset` URLs from `refs/heads/master` to `refs/heads/main` to match QUBO.jl's current default branch
- Sets a proper fallback `src` on the `<img>` element (was `src=""`) so the logo renders in renderers that do not support `<picture>`

Closes #98

## Test plan

- [ ] Verify the footer logo renders correctly in the GitHub README (both light and dark mode)
- [ ] Verify the fallback image URL resolves to the correct asset