### PR TITLE
Harden GDP indicator support

### DIFF
--- a/src/compiler/parse.jl
+++ b/src/compiler/parse.jl
@@ -19,7 +19,7 @@ function parse!(
 ) where {T}
     Base.empty!(g)
 
-    for (ω, c) in expansion(model.source[vi])
+    for (ω, c) in Virtual.expansion(model.source[vi])
         g[ω] += c
     end
 
@@ -183,4 +183,3 @@ function parse!(
 
     return nothing
 end
-

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+DisjunctiveProgramming = "0d27d021-0159-4c7d-b4a7-9ccb5d9366cf"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PseudoBooleanOptimization = "c8fa9a04-bc42-452d-8558-dc51757be744"
@@ -8,5 +9,6 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+DisjunctiveProgramming = "0.5, 0.6"
 JuMP = "1"
 QUBODrivers = "0.3"

--- a/test/integration/examples/logical/indicator.jl
+++ b/test/integration/examples/logical/indicator.jl
@@ -1,6 +1,9 @@
+using DisjunctiveProgramming
+
 function test_indicator()
     test_indicator_linear()
     test_indicator_quadratic()
+    test_indicator_disjunctive_programming()
 end
 
 """
@@ -56,3 +59,80 @@ function test_indicator_quadratic()
     return nothing
 end
 
+function test_indicator_disjunctive_programming()
+    @testset "→ DisjunctiveProgramming Indicator Reformulation" begin
+        test_indicator_disjunctive_programming_linear()
+        test_indicator_disjunctive_programming_quadratic()
+    end
+
+    return nothing
+end
+
+function test_indicator_disjunctive_programming_linear()
+    @testset "Linear GDP disjunction" begin
+        model = GDPModel(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+        @variable(model, 0 <= x <= 3)
+        @variable(model, Y[1:2], Logical)
+
+        @constraint(model, x <= 0, Disjunct(Y[1]))
+        @constraint(model, x >= 2, Disjunct(Y[2]))
+        @disjunction(model, Y)
+        @objective(model, Min, x)
+
+        set_attribute(x, ToQUBO.Attributes.VariableEncodingMethod(), ToQUBO.Encoding.Unary())
+        set_attribute(x, ToQUBO.Attributes.VariableEncodingBits(), 3)
+
+        optimize!(model; gdp_method = Indicator())
+
+        n, L, Q, α, β = QUBOTools.qubo(model, :dense)
+
+        @test n > 0
+        @test size(Q) == (n, n)
+        @test length(L) == n
+        @test termination_status(model) === MOI.LOCALLY_SOLVED
+        @test get_attribute(model, Attributes.CompilationStatus()) === MOI.LOCALLY_SOLVED
+
+        x̂ = value(x)
+
+        @test x̂ ≈ 0.0
+        @test x̂ <= 0.0 || x̂ >= 2.0
+    end
+
+    return nothing
+end
+
+function test_indicator_disjunctive_programming_quadratic()
+    @testset "Quadratic GDP disjunction" begin
+        model = GDPModel(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+        @variable(model, -1 <= x <= 2)
+        @variable(model, Y[1:2], Logical)
+
+        @constraint(model, (x + 1)^2 <= 0, Disjunct(Y[1]))
+        @constraint(model, (x - 1)^2 <= 0, Disjunct(Y[2]))
+        @disjunction(model, Y)
+        @objective(model, Min, x)
+
+        set_attribute(x, ToQUBO.Attributes.VariableEncodingMethod(), ToQUBO.Encoding.Unary())
+        set_attribute(x, ToQUBO.Attributes.VariableEncodingBits(), 3)
+
+        optimize!(model; gdp_method = Indicator())
+
+        n, L, Q, α, β = QUBOTools.qubo(model, :dense)
+
+        @test n > 0
+        @test size(Q) == (n, n)
+        @test length(L) == n
+        @test termination_status(model) === MOI.LOCALLY_SOLVED
+        @test get_attribute(model, Attributes.CompilationStatus()) === MOI.LOCALLY_SOLVED
+
+        x̂ = value(x)
+
+        @test x̂ ≈ -1.0
+        @test isapprox((x̂ + 1)^2, 0.0; atol = 1e-6) ||
+            isapprox((x̂ - 1)^2, 0.0; atol = 1e-6)
+    end
+
+    return nothing
+end


### PR DESCRIPTION
## Summary

- Add DisjunctiveProgramming as a test-only dependency for GDP indicator coverage.
- Add focused GDP tests that compile affine and quadratic disjunctions through `ToQUBO.Optimizer` using `gdp_method = Indicator()`.
- Fix variable-objective parsing by qualifying the virtual expansion API call.

## Tests run

- `julia +release -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(path=pwd()); Pkg.add(["JuMP", "QUBODrivers", "QUBOTools", "DisjunctiveProgramming"]); using Test; using JuMP; using QUBODrivers; using ToQUBO; using ToQUBO: Attributes; import QUBOTools; const MOI = ToQUBO.MOI; function QUBOTools.backend(model::JuMP.Model) return QUBOTools.backend(JuMP.unsafe_backend(model)) end; include("test/integration/examples/logical/indicator.jl"); @testset "GDP indicator target" begin test_indicator_disjunctive_programming() end'` - passed, 14/14
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` - passed, 693/693

## Notes

- `julia --project=. -e 'using Pkg; Pkg.test()'` with the default local Julia 1.11.5 failed before tests because the checked-in manifest was resolved with Julia 1.12 and referenced unavailable artifact sources. The passing full suite was run with the local `julia +release` channel, which is Julia 1.12.0.

Closes #100
