### PR TITLE
Document GDP indicator workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,21 @@ Below, we present a list containing all[⁴](#4) MOI constraint types and their 
 | $x_i \in \left\lbrace{0}\right\rbrace \cup \left[{l, l + 1, \dots, u - 1, u}\right]$ | VariableIndex        | Semiinteger    |   ⌛    |
 | [¹](#1)                                                                              | VectorOfVariables    | SOS1           |   ✔️    |
 | [²](#2)                                                                              | VectorOfVariables    | SOS2           |   📖    |
-| $y = 1 \implies \vec{a}' \vec{x} \in S$                                              | VectorAffineFunction | Indicator      |   📖    |//////
+| $y = 1 \implies \vec{a}' \vec{x} \in S$                                              | VectorAffineFunction | Indicator      |   ✔️    |
 
 <a id="1">¹</a> 
 At most one component of **x** can be nonzero
 
 <a id="2">²</a>
 At most two components of **x** can be nonzero, and if so they must be adjacent components
+
+Indicator constraints are supported for activation on zero or one when the
+inner constraint is one of the scalar affine or quadratic constraint classes
+that ToQUBO can otherwise compile. Generalized disjunctive programming (GDP)
+models should use [DisjunctiveProgramming.jl](https://github.com/infiniteopt/DisjunctiveProgramming.jl)'s
+`Indicator()` reformulation, which emits JuMP/MOI indicator constraints that
+ToQUBO compiles directly; no separate `DisjunctiveToQUBO.jl` runtime package is
+required.
 
 | Symbol | Meaning                            |
 | :----: | ---------------------------------- |

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+DisjunctiveProgramming = "0d27d021-0159-4c7d-b4a7-9ccb5d9366cf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
@@ -7,6 +8,7 @@ QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 ToQUBO = "9a412ddf-83fa-43b6-9748-7843c851aa65"
 
 [compat]
+DisjunctiveProgramming = "0.5, 0.6"
 Documenter = "1"
 JuMP = "1"
 MathOptInterface = "1"

--- a/docs/src/manual/2-model.md
+++ b/docs/src/manual/2-model.md
@@ -80,6 +80,46 @@ ToQUBO.jl supports linear and quadratic constraints, which are reformulated as p
 @constraint(model, y[1] * y[2] + y[3] <= 1)
 ```
 
+### Generalized Disjunctive Programming
+
+Generalized disjunctive programming models can be written with
+[DisjunctiveProgramming.jl](https://github.com/infiniteopt/DisjunctiveProgramming.jl)
+and solved through ToQUBO when they are reformulated with `Indicator()`. In
+that workflow, `DisjunctiveProgramming.jl` turns logical disjuncts into JuMP/MOI
+indicator constraints, and ToQUBO compiles those indicator constraints into the
+QUBO objective. Add `DisjunctiveProgramming.jl` to your project environment
+when using this workflow.
+
+The compact example below is a two-square disjunction: `x` must lie either in
+the lower-left square or the upper-right square.
+
+```julia
+using JuMP
+using ToQUBO
+using QUBODrivers
+using DisjunctiveProgramming
+
+model = GDPModel(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+@variable(model, -2 <= x[1:2] <= 2)
+@variable(model, Y[1:2], Logical)
+
+@constraint(model, [i = 1:2], -2 <= x[i] <= -1, Disjunct(Y[1]))
+@constraint(model, [i = 1:2], 1 <= x[i] <= 2, Disjunct(Y[2]))
+@disjunction(model, Y)
+
+@objective(model, Min, x[1] - x[2])
+
+set_attribute.(x, ToQUBO.Attributes.VariableEncodingMethod(), ToQUBO.Encoding.Unary())
+set_attribute.(x, ToQUBO.Attributes.VariableEncodingBits(), 3)
+
+optimize!(model; gdp_method = Indicator())
+```
+
+This integration does not require a separate `DisjunctiveToQUBO.jl` package.
+Use `DisjunctiveProgramming.jl` for GDP modeling and reformulation, then use
+`ToQUBO.Optimizer` as the optimizer backend.
+
 ## Defining the Objective Function
 
 The objective function can be linear or quadratic. ToQUBO.jl supports both minimization and maximization.

--- a/docs/src/manual/2-model.md
+++ b/docs/src/manual/2-model.md
@@ -90,10 +90,11 @@ indicator constraints, and ToQUBO compiles those indicator constraints into the
 QUBO objective. Add `DisjunctiveProgramming.jl` to your project environment
 when using this workflow.
 
-The compact example below is a two-square disjunction: `x` must lie either in
-the lower-left square or the upper-right square.
+The compact example below is a reduced two-corner disjunction: `x` must lie
+either at the lower-left point or the upper-right point. It keeps the compiled
+QUBO small enough for `ExactSampler`.
 
-```julia
+```@example gdp_indicator
 using JuMP
 using ToQUBO
 using QUBODrivers
@@ -101,19 +102,21 @@ using DisjunctiveProgramming
 
 model = GDPModel(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
 
-@variable(model, -2 <= x[1:2] <= 2)
+@variable(model, -1 <= x[1:2] <= 1)
 @variable(model, Y[1:2], Logical)
 
-@constraint(model, [i = 1:2], -2 <= x[i] <= -1, Disjunct(Y[1]))
-@constraint(model, [i = 1:2], 1 <= x[i] <= 2, Disjunct(Y[2]))
+@constraint(model, [i = 1:2], x[i] == -1, Disjunct(Y[1]))
+@constraint(model, [i = 1:2], x[i] == 1, Disjunct(Y[2]))
 @disjunction(model, Y)
 
-@objective(model, Min, x[1] - x[2])
+@objective(model, Min, x[1] + x[2])
 
 set_attribute.(x, ToQUBO.Attributes.VariableEncodingMethod(), ToQUBO.Encoding.Unary())
-set_attribute.(x, ToQUBO.Attributes.VariableEncodingBits(), 3)
+set_attribute.(x, ToQUBO.Attributes.VariableEncodingBits(), 1)
 
 optimize!(model; gdp_method = Indicator())
+
+termination_status(model), primal_status(model), value.(x)
 ```
 
 This integration does not require a separate `DisjunctiveToQUBO.jl` package.

--- a/test/integration/examples/logical/indicator.jl
+++ b/test/integration/examples/logical/indicator.jl
@@ -63,6 +63,7 @@ function test_indicator_disjunctive_programming()
     @testset "→ DisjunctiveProgramming Indicator Reformulation" begin
         test_indicator_disjunctive_programming_linear()
         test_indicator_disjunctive_programming_quadratic()
+        test_indicator_disjunctive_programming_manual_example()
     end
 
     return nothing
@@ -132,6 +133,40 @@ function test_indicator_disjunctive_programming_quadratic()
         @test x̂ ≈ -1.0
         @test isapprox((x̂ + 1)^2, 0.0; atol = 1e-6) ||
             isapprox((x̂ - 1)^2, 0.0; atol = 1e-6)
+    end
+
+    return nothing
+end
+
+function test_indicator_disjunctive_programming_manual_example()
+    @testset "Manual GDP example" begin
+        model = GDPModel(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+        @variable(model, -1 <= x[1:2] <= 1)
+        @variable(model, Y[1:2], Logical)
+
+        @constraint(model, [i = 1:2], x[i] == -1, Disjunct(Y[1]))
+        @constraint(model, [i = 1:2], x[i] == 1, Disjunct(Y[2]))
+        @disjunction(model, Y)
+
+        @objective(model, Min, x[1] + x[2])
+
+        set_attribute.(x, ToQUBO.Attributes.VariableEncodingMethod(), ToQUBO.Encoding.Unary())
+        set_attribute.(x, ToQUBO.Attributes.VariableEncodingBits(), 1)
+
+        optimize!(model; gdp_method = Indicator())
+
+        n, L, Q, α, β = QUBOTools.qubo(model, :dense)
+
+        @test n > 0
+        @test n <= 8
+        @test size(Q) == (n, n)
+        @test length(L) == n
+        @test result_count(model) > 0
+        @test termination_status(model) === MOI.LOCALLY_SOLVED
+        @test primal_status(model) === MOI.FEASIBLE_POINT
+        @test get_attribute(model, Attributes.CompilationStatus()) === MOI.LOCALLY_SOLVED
+        @test value.(x) ≈ [-1.0, -1.0]
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- Document the DisjunctiveProgramming GDP workflow with `ToQUBO.Optimizer` and `gdp_method = Indicator()`.
- Add a compact two-square GDP example to the Running a Model manual page.
- Update the README indicator-constraint support table from research status to supported, with caveats and a note that no separate `DisjunctiveToQUBO.jl` runtime package is required.

## Tests run

- `julia +release -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(path=pwd()); Pkg.add(["Documenter", "JuMP", "MathOptInterface", "PySA", "QUBODrivers"]); push!(ARGS, "--skip-deploy"); include("docs/make.jl")'` - passed
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` - passed, 693/693

## Notes

- `julia +release --project=docs docs/make.jl --skip-deploy` was attempted first and failed before reaching these documentation changes because the local checked-out docs environment had not installed `PySA`, which is used by existing `@example` blocks. The successful docs build above uses a temporary instantiated environment and does not modify tracked manifest files.

Closes #101
