### PR TITLE
Document DisjunctiveToQUBO artifact disposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ that ToQUBO can otherwise compile. Generalized disjunctive programming (GDP)
 models should use [DisjunctiveProgramming.jl](https://github.com/infiniteopt/DisjunctiveProgramming.jl)'s
 `Indicator()` reformulation, which emits JuMP/MOI indicator constraints that
 ToQUBO compiles directly; no separate `DisjunctiveToQUBO.jl` runtime package is
-required.
+required. The historical
+[`pedromxavier/DisjunctiveToQUBO.jl`](https://github.com/pedromxavier/DisjunctiveToQUBO.jl)
+repository should be treated as a paper artifact, not as part of ToQUBO's
+runtime surface or CI.
 
 | Symbol | Meaning                            |
 | :----: | ---------------------------------- |

--- a/docs/src/manual/2-model.md
+++ b/docs/src/manual/2-model.md
@@ -123,6 +123,22 @@ This integration does not require a separate `DisjunctiveToQUBO.jl` package.
 Use `DisjunctiveProgramming.jl` for GDP modeling and reformulation, then use
 `ToQUBO.Optimizer` as the optimizer backend.
 
+#### Paper Artifact Repository
+
+The historical
+[`pedromxavier/DisjunctiveToQUBO.jl`](https://github.com/pedromxavier/DisjunctiveToQUBO.jl)
+repository is a paper/reproducibility artifact, not a maintained ToQUBO
+runtime package. Its notebooks, generated result files, PDFs, plots, and pinned
+notebook environments should stay outside ToQUBO's normal package tests and
+documentation CI.
+
+Maintained GDP usage examples belong in this manual. The artifact repository
+should either be archived as-is or keep its current ownership with a README
+notice that points readers to the maintained ToQUBO documentation for supported
+GDP workflows. Transferring it under `JuliaQUBO` should only be considered if
+the organization chooses to steward paper artifacts separately from production
+packages.
+
 ## Defining the Objective Function
 
 The objective function can be linear or quadratic. ToQUBO.jl supports both minimization and maximization.


### PR DESCRIPTION
## Summary

- Document that `pedromxavier/DisjunctiveToQUBO.jl` is a paper/reproducibility artifact, not a maintained ToQUBO runtime package.
- Record that notebooks, generated results, PDFs, plots, and pinned notebook environments should stay outside ToQUBO's normal package tests and documentation CI.
- Add a README pointer so users do not treat the historical artifact repository as part of the supported GDP workflow.

## Tests run

- `julia +release --project=docs docs/make.jl --skip-deploy` - passed; existing missing-docstring warnings remain.
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` - passed, 702/702.

## Notes

- No tests were skipped.
- The external artifact repository is currently not archived; this PR records the ToQUBO-side disposition and does not modify that repository.

Closes #102
