### PR TITLE
Document GDP support status

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ that ToQUBO can otherwise compile. Generalized disjunctive programming (GDP)
 models should use [DisjunctiveProgramming.jl](https://github.com/infiniteopt/DisjunctiveProgramming.jl)'s
 `Indicator()` reformulation, which emits JuMP/MOI indicator constraints that
 ToQUBO compiles directly; no separate `DisjunctiveToQUBO.jl` runtime package is
-required. The historical
+required. ToQUBO's maintained GDP support is this indicator-constraint
+compilation path, not a separate GDP-specific API or runtime dependency on
+`DisjunctiveProgramming.jl`. The historical
 [`pedromxavier/DisjunctiveToQUBO.jl`](https://github.com/pedromxavier/DisjunctiveToQUBO.jl)
 repository should be treated as a paper artifact, not as part of ToQUBO's
 runtime surface or CI.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,11 @@ compilation path, not a separate GDP-specific API or runtime dependency on
 `DisjunctiveProgramming.jl`. The historical
 [`pedromxavier/DisjunctiveToQUBO.jl`](https://github.com/pedromxavier/DisjunctiveToQUBO.jl)
 repository should be treated as a paper artifact, not as part of ToQUBO's
-runtime surface or CI.
+runtime surface or CI. The associated paper is Xavier, Pedro Maciel, Pedro
+Ripper, Joshua Pulsipher, Joaquim Dias Garcia, Nelson Maculan, and David E.
+Bernal Neira. "Disjunctive programming meets QUBO." In *Computer Aided Chemical
+Engineering*, vol. 53, pp. 3433-3438. Elsevier, 2024.
+[`ScienceDirect`](https://www.sciencedirect.com/science/chapter/bookseries/pii/B9780443288241505731).
 
 | Symbol | Meaning                            |
 | :----: | ---------------------------------- |

--- a/docs/src/manual/2-model.md
+++ b/docs/src/manual/2-model.md
@@ -90,6 +90,14 @@ indicator constraints, and ToQUBO compiles those indicator constraints into the
 QUBO objective. Add `DisjunctiveProgramming.jl` to your project environment
 when using this workflow.
 
+ToQUBO's maintained GDP support boundary is this indicator-constraint
+compilation path. `DisjunctiveProgramming.jl` remains the modeling and
+reformulation package, ToQUBO remains the optimizer backend, and ToQUBO does
+not expose a separate GDP-specific runtime API. The historical
+`DisjunctiveToQUBO.jl` artifact did not introduce production package code that
+needs to be migrated into ToQUBO; ongoing support is maintained here through
+indicator-constraint compilation, tests, and examples.
+
 The compact example below is a reduced two-corner disjunction: `x` must lie
 either at the lower-left point or the upper-right point. It keeps the compiled
 QUBO small enough for `ExactSampler`.

--- a/docs/src/manual/2-model.md
+++ b/docs/src/manual/2-model.md
@@ -96,7 +96,12 @@ reformulation package, ToQUBO remains the optimizer backend, and ToQUBO does
 not expose a separate GDP-specific runtime API. The historical
 `DisjunctiveToQUBO.jl` artifact did not introduce production package code that
 needs to be migrated into ToQUBO; ongoing support is maintained here through
-indicator-constraint compilation, tests, and examples.
+indicator-constraint compilation, tests, and examples. The underlying paper is
+Xavier, Pedro Maciel, Pedro Ripper, Joshua Pulsipher, Joaquim Dias Garcia,
+Nelson Maculan, and David E. Bernal Neira. "Disjunctive programming meets
+QUBO." In *Computer Aided Chemical Engineering*, vol. 53, pp. 3433-3438.
+Elsevier, 2024.
+[`ScienceDirect`](https://www.sciencedirect.com/science/chapter/bookseries/pii/B9780443288241505731).
 
 The compact example below is a reduced two-corner disjunction: `x` must lie
 either at the lower-left point or the upper-right point. It keeps the compiled
@@ -138,7 +143,9 @@ The historical
 repository is a paper/reproducibility artifact, not a maintained ToQUBO
 runtime package. Its notebooks, generated result files, PDFs, plots, and pinned
 notebook environments should stay outside ToQUBO's normal package tests and
-documentation CI.
+documentation CI. Cite the associated paper as Xavier et al. (2024),
+"Disjunctive programming meets QUBO," *Computer Aided Chemical Engineering*,
+vol. 53, pp. 3433-3438.
 
 Maintained GDP usage examples belong in this manual. The artifact repository
 should either be archived as-is or keep its current ownership with a README


### PR DESCRIPTION
## Summary

- Document ToQUBO's maintained GDP support boundary as the MOI/JuMP indicator-constraint compilation path.
- Clarify that `DisjunctiveProgramming.jl` remains the GDP modeling/reformulation package and is not a ToQUBO runtime dependency.
- Record that the historical `DisjunctiveToQUBO.jl` artifact did not introduce production package code to migrate into ToQUBO.
- Add the bibliographic reference for Xavier et al. (2024), "Disjunctive programming meets QUBO."

## Tests run

- `julia +release --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'` - passed; restored the local docs environment after the first docs build found missing `MbedTLS_jll` source data for existing PySA examples.
- `julia +release --project=docs docs/make.jl --skip-deploy` - passed after instantiating docs; existing missing-docstring warnings remain.
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` - passed, 702/702.
- After adding the paper reference, reran `julia +release --project=docs docs/make.jl --skip-deploy` - passed with existing missing-docstring warnings.
- After adding the paper reference, reran `julia +release --project=. -e 'using Pkg; Pkg.test()'` - passed, 702/702.

## Notes

- No tests were skipped.
- This closes the umbrella tracking issue after #100, #101, and #102 were completed.

Closes #103
