### PR TITLE
Implement linear constraint penalties

### DIFF
--- a/docs/src/booklet/4-encoding.md
+++ b/docs/src/booklet/4-encoding.md
@@ -93,4 +93,12 @@ A QUBO model is unconstrained. So when `ToQUBO` is reformulating a problem, it n
 As constraints are introduced into the objective function, we need to make sure that they won't be violated.
 In order to do that, `ToQUBO` multiplies the encoded constraint by a large penalty ``\rho``, so that any violation would result in a sub-optimal solution to the problem.
 
+Equality constraints use a squared residual penalty by default. The compiler can
+also encode an equality constraint with a signed linear residual through
+[`ToQUBO.Attributes.LinearPenalty`](@ref). This is a heuristic method: the sign
+and magnitude of ``\rho`` affect whether the residual discourages the intended
+violations, so `ToQUBO` requires an explicit
+[`ToQUBO.Attributes.ConstraintEncodingPenaltyHint`](@ref) instead of inferring
+``\rho`` automatically.
+
 Sometimes, the encoding process might introduce higher-order terms, demanding `ToQUBO` to reduce the offending polynomials back to a quadratic form.

--- a/docs/src/booklet/4-encoding.md
+++ b/docs/src/booklet/4-encoding.md
@@ -95,10 +95,24 @@ In order to do that, `ToQUBO` multiplies the encoded constraint by a large penal
 
 Equality constraints use a squared residual penalty by default. The compiler can
 also encode an equality constraint with a signed linear residual through
-[`ToQUBO.Attributes.LinearPenalty`](@ref). This is a heuristic method: the sign
-and magnitude of ``\rho`` affect whether the residual discourages the intended
-violations, so `ToQUBO` requires an explicit
+[`ToQUBO.Attributes.LinearPenalty`](@ref). This option follows the linear Ising
+penalty method studied by Mirkarimi et al.[^Mirkarimi2024PRR] and demonstrated
+experimentally for quantum annealing.[^Mirkarimi2024NJP] It is a heuristic
+method: the sign and magnitude of ``\rho`` affect whether the residual
+discourages the intended violations, so `ToQUBO` requires an explicit
 [`ToQUBO.Attributes.ConstraintEncodingPenaltyHint`](@ref) instead of inferring
 ``\rho`` automatically.
 
 Sometimes, the encoding process might introduce higher-order terms, demanding `ToQUBO` to reduce the offending polynomials back to a quadratic form.
+
+[^Mirkarimi2024PRR]:
+    Puya Mirkarimi, Ishaan Shukla, David C. Hoyle, Ross Williams, and Nicholas
+    Chancellor. **Quantum optimization with linear Ising penalty functions for
+    customer data science**. _Physical Review Research_ 6, 043241 (2024).
+    [{doi}](https://doi.org/10.1103/PhysRevResearch.6.043241)
+
+[^Mirkarimi2024NJP]:
+    Puya Mirkarimi, David C. Hoyle, Ross Williams, and Nicholas Chancellor.
+    **Experimental demonstration of improved quantum optimization with linear
+    Ising penalties**. _New Journal of Physics_ 26, 103005 (2024).
+    [{doi}](https://doi.org/10.1088/1367-2630/ad7e4a)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -69,3 +69,18 @@ If you use `ToQUBO.jl` in your work, we kindly ask you to include the following 
   url          = {https://doi.org/10.5281/zenodo.7644291}
 }
 ```
+
+For the broader `QUBO.jl` ecosystem paper, cite the current preprint:
+
+```tex
+@misc{xavier2023qubojl,
+  author       = {Pedro Maciel Xavier and Pedro Ripper and Tiago Andrade and Joaquim Dias Garcia and Nelson Maculan and David E. Bernal Neira},
+  title        = {{QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}},
+  year         = {2023},
+  eprint       = {2307.02577},
+  archivePrefix = {arXiv},
+  primaryClass = {math.OC},
+  doi          = {10.48550/arXiv.2307.02577},
+  url          = {https://arxiv.org/abs/2307.02577}
+}
+```

--- a/docs/src/manual/2-model.md
+++ b/docs/src/manual/2-model.md
@@ -60,6 +60,11 @@ Continuous variables within a bounded interval are discretized and encoded.
 ## Defining Constraints
 
 ToQUBO.jl supports linear and quadratic constraints, which are reformulated as penalty terms in the QUBO objective function.
+Equality constraints use a quadratic residual penalty by default. A signed
+linear residual can be selected with `Attributes.LinearPenalty()`, but it
+requires an explicit `Attributes.ConstraintEncodingPenaltyHint()` because the
+compiler cannot infer a safe coefficient for that form automatically. See
+[Constraint Penalty Methods](@ref) for the settings and an example.
 
 ### Linear Constraints
 

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -46,6 +46,12 @@ inference is disabled. Every equality constraint that uses `LinearPenalty()`
 must also have an explicit
 [`ToQUBO.Attributes.ConstraintEncodingPenaltyHint`](@ref).
 
+The method is motivated by the linear Ising penalty approach of Mirkarimi et
+al.[^Mirkarimi2024PRR] and its quantum annealing demonstration.[^Mirkarimi2024NJP]
+Those papers highlight the main tradeoff reflected in this API: linear
+penalties can avoid the extra couplings introduced by quadratic penalties, but
+they are heuristic and are not guaranteed to exactly enforce every constraint.
+
 ```julia
 using JuMP
 using ToQUBO
@@ -64,6 +70,18 @@ For mixed models, keep the default method as
 [`ToQUBO.Attributes.QuadraticPenalty`](@ref) and set
 [`ToQUBO.Attributes.ConstraintEncodingMethod`](@ref) only on the constraints
 that should use the linear residual.
+
+[^Mirkarimi2024PRR]:
+    Puya Mirkarimi, Ishaan Shukla, David C. Hoyle, Ross Williams, and Nicholas
+    Chancellor. **Quantum optimization with linear Ising penalty functions for
+    customer data science**. _Physical Review Research_ 6, 043241 (2024).
+    [{doi}](https://doi.org/10.1103/PhysRevResearch.6.043241)
+
+[^Mirkarimi2024NJP]:
+    Puya Mirkarimi, David C. Hoyle, Ross Williams, and Nicholas Chancellor.
+    **Experimental demonstration of improved quantum optimization with linear
+    Ising penalties**. _New Journal of Physics_ 26, 103005 (2024).
+    [{doi}](https://doi.org/10.1088/1367-2630/ad7e4a)
 
 ```@docs
 ToQUBO.Attributes.VariableEncodingBits

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -32,6 +32,39 @@ ToQUBO.Attributes.StableQuadratization
 
 ## Variable & Constraint Encoding
 
+### Constraint Penalty Methods
+
+Equality constraints are encoded with
+[`ToQUBO.Attributes.QuadraticPenalty`](@ref) by default. This squares the
+residual and lets the compiler infer a penalty coefficient when
+[`ToQUBO.Attributes.ConstraintEncodingPenaltyHint`](@ref) is not set.
+
+Use [`ToQUBO.Attributes.LinearPenalty`](@ref) only when you want an equality
+constraint encoded as its signed residual. Since this form can make infeasible
+assignments cheaper when the sign or magnitude is wrong, automatic penalty
+inference is disabled. Every equality constraint that uses `LinearPenalty()`
+must also have an explicit
+[`ToQUBO.Attributes.ConstraintEncodingPenaltyHint`](@ref).
+
+```julia
+using JuMP
+using ToQUBO
+using ToQUBO: Attributes
+
+model = Model(ToQUBO.Optimizer)
+@variable(model, x[1:2], Bin)
+@objective(model, Min, 0)
+c = @constraint(model, x[1] + x[2] == 1)
+
+set_attribute(model, Attributes.DefaultConstraintEncodingMethod(), Attributes.LinearPenalty())
+set_attribute(c, Attributes.ConstraintEncodingPenaltyHint(), -2.0)
+```
+
+For mixed models, keep the default method as
+[`ToQUBO.Attributes.QuadraticPenalty`](@ref) and set
+[`ToQUBO.Attributes.ConstraintEncodingMethod`](@ref) only on the constraints
+that should use the linear residual.
+
 ```@docs
 ToQUBO.Attributes.VariableEncodingBits
 ToQUBO.Attributes.DefaultVariableEncodingBits

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -40,6 +40,11 @@ ToQUBO.Attributes.DefaultVariableEncodingATol
 ToQUBO.Attributes.VariableEncodingMethod
 ToQUBO.Attributes.DefaultVariableEncodingMethod
 ToQUBO.Attributes.VariableEncodingPenalty
+ToQUBO.Attributes.QuadraticPenalty
+ToQUBO.Attributes.LinearPenalty
+ToQUBO.Attributes.DefaultConstraintEncodingMethod
+ToQUBO.Attributes.ConstraintEncodingMethod
+ToQUBO.Attributes.ConstraintEncodingPenaltyHint
 ToQUBO.Attributes.ConstraintEncodingPenalty
 ```
 

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -33,6 +33,7 @@ Encode equality constraints with a signed linear residual penalty.
 This method is heuristic: unlike [`QuadraticPenalty`](@ref), it is not
 guaranteed to make every infeasible assignment more expensive. Use
 [`ConstraintEncodingPenaltyHint`](@ref) to tune the signed penalty strength.
+Automatic penalty inference is not available for this method.
 """
 struct LinearPenalty <: ConstraintPenaltyMethod end
 
@@ -849,6 +850,8 @@ Sets the method used to reformulate an equality constraint.
 
 When unset, this falls back to [`DefaultConstraintEncodingMethod`](@ref).
 Inequality constraints keep the existing quadratic slack formulation.
+When set to [`LinearPenalty`](@ref), the constraint must also have an explicit
+[`ConstraintEncodingPenaltyHint`](@ref).
 """
 struct ConstraintEncodingMethod <: CompilerConstraintAttribute end
 

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -16,6 +16,30 @@ function MOIU.map_indices(::Function, e::Encoding.VariableEncodingMethod)
     return e
 end
 
+abstract type ConstraintPenaltyMethod end
+
+@doc raw"""
+    QuadraticPenalty()
+
+Encode equality constraints with the standard squared residual penalty.
+"""
+struct QuadraticPenalty <: ConstraintPenaltyMethod end
+
+@doc raw"""
+    LinearPenalty()
+
+Encode equality constraints with a signed linear residual penalty.
+
+This method is heuristic: unlike [`QuadraticPenalty`](@ref), it is not
+guaranteed to make every infeasible assignment more expensive. Use
+[`ConstraintEncodingPenaltyHint`](@ref) to tune the signed penalty strength.
+"""
+struct LinearPenalty <: ConstraintPenaltyMethod end
+
+function MOIU.map_indices(::Function, method::ConstraintPenaltyMethod)
+    return method
+end
+
 function _attribute_from_key end
 
 _attribute_from_key(key::Symbol) = _attribute_from_key(Val(key))
@@ -217,6 +241,51 @@ end
 
 function discretize(model::Optimizer)::Bool
     return MOI.get(model, Discretize())
+end
+
+@doc raw"""
+    DefaultConstraintEncodingMethod()
+
+Fallback method used to reformulate equality constraints.
+
+Available options are:
+- [`QuadraticPenalty`](@ref) (default)
+- [`LinearPenalty`](@ref)
+"""
+struct DefaultConstraintEncodingMethod <: CompilerAttribute end
+
+_attribute_from_key(::Val{:default_constraint_encoding_method}) =
+    DefaultConstraintEncodingMethod
+
+function MOI.get(
+    model::Optimizer,
+    ::DefaultConstraintEncodingMethod,
+)::ConstraintPenaltyMethod
+    return get(
+        model.compiler_settings,
+        :default_constraint_encoding_method,
+        QuadraticPenalty(),
+    )
+end
+
+function MOI.set(
+    model::Optimizer,
+    ::DefaultConstraintEncodingMethod,
+    method::ConstraintPenaltyMethod,
+)
+    model.compiler_settings[:default_constraint_encoding_method] = method
+
+    return nothing
+end
+
+function MOI.set(model::Optimizer, ::DefaultConstraintEncodingMethod, ::Nothing)
+    delete!(model.compiler_settings, :default_constraint_encoding_method)
+
+    return nothing
+end
+
+function default_constraint_encoding_method(model::Optimizer)::ConstraintPenaltyMethod
+    return MOI.get(model, DefaultConstraintEncodingMethod())
 end
 
 @doc raw"""
@@ -769,6 +838,75 @@ function MOI.set(
     ::Nothing,
 ) where {T}
     delete!(model.ρ, ci)
+
+    return nothing
+end
+
+@doc raw"""
+    ConstraintEncodingMethod()
+
+Sets the method used to reformulate an equality constraint.
+
+When unset, this falls back to [`DefaultConstraintEncodingMethod`](@ref).
+Inequality constraints keep the existing quadratic slack formulation.
+"""
+struct ConstraintEncodingMethod <: CompilerConstraintAttribute end
+
+_attribute_from_key(::Val{:constraint_encoding_method}) = ConstraintEncodingMethod
+
+function constraint_encoding_method(model::Optimizer, ci::CI)::ConstraintPenaltyMethod
+    method = MOI.get(model, ConstraintEncodingMethod(), ci)
+
+    if isnothing(method)
+        return MOI.get(model, DefaultConstraintEncodingMethod())
+    else
+        return method
+    end
+end
+
+function MOI.get(
+    model::Optimizer,
+    ::ConstraintEncodingMethod,
+    ci::CI,
+)::Union{ConstraintPenaltyMethod,Nothing}
+    attr = :constraint_encoding_method
+
+    if !haskey(model.constraint_settings, attr) ||
+       !haskey(model.constraint_settings[attr], ci)
+        return nothing
+    else
+        return model.constraint_settings[attr][ci]
+    end
+end
+
+function MOI.set(
+    model::Optimizer,
+    ::ConstraintEncodingMethod,
+    ci::CI,
+    method::ConstraintPenaltyMethod,
+)
+    attr = :constraint_encoding_method
+
+    if !haskey(model.constraint_settings, attr)
+        model.constraint_settings[attr] = Dict{CI,Any}()
+    end
+
+    model.constraint_settings[attr][ci] = method
+
+    return nothing
+end
+
+function MOI.set(
+    model::Optimizer,
+    ::ConstraintEncodingMethod,
+    ci::CI,
+    ::Nothing,
+)
+    attr = :constraint_encoding_method
+
+    if haskey(model.constraint_settings, attr)
+        delete!(model.constraint_settings[attr], ci)
+    end
 
     return nothing
 end

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -34,6 +34,12 @@ This method is heuristic: unlike [`QuadraticPenalty`](@ref), it is not
 guaranteed to make every infeasible assignment more expensive. Use
 [`ConstraintEncodingPenaltyHint`](@ref) to tune the signed penalty strength.
 Automatic penalty inference is not available for this method.
+
+This option follows the linear Ising penalty method studied by Mirkarimi et al.
+in "Quantum optimization with linear Ising penalty functions for customer data
+science" ([doi:10.1103/PhysRevResearch.6.043241](https://doi.org/10.1103/PhysRevResearch.6.043241))
+and "Experimental demonstration of improved quantum optimization with linear
+Ising penalties" ([doi:10.1088/1367-2630/ad7e4a](https://doi.org/10.1088/1367-2630/ad7e4a)).
 """
 struct LinearPenalty <: ConstraintPenaltyMethod end
 

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -26,6 +26,18 @@ function constraints!(
     return nothing
 end
 
+function _is_quadratic_penalty(model::Virtual.Model, ci::CI)::Bool
+    return Attributes.constraint_encoding_method(model, ci) isa Attributes.QuadraticPenalty
+end
+
+function _equality_penalty(model::Virtual.Model, ci::CI, g::PBO.PBF)
+    if _is_quadratic_penalty(model, ci)
+        return g^2
+    else
+        return g
+    end
+end
+
 @doc raw"""
     constraint(
         ::Virtual.Model{T},
@@ -80,7 +92,7 @@ into
 """
 function constraint(
     model::Virtual.Model{T},
-    ::CI,
+    ci::CI,
     f::SAF{T},
     s::EQ{T},
     arch::AbstractArchitecture,
@@ -105,7 +117,7 @@ function constraint(
         @warn "Infeasible constraint detected"
     end
 
-    return g^2
+    return _equality_penalty(model, ci, g)
 end
 
 @doc raw"""
@@ -283,7 +295,7 @@ into
 """
 function constraint(
     model::Virtual.Model{T},
-    ::CI,
+    ci::CI,
     f::SQF{T},
     s::EQ{T},
     arch::AbstractArchitecture,
@@ -311,10 +323,12 @@ function constraint(
         """
     end
 
-    # Tell the compiler that quadratization is necessary
-    MOI.set(model, Attributes.Quadratize(), true)
+    if _is_quadratic_penalty(model, ci)
+        # Tell the compiler that quadratization is necessary
+        MOI.set(model, Attributes.Quadratize(), true)
+    end
 
-    return g^2
+    return _equality_penalty(model, ci, g)
 end
 
 

--- a/src/compiler/penalties.jl
+++ b/src/compiler/penalties.jl
@@ -1,3 +1,8 @@
+function _uses_linear_equality_penalty(model::Virtual.Model, ci::CI)::Bool
+    return MOI.get(model, MOI.ConstraintSet(), ci) isa MOI.EqualTo &&
+           Attributes.constraint_encoding_method(model, ci) isa Attributes.LinearPenalty
+end
+
 function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
     # Adjust Sign
     σ = MOI.get(model, MOI.ObjectiveSense()) === MOI.MAX_SENSE ? -1 : 1
@@ -9,6 +14,14 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
         ρ = Attributes.constraint_encoding_penalty_hint(model, ci)
 
         if isnothing(ρ)
+            if _uses_linear_equality_penalty(model, ci)
+                compilation_error!(
+                    model,
+                    "LinearPenalty requires an explicit ConstraintEncodingPenaltyHint";
+                    status = "Missing linear constraint penalty hint",
+                )
+            end
+
             ϵ = PBO.mingap(g)
             ρ = σ * (δ / ϵ + β)
         end

--- a/test/integration/interface.jl
+++ b/test/integration/interface.jl
@@ -531,6 +531,20 @@ function test_interface_jump()
                 JuMP.set_attribute(model, Attributes.StableQuadratization(), true)
                 @test JuMP.get_attribute(model, Attributes.StableQuadratization()) === true
 
+                @test JuMP.get_attribute(
+                    model,
+                    Attributes.DefaultConstraintEncodingMethod(),
+                ) isa Attributes.QuadraticPenalty
+                JuMP.set_attribute(
+                    model,
+                    Attributes.DefaultConstraintEncodingMethod(),
+                    Attributes.LinearPenalty(),
+                )
+                @test JuMP.get_attribute(
+                    model,
+                    Attributes.DefaultConstraintEncodingMethod(),
+                ) isa Attributes.LinearPenalty
+
                 # Variable Encoding Method
                 @test JuMP.get_attribute(model, Attributes.DefaultVariableEncodingMethod()) isa Encoding.Binary
                 JuMP.set_attribute(model, Attributes.DefaultVariableEncodingMethod(), Encoding.Unary())
@@ -588,6 +602,16 @@ function test_interface_jump()
                 JuMP.set_attribute(c[1], Attributes.ConstraintEncodingPenaltyHint(), -10.0)
 
                 @test JuMP.get_attribute(c[1], Attributes.ConstraintEncodingPenaltyHint()) == -10.0
+                @test JuMP.get_attribute(c[1], Attributes.ConstraintEncodingMethod()) === nothing
+                JuMP.set_attribute(
+                    c[1],
+                    Attributes.ConstraintEncodingMethod(),
+                    Attributes.QuadraticPenalty(),
+                )
+                @test JuMP.get_attribute(
+                    c[1],
+                    Attributes.ConstraintEncodingMethod(),
+                ) isa Attributes.QuadraticPenalty
 
                 JuMP.optimize!(model)
 
@@ -601,6 +625,10 @@ function test_interface_jump()
 
                 @test JuMP.get_attribute(model, Attributes.QuadratizationMethod()) isa PBO.PTR_BG
                 @test JuMP.get_attribute(model, Attributes.StableQuadratization()) === true
+                @test JuMP.get_attribute(
+                    model,
+                    Attributes.DefaultConstraintEncodingMethod(),
+                ) isa Attributes.LinearPenalty
 
                 @test JuMP.get_attribute(model, Attributes.DefaultVariableEncodingMethod()) isa Encoding.Unary
 
@@ -626,6 +654,11 @@ function test_interface_jump()
 
                 @test JuMP.get_attribute(c[1], Attributes.ConstraintEncodingPenaltyHint()) == -10.0
                 @test JuMP.get_attribute(c[2], Attributes.ConstraintEncodingPenaltyHint()) === nothing
+                @test JuMP.get_attribute(
+                    c[1],
+                    Attributes.ConstraintEncodingMethod(),
+                ) isa Attributes.QuadraticPenalty
+                @test JuMP.get_attribute(c[2], Attributes.ConstraintEncodingMethod()) === nothing
 
                 @test JuMP.get_attribute(c[1], Attributes.ConstraintEncodingPenalty()) == -10.0
                 @test JuMP.get_attribute(c[2], Attributes.ConstraintEncodingPenalty()) == -4.0

--- a/test/unit/attributes/attributes.jl
+++ b/test/unit/attributes/attributes.jl
@@ -91,6 +91,33 @@ function test_compiler_attributes()
             end
         end
 
+        @testset "DefaultConstraintEncodingMethod" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                @test MOI.supports(model, Attributes.DefaultConstraintEncodingMethod())
+                @test MOI.get(
+                    model,
+                    Attributes.DefaultConstraintEncodingMethod(),
+                ) isa Attributes.QuadraticPenalty
+                @test Attributes.default_constraint_encoding_method(model) isa Attributes.QuadraticPenalty
+
+                MOI.set(
+                    model,
+                    Attributes.DefaultConstraintEncodingMethod(),
+                    Attributes.LinearPenalty(),
+                )
+                @test MOI.get(
+                    model,
+                    Attributes.DefaultConstraintEncodingMethod(),
+                ) isa Attributes.LinearPenalty
+
+                MOI.set(model, Attributes.DefaultConstraintEncodingMethod(), nothing)
+                @test MOI.get(
+                    model,
+                    Attributes.DefaultConstraintEncodingMethod(),
+                ) isa Attributes.QuadraticPenalty
+            end
+        end
+
         @testset "Quadratize" begin
             let model = ToQUBO.Optimizer{Float64}()
                 @test MOI.supports(model, Attributes.Quadratize())
@@ -277,6 +304,45 @@ function test_constraint_attributes()
 
                 MOI.set(model, Attributes.ConstraintEncodingPenaltyHint(), ci, nothing)
                 @test MOI.get(model, Attributes.ConstraintEncodingPenaltyHint(), ci) === nothing
+            end
+        end
+
+        @testset "ConstraintEncodingMethod" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                vi = MOI.add_variable(model)
+                f = MOI.ScalarAffineFunction{Float64}(
+                    [MOI.ScalarAffineTerm(1.0, vi)],
+                    0.0
+                )
+                ci = MOI.add_constraint(model, f, MOI.LessThan{Float64}(1.0))
+
+                @test MOI.supports(model, Attributes.ConstraintEncodingMethod(), typeof(ci))
+                @test MOI.get(model, Attributes.ConstraintEncodingMethod(), ci) === nothing
+                @test Attributes.constraint_encoding_method(model, ci) isa Attributes.QuadraticPenalty
+
+                MOI.set(
+                    model,
+                    Attributes.DefaultConstraintEncodingMethod(),
+                    Attributes.LinearPenalty(),
+                )
+                @test Attributes.constraint_encoding_method(model, ci) isa Attributes.LinearPenalty
+
+                MOI.set(
+                    model,
+                    Attributes.ConstraintEncodingMethod(),
+                    ci,
+                    Attributes.QuadraticPenalty(),
+                )
+                @test MOI.get(
+                    model,
+                    Attributes.ConstraintEncodingMethod(),
+                    ci,
+                ) isa Attributes.QuadraticPenalty
+                @test Attributes.constraint_encoding_method(model, ci) isa Attributes.QuadraticPenalty
+
+                MOI.set(model, Attributes.ConstraintEncodingMethod(), ci, nothing)
+                @test MOI.get(model, Attributes.ConstraintEncodingMethod(), ci) === nothing
+                @test Attributes.constraint_encoding_method(model, ci) isa Attributes.LinearPenalty
             end
         end
 

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -105,10 +105,54 @@ function test_compiler_constraints_linear_penalty()
     return nothing
 end
 
+function test_compiler_constraints_linear_penalty_requires_hint()
+    model = ToQUBO.Optimizer{Float64}()
+    x     = [MOI.add_variable(model) for _ = 1:2]
+
+    for xi in x
+        MOI.add_constraint(model, xi, MOI.ZeroOne())
+    end
+
+    f = MOI.ScalarAffineFunction{Float64}(
+        [
+            MOI.ScalarAffineTerm(1.0, x[1]),
+            MOI.ScalarAffineTerm(1.0, x[2]),
+        ],
+        0.0,
+    )
+    c = MOI.add_constraint(model, f, MOI.EqualTo{Float64}(1.0))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
+    )
+    MOI.set(
+        model,
+        Attributes.DefaultConstraintEncodingMethod(),
+        Attributes.LinearPenalty(),
+    )
+
+    @test_throws ToQUBO.Compiler.CompilationError MOI.optimize!(model)
+    @test MOI.get(model, Attributes.CompilationStatus()) == MOI.OTHER_ERROR
+    @test MOI.get(model, MOI.RawStatusString()) ==
+          "Missing linear constraint penalty hint"
+
+    MOI.set(model, Attributes.ConstraintEncodingPenaltyHint(), c, -2.0)
+    MOI.optimize!(model)
+
+    @test MOI.get(model, Attributes.CompilationStatus()) == MOI.LOCALLY_SOLVED
+    @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), c) == -2.0
+
+    return nothing
+end
+
 function test_compiler_constraints()
     @testset "→ Constraints" verbose = true begin
         test_compiler_constraints_quadratic()
         test_compiler_constraints_linear_penalty()
+        test_compiler_constraints_linear_penalty_requires_hint()
     end
 
     return nothing

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -50,9 +50,65 @@ function test_compiler_constraints_quadratic()
     return nothing
 end
 
+function test_compiler_constraints_linear_penalty()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch = ToQUBO.Compiler.GenericArchitecture()
+    x, _ = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 2))
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    f = MOI.ScalarAffineFunction{Float64}(
+        [
+            MOI.ScalarAffineTerm(1.0, x[1]),
+            MOI.ScalarAffineTerm(1.0, x[2]),
+        ],
+        0.0,
+    )
+    s = MOI.EqualTo{Float64}(1.0)
+    c = MOI.add_constraint(model.source_model, f, s)
+
+    g_quadratic = ToQUBO.Compiler.constraint(model, c, f, s, arch)
+
+    @test g_quadratic == PBO.PBF{VI,Float64}(
+        1.0,
+        x[1] => -1.0,
+        x[2] => -1.0,
+        [x[1], x[2]] => 2.0,
+    )
+
+    MOI.set(
+        model,
+        Attributes.DefaultConstraintEncodingMethod(),
+        Attributes.LinearPenalty(),
+    )
+
+    g_linear = ToQUBO.Compiler.constraint(model, c, f, s, arch)
+
+    @test g_linear == PBO.PBF{VI,Float64}(
+        -1.0,
+        x[1] => 1.0,
+        x[2] => 1.0,
+    )
+    @test MOI.get(model, Attributes.Quadratize()) === false
+
+    MOI.set(
+        model,
+        Attributes.ConstraintEncodingMethod(),
+        c,
+        Attributes.QuadraticPenalty(),
+    )
+
+    g_override = ToQUBO.Compiler.constraint(model, c, f, s, arch)
+
+    @test g_override == g_quadratic
+
+    return nothing
+end
+
 function test_compiler_constraints()
     @testset "→ Constraints" verbose = true begin
         test_compiler_constraints_quadratic()
+        test_compiler_constraints_linear_penalty()
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- Add `QuadraticPenalty` and `LinearPenalty` constraint penalty method objects.
- Add model-level `DefaultConstraintEncodingMethod` and per-constraint `ConstraintEncodingMethod` attributes.
- Compile equality constraints with either the existing squared residual penalty or the new signed linear residual penalty; inequalities continue to use the existing quadratic slack formulation.
- Document the new settings and add unit/integration coverage for MOI and JuMP usage.

## Tests run

- `julia +1.12 --project=test -e 'push!(LOAD_PATH, pwd()); using Test; import MathOptInterface as MOI; using JuMP; const MOIU = MOI.Utilities; const VI = MOI.VariableIndex; const CI{F,S} = MOI.ConstraintIndex{F,S}; using QUBODrivers; using LinearAlgebra; using TOML; using ToQUBO; using ToQUBO: Attributes, Encoding; import QUBOTools; import PseudoBooleanOptimization as PBO; function MOIU.map_indices(::Function, arch::QUBOTools.AbstractArchitecture) return arch end; function MOIU.map_indices(::Function, quad::PBO.QuadratizationMethod) return quad end; function QUBOTools.backend(model::JuMP.Model) return QUBOTools.backend(JuMP.unsafe_backend(model)) end; include("test/unit/compiler/constraints.jl"); include("test/unit/attributes/attributes.jl"); @testset "targeted linear penalty" begin test_compiler_constraints_linear_penalty(); test_compiler_attributes(); test_constraint_attributes(); end'`
  - Passed: 92/92.
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
  - Passed: 726/726.
- `julia +1.12 --project=docs docs/make.jl`
  - Passed. Documenter reported existing warnings for docstrings not included in the manual and skipped deployment because the command was run outside GitHub Actions.
- `git diff --check`
  - Passed.

## Notes

- No separate lint, type-check, or formatting command is documented in the repository. The repo has `.JuliaFormatter.toml`, but JuliaFormatter is not listed as a project/test/docs dependency.
- The default `julia` executable is 1.11.5 locally; `julia --project=. -e 'using Pkg; Pkg.test()'` failed before loading ToQUBO because the manifest was resolved with Julia 1.12 and `OpenSSL_jll` could not be located. The suite was rerun successfully with `julia +1.12`.

Closes #90
