### PR TITLE
Support semi variable encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Below, we present a list containing all[⁴](#4) MOI constraint types and their 
 | ------------------------------------------------------------------------------------ | -------------------- | -------------- | :----: |
 | $x_i  \in \mathbb{Z}$                                                                | VariableIndex        | Integer        |   ✔️    |
 | $x_i \in \left\lbrace{0, 1}\right\rbrace$                                            | VariableIndex        | ZeroOne        |   ✔️    |
-| $x_i \in \left\lbrace{0}\right\rbrace \cup \left[{l, u}\right]$                      | VariableIndex        | Semicontinuous |   ⌛    |
-| $x_i \in \left\lbrace{0}\right\rbrace \cup \left[{l, l + 1, \dots, u - 1, u}\right]$ | VariableIndex        | Semiinteger    |   ⌛    |
+| $x_i \in \left\lbrace{0}\right\rbrace \cup \left[{l, u}\right]$                      | VariableIndex        | Semicontinuous |   ✔️    |
+| $x_i \in \left\lbrace{0}\right\rbrace \cup \left[{l, l + 1, \dots, u - 1, u}\right]$ | VariableIndex        | Semiinteger    |   ✔️    |
 | [¹](#1)                                                                              | VectorOfVariables    | SOS1           |   ✔️    |
 | [²](#2)                                                                              | VectorOfVariables    | SOS2           |   📖    |
 | $y = 1 \implies \vec{a}' \vec{x} \in S$                                              | VectorAffineFunction | Indicator      |   ✔️    |

--- a/docs/src/booklet/4-encoding.md
+++ b/docs/src/booklet/4-encoding.md
@@ -11,7 +11,7 @@ ToQUBO.Encoding.encodes
 As you may already know, QUBO models are comprised only of binary variables.
 So when we are reformulating general optimization problems, one important step is to encode variables into binary ones.
 
-`ToQUBO` currently implements 6 encoding techniques.
+`ToQUBO` currently implements 6 base encoding techniques.
 Each method introduces a different number of variables, quadratic terms and linear terms.
 Also, they differ in the magnitude of their coefficients ``\Delta``.
 
@@ -52,6 +52,12 @@ ToQUBO.Encoding.Bounded
 ToQUBO.Encoding.SetVariableEncodingMethod
 ToQUBO.Encoding.OneHot
 ToQUBO.Encoding.DomainWall
+```
+
+### Semi-Domain Encoding
+
+```@docs
+ToQUBO.Encoding.Semi
 ```
 
 ### Representation Error

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -58,7 +58,15 @@ function constraint(
     ::Virtual.Model{T},
     ::CI,
     ::VI,
-    ::Union{MOI.ZeroOne,MOI.Integer,MOI.Interval{T},LT{T},GT{T}},
+    ::Union{
+        MOI.ZeroOne,
+        MOI.Integer,
+        MOI.Interval{T},
+        MOI.Semicontinuous{T},
+        MOI.Semiinteger{T},
+        LT{T},
+        GT{T},
+    },
     ::AbstractArchitecture,
 ) where {T}
     return nothing

--- a/src/compiler/variables.jl
+++ b/src/compiler/variables.jl
@@ -6,6 +6,8 @@ function variables!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
     𝔹 = Vector{VI}()
     ℤ = Dict{VI,Tuple{Union{T,Nothing},Union{T,Nothing}}}()
     ℝ = Dict{VI,Tuple{Union{T,Nothing},Union{T,Nothing}}}()
+    semiinteger = Dict{VI,Tuple{T,T}}()
+    semicontinuous = Dict{VI,Tuple{T,T}}()
 
     for ci in MOI.get(model, MOI.ListOfConstraintIndices{VI,MOI.ZeroOne}())
         # Binary Variable
@@ -23,7 +25,23 @@ function variables!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
         ℤ[x] = (nothing, nothing)
     end
 
-    for x in setdiff(Ω, 𝔹, keys(ℤ))
+    for ci in MOI.get(model, MOI.ListOfConstraintIndices{VI,MOI.Semiinteger{T}}())
+        # Semi-integer Variable
+        x = MOI.get(model, MOI.ConstraintFunction(), ci)
+        s = MOI.get(model, MOI.ConstraintSet(), ci)
+
+        semiinteger[x] = (s.lower, s.upper)
+    end
+
+    for ci in MOI.get(model, MOI.ListOfConstraintIndices{VI,MOI.Semicontinuous{T}}())
+        # Semi-continuous Variable
+        x = MOI.get(model, MOI.ConstraintFunction(), ci)
+        s = MOI.get(model, MOI.ConstraintSet(), ci)
+
+        semicontinuous[x] = (s.lower, s.upper)
+    end
+
+    for x in setdiff(Ω, 𝔹, keys(ℤ), keys(semiinteger), keys(semicontinuous))
         # Real Variable
         ℝ[x] = (nothing, nothing)
     end
@@ -82,7 +100,11 @@ function variables!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
             continue
         end
 
-        if haskey(ℤ, x)
+        if haskey(semiinteger, x)
+            variable_semiinteger!(model, x, semiinteger[x])
+        elseif haskey(semicontinuous, x)
+            variable_semicontinuous!(model, x, semicontinuous[x])
+        elseif haskey(ℤ, x)
             variable_ℤ!(model, x, ℤ[x])
         elseif haskey(ℝ, x)
             variable_ℝ!(model, x, ℝ[x])
@@ -96,6 +118,37 @@ end
 
 function variable_𝔹!(model::Virtual.Model{T}, i::Union{VI,CI}) where {T}
     return Encoding.encode!(model, i, Encoding.Mirror{T}())
+end
+
+function variable_semiinteger!(
+    model::Virtual.Model{T},
+    vi::VI,
+    S::Tuple{T,T},
+) where {T}
+    e = Attributes.variable_encoding_method(model, vi)
+
+    MOI.set(model, Attributes.Quadratize(), true)
+
+    return Encoding.encode!(model, vi, Encoding.Semi(e), S)
+end
+
+function variable_semicontinuous!(
+    model::Virtual.Model{T},
+    vi::VI,
+    S::Tuple{T,T},
+) where {T}
+    e = Attributes.variable_encoding_method(model, vi)
+    n = Attributes.variable_encoding_bits(model, vi)
+
+    MOI.set(model, Attributes.Quadratize(), true)
+
+    if !isnothing(n)
+        return Encoding.encode!(model, vi, Encoding.Semi(e), S, n)
+    else
+        tol = Attributes.variable_encoding_atol(model, vi)
+
+        return Encoding.encode!(model, vi, Encoding.Semi(e), S; tol)
+    end
 end
 
 function variable_ℤ!(model::Virtual.Model{T}, vi::VI, (a, b)::Tuple{A,B}) where {T,A<:Union{T,Nothing},B<:Union{T,Nothing}}

--- a/src/encoding/encoding.jl
+++ b/src/encoding/encoding.jl
@@ -16,6 +16,7 @@ include("variables/interval/arithmetic.jl")
 
 include("variables/set/one_hot.jl")
 include("variables/set/domain_wall.jl")
+include("variables/semi.jl")
 
 # include("constraints/constraints.jl")
 

--- a/src/encoding/variables/semi.jl
+++ b/src/encoding/variables/semi.jl
@@ -1,0 +1,46 @@
+@doc raw"""
+    Semi(e::VariableEncodingMethod)
+
+Wraps another variable encoding method to represent ``x \in \{0\} \cup X``.
+If the wrapped method encodes ``X`` as ``\xi[X](y)``, then `Semi` uses an
+additional activation bit ``z`` and encodes the semi-domain as
+``z \xi[X](y)``.
+"""
+struct Semi{E<:VariableEncodingMethod} <: VariableEncodingMethod
+    e::E
+end
+
+function _semi_encode(
+    var::Function,
+    y::Vector{VI},
+    xi::PBO.PBF{VI,T},
+    chi::Union{PBO.PBF{VI,T},Nothing},
+) where {T}
+    z = var(nothing)::VI
+    active = PBO.PBF{VI,T}(z)
+
+    return ([y; z], active * xi, isnothing(chi) ? nothing : active * chi)
+end
+
+function encode(var::Function, e::Semi, gamma::AbstractVector{T}) where {T}
+    return _semi_encode(var, encode(var, e.e, gamma)...)
+end
+
+function encode(
+    var::Function,
+    e::Semi,
+    S::Tuple{T,T};
+    tol::Union{T,Nothing} = nothing,
+) where {T}
+    return _semi_encode(var, encode(var, e.e, S; tol)...)
+end
+
+function encode(
+    var::Function,
+    e::Semi,
+    S::Tuple{T,T},
+    n::Union{Integer,Nothing};
+    tol::Union{T,Nothing} = nothing,
+) where {T}
+    return _semi_encode(var, encode(var, e.e, S, n; tol)...)
+end

--- a/test/unit/compiler/compiler.jl
+++ b/test/unit/compiler/compiler.jl
@@ -1,12 +1,14 @@
 include("constraints.jl")
 include("error.jl")
 include("analysis.jl")
+include("variables.jl")
 
 function test_compiler()
     @testset "□ Compiler" verbose = true begin
         test_compiler_constraints()
         test_compiler_error()
         test_compiler_analysis()
+        test_compiler_variables()
     end
 
     return nothing

--- a/test/unit/compiler/variables.jl
+++ b/test/unit/compiler/variables.jl
@@ -1,0 +1,62 @@
+function test_compiler_variables_semiinteger()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch = ToQUBO.Compiler.GenericArchitecture()
+    x = MOI.add_variable(model.source_model)
+    s = MOI.Semiinteger{Float64}(2.0, 4.0)
+    c = MOI.add_constraint(model.source_model, x, s)
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    v = model.source[x]
+    y = ToQUBO.Virtual.target(v)
+
+    @test ToQUBO.Virtual.encoding(v) isa Encoding.Semi
+    @test ToQUBO.Virtual.encoding(v).e isa Encoding.Binary
+    @test length(y) == 3
+    @test ToQUBO.Virtual.expansion(v) == PBO.PBF{VI,Float64}(
+        y[3] => 2.0,
+        [y[1], y[3]] => 1.0,
+        [y[2], y[3]] => 1.0,
+    )
+    @test isnothing(ToQUBO.Compiler.constraint(model, c, x, s, arch))
+    @test MOI.get(model, Attributes.Quadratize()) === true
+
+    return nothing
+end
+
+function test_compiler_variables_semicontinuous()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch = ToQUBO.Compiler.GenericArchitecture()
+    x = MOI.add_variable(model.source_model)
+    s = MOI.Semicontinuous{Float64}(1.0, 2.0)
+    c = MOI.add_constraint(model.source_model, x, s)
+
+    MOI.set(model, Attributes.VariableEncodingBits(), x, 2)
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    v = model.source[x]
+    y = ToQUBO.Virtual.target(v)
+
+    @test ToQUBO.Virtual.encoding(v) isa Encoding.Semi
+    @test ToQUBO.Virtual.encoding(v).e isa Encoding.Binary
+    @test length(y) == 3
+    @test ToQUBO.Virtual.expansion(v) == PBO.PBF{VI,Float64}(
+        y[3] => 1.0,
+        [y[1], y[3]] => 1 / 3,
+        [y[2], y[3]] => 2 / 3,
+    )
+    @test isnothing(ToQUBO.Compiler.constraint(model, c, x, s, arch))
+    @test MOI.get(model, Attributes.Quadratize()) === true
+
+    return nothing
+end
+
+function test_compiler_variables()
+    @testset "→ Variables" begin
+        test_compiler_variables_semiinteger()
+        test_compiler_variables_semicontinuous()
+    end
+
+    return nothing
+end

--- a/test/unit/encoding/variables.jl
+++ b/test/unit/encoding/variables.jl
@@ -688,6 +688,68 @@ function test_variable_encoding_methods()
                 end
             end
         end
+
+        @testset "⊛ Semi" begin
+            let e = ToQUBO.Encoding.Semi(ToQUBO.Encoding.Binary{Float64}())
+                @testset "ℤ" begin
+                    let φ = PBO.vargen(VI)
+                        S = (2.0, 4.0)
+
+                        y, ξ, χ = ToQUBO.Encoding.encode(φ, e, S)
+
+                        @test length(y) == 3
+                        @test y == VI.(1:3)
+                        @test ξ == PBO.PBF{VI,Float64}(
+                            y[3] => 2.0,
+                            [y[1], y[3]] => 1.0,
+                            [y[2], y[3]] => 1.0,
+                        )
+                        @test isnothing(χ)
+                    end
+                end
+
+                @testset "ℝ (fixed)" begin
+                    let φ = PBO.vargen(VI)
+                        S = (2.0, 4.0)
+                        n = 2
+
+                        y, ξ, χ = ToQUBO.Encoding.encode(φ, e, S, n)
+
+                        @test length(y) == n + 1
+                        @test y == VI.(1:(n+1))
+                        @test ξ == PBO.PBF{VI,Float64}(
+                            y[3] => 2.0,
+                            [y[1], y[3]] => 2 / 3,
+                            [y[2], y[3]] => 4 / 3,
+                        )
+                        @test isnothing(χ)
+                    end
+                end
+            end
+
+            let e = ToQUBO.Encoding.Semi(ToQUBO.Encoding.OneHot{Float64}())
+                @testset "Γ ⊂ ℝ" begin
+                    let φ = PBO.vargen(VI)
+                        Γ = [-1.0, 1.0]
+
+                        y, ξ, χ = ToQUBO.Encoding.encode(φ, e, Γ)
+
+                        @test length(y) == 3
+                        @test y == VI.(1:3)
+                        @test ξ == PBO.PBF{VI,Float64}(
+                            [y[1], y[3]] => -1.0,
+                            [y[2], y[3]] => 1.0,
+                        )
+                        @test χ == PBO.PBF{VI,Float64}(
+                            y[3] => 1.0,
+                            [y[1], y[3]] => -1.0,
+                            [y[2], y[3]] => -1.0,
+                            [y[1], y[2], y[3]] => 2.0,
+                        )
+                    end
+                end
+            end
+        end
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- Add `Encoding.Semi` to encode `{0} union X` domains as an activation bit times an existing variable encoding.
- Compile `MOI.Semicontinuous` and `MOI.Semiinteger` variable-domain constraints through the semi encoding path and skip them as regular constraints after variable encoding.
- Add focused encoding/compiler coverage and update support documentation.

## Tests run

- `julia +release --project=. -e 'using ToQUBO; using MathOptInterface; println(ToQUBO.__version__())'` - passed, printed `0.2.0`.
- `julia +release --project=. -e 'push!(LOAD_PATH, joinpath(pwd(), "test")); using Test; using JuMP; const MOI = JuMP.MOI; const MOIU = MOI.Utilities; const VI = MOI.VariableIndex; const CI{F,S} = MOI.ConstraintIndex{F,S}; using QUBODrivers; using LinearAlgebra; using TOML; using ToQUBO; using ToQUBO: Attributes, Encoding; import QUBOTools; import PseudoBooleanOptimization as PBO; include("test/unit/encoding/variables.jl"); include("test/unit/compiler/variables.jl"); @testset "targeted semi variable encodings" begin test_variable_encoding_methods(); test_compiler_variables(); end'` - passed, 142/142 assertions.
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` - passed, 755/755 assertions.
- `julia +release --project=docs docs/make.jl` - passed; Documenter reported existing non-fatal warnings about unlisted docstrings and skipped deployment outside CI.
- `git diff --check` - passed.

## Notes about tests not run

- No separate lint, type-check, or JuliaFormatter invocation was documented in the repository or CI. The repository has a `.JuliaFormatter.toml`, but no formatter dependency or command is configured.
- The default `julia --project=. ...` path on this machine uses Julia 1.11.5 and failed before loading the package because the global depot has incompatible precompile state for `MathOptInterface` dependencies. Local validation used `julia +release` 1.12.0, matching the checked-in manifests.

Closes #73
