### PR TITLE
Use domain-wall encoding for SOS1

### DIFF
--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -498,6 +498,14 @@ function constraint(
     ::MOI.SOS1{T},
     ::AbstractArchitecture,
 ) where {T}
+    if haskey(model.slack, ci)
+        v = model.slack[ci]
+
+        if Virtual.encoding(v) isa Encoding.DomainWall
+            return _sos1_domain_wall_penalty(T, Virtual.target(v))
+        end
+    end
+
     # Special Ordered Set of Type 1: ∑ x ≤ min x
     g = PBO.PBF{VI,T}()
     h = PBO.PBF{VI,T}()

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -560,6 +560,51 @@ function constraint(
     return g^2 + h
 end
 
+function _domain_wall_indicator_activation(::Type{T}, ξ::PBO.PBF{VI,T}) where {T}
+    if !(ξ[nothing] ≈ zero(T))
+        return ξ
+    end
+
+    positive = VI[]
+    negative = VI[]
+
+    for (ω, c) in ξ
+        if isempty(ω)
+            continue
+        elseif length(ω) != 1
+            return ξ
+        elseif c ≈ one(T)
+            push!(positive, only(ω))
+        elseif c ≈ -one(T)
+            push!(negative, only(ω))
+        else
+            return ξ
+        end
+    end
+
+    if length(positive) == 1 && isempty(negative)
+        return PBO.PBF{VI,T}(only(positive))
+    elseif length(positive) == 1 && length(negative) == 1
+        yi = PBO.PBF{VI,T}(only(positive))
+        yj = PBO.PBF{VI,T}(only(negative))
+
+        return yi * (one(T) - yj)
+    else
+        return ξ
+    end
+end
+
+function _indicator_activation(model::Virtual.Model{T}, xi::VI) where {T}
+    vi = model.source[xi]
+    ξ = Virtual.expansion(vi)
+
+    if Virtual.encoding(vi) isa Encoding.DomainWall
+        return _domain_wall_indicator_activation(T, ξ)
+    else
+        return ξ
+    end
+end
+
 function constraint(
     model::Virtual.Model{T},
     ci::CI,
@@ -570,11 +615,7 @@ function constraint(
     # Indicator Constraint: y = 0|1 => {g(x)}
 
     xi = first(f.terms).scalar_term.variable # Indicator Variable
-    vi = model.source[xi]
-
-    @assert Virtual.encoding(vi) isa Encoding.Mirror
-
-    yi = only(Virtual.target(vi))
+    yi = _indicator_activation(model, xi)
 
     g = MOI.ScalarAffineFunction{T}(
         SAT{T}[f.terms[i].scalar_term for i = 2:length(f.terms)],
@@ -585,9 +626,9 @@ function constraint(
     MOI.set(model, Attributes.Quadratize(), true)
 
     if A === MOI.ACTIVATE_ON_ONE
-        return PBO.PBF{VI,T}(yi) * constraint(model, ci, g, s.set, arch)
+        return yi * constraint(model, ci, g, s.set, arch)
     elseif A === MOI.ACTIVATE_ON_ZERO
-        return (one(T) - PBO.PBF{VI,T}(yi)) * constraint(model, ci, g, s.set, arch)
+        return (one(T) - yi) * constraint(model, ci, g, s.set, arch)
     else
         error("Indicator constraint activation type $(A) not supported")
     end
@@ -605,11 +646,7 @@ function constraint(
     # Indicator Constraint: y = 0|1 => {g(x)}
 
     xi = first(f.affine_terms).scalar_term.variable # Indicator Variable
-    vi = model.source[xi]
-
-    @assert Virtual.encoding(vi) isa Encoding.Mirror
-
-    yi = only(Virtual.target(vi))
+    yi = _indicator_activation(model, xi)
 
     g = MOI.ScalarQuadraticFunction{T}(
         SQT{T}[f.quadratic_terms[i].scalar_term for i = 2:length(f.quadratic_terms)],
@@ -621,9 +658,9 @@ function constraint(
     MOI.set(model, Attributes.Quadratize(), true)
 
     if A === MOI.ACTIVATE_ON_ONE
-        return PBO.PBF{VI,T}(yi) * constraint(model, ci, g, s.set, arch)
+        return yi * constraint(model, ci, g, s.set, arch)
     elseif A === MOI.ACTIVATE_ON_ZERO
-        return (one(T) - PBO.PBF{VI,T}(yi)) * constraint(model, ci, g, s.set, arch)
+        return (one(T) - yi) * constraint(model, ci, g, s.set, arch)
     else
         error("Indicator constraint activation type $(A) not supported")
     end

--- a/src/compiler/variables.jl
+++ b/src/compiler/variables.jl
@@ -92,7 +92,9 @@ function variables!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
     if Attributes.stable_compilation(model)
         sort!(Ω; by = x -> x.value)
     end
-    
+
+    _sos1_domain_wall_variables!(model, Set(𝔹))
+
     # Encode Variables
     for x in Ω
         # If variable was already encoded, skip
@@ -118,6 +120,90 @@ end
 
 function variable_𝔹!(model::Virtual.Model{T}, i::Union{VI,CI}) where {T}
     return Encoding.encode!(model, i, Encoding.Mirror{T}())
+end
+
+function _sos1_variable_counts(model::Virtual.Model{T}) where {T}
+    counts = Dict{VI,Int}()
+
+    for ci in MOI.get(
+        model,
+        MOI.ListOfConstraintIndices{MOI.VectorOfVariables,MOI.SOS1{T}}(),
+    )
+        x = MOI.get(model, MOI.ConstraintFunction(), ci)
+
+        for xi in x.variables
+            counts[xi] = get(counts, xi, 0) + 1
+        end
+    end
+
+    return counts
+end
+
+function _sos1_domain_wall_penalty(::Type{T}, y::Vector{VI}) where {T}
+    two = T(2)
+
+    return PBO.PBF{VI,T}(
+        [
+            [y[i] => two for i = 2:length(y)]
+            [(y[i], y[i+1]) => -two for i = 1:(length(y)-1)]
+        ],
+    )
+end
+
+function _sos1_domain_wall_expansion(::Type{T}, y::Vector{VI}, i::Integer) where {T}
+    if i == length(y)
+        return PBO.PBF{VI,T}(y[i] => one(T))
+    else
+        return PBO.PBF{VI,T}([y[i] => one(T), y[i+1] => -one(T)])
+    end
+end
+
+function _encode_sos1_domain_wall!(
+    model::Virtual.Model{T},
+    ci::CI{MOI.VectorOfVariables,MOI.SOS1{T}},
+    x::Vector{VI},
+) where {T}
+    y = MOI.add_variables(model.target_model, length(x))
+    e = Encoding.DomainWall{T}()
+    v = Virtual.Variable{T}(e, ci, y, PBO.PBF{VI,T}(), nothing)
+
+    Encoding.encode!(model, v)
+
+    for i in eachindex(x)
+        ξ = _sos1_domain_wall_expansion(T, y, i)
+        v = Virtual.Variable{T}(e, x[i], VI[], ξ, nothing)
+
+        Encoding.encode!(model, v)
+    end
+
+    return nothing
+end
+
+function _sos1_domain_wall_variables!(
+    model::Virtual.Model{T},
+    binary_variables::Set{VI},
+) where {T}
+    counts = _sos1_variable_counts(model)
+
+    for ci in MOI.get(
+        model,
+        MOI.ListOfConstraintIndices{MOI.VectorOfVariables,MOI.SOS1{T}}(),
+    )
+        x = MOI.get(model, MOI.ConstraintFunction(), ci)
+
+        if length(x.variables) <= 1
+            continue
+        end
+
+        if all(
+            xi -> xi in binary_variables && !haskey(model.source, xi) && counts[xi] == 1,
+            x.variables,
+        )
+            _encode_sos1_domain_wall!(model, ci, x.variables)
+        end
+    end
+
+    return nothing
 end
 
 function variable_semiinteger!(

--- a/test/integration/examples/logical/logical_sos.jl
+++ b/test/integration/examples/logical/logical_sos.jl
@@ -9,18 +9,17 @@ function test_logical_sos1()
         ]
 
         # Penalty Choice
-        ρ̄ = -16
+        ρ̄ = -13.5
 
         # Solution Data
         Q̄ = [
-            15 -28 -28 -32
-             0  15 -28 -32
-             0   0  15 -32
-             0   0   0  16
+            -1  33   0
+             0 -33  33
+             0   0 -33
         ]
 
         ᾱ = 1
-        β̄ = -16
+        β̄ = 0
 
         x̄ = Set{Vector{Int}}([[0, 0, 0]])
         ȳ = 0

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -194,35 +194,61 @@ function test_compiler_constraints_sos1_domain_wall()
 end
 
 function test_compiler_constraints_sos1_domain_wall_indicator_activation()
-    model = ToQUBO.Optimizer{Float64}()
-    x, _  = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), 2))
+    function indicator_function(::Val{:affine}, x)
+        return MOI.VectorAffineFunction{Float64}(
+            [
+                MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1])),
+                MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x[2])),
+            ],
+            [0.0, 0.0],
+        )
+    end
 
-    MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.SOS1{Float64}([1.0, 2.0]))
+    function indicator_function(::Val{:quadratic}, x)
+        return MOI.VectorQuadraticFunction{Float64}(
+            [MOI.VectorQuadraticTerm(2, MOI.ScalarQuadraticTerm(1.0, x[2], x[2]))],
+            [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1]))],
+            [0.0, 0.0],
+        )
+    end
 
-    f = MOI.VectorAffineFunction{Float64}(
-        [
-            MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1])),
-            MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x[2])),
-        ],
-        [0.0, 0.0],
-    )
+    for (label, function_type) in ("affine" => Val(:affine), "quadratic" => Val(:quadratic))
+        for activation in (MOI.ACTIVATE_ON_ONE, MOI.ACTIVATE_ON_ZERO)
+            @testset "$(label) $(activation)" begin
+                model = ToQUBO.Optimizer{Float64}()
+                x, _  = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), 2))
 
-    MOI.add_constraint(
-        model,
-        f,
-        MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan{Float64}(0.0)),
-    )
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-    MOI.set(
-        model,
-        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-        MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
-    )
+                c = MOI.add_constraint(
+                    model,
+                    MOI.VectorOfVariables(x),
+                    MOI.SOS1{Float64}([1.0, 2.0]),
+                )
 
-    MOI.optimize!(model)
+                MOI.add_constraint(
+                    model,
+                    indicator_function(function_type, x),
+                    MOI.Indicator{activation}(MOI.LessThan{Float64}(0.0)),
+                )
+                MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+                MOI.set(
+                    model,
+                    MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+                    MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
+                )
 
-    @test MOI.get(model, Attributes.CompilationStatus()) == MOI.LOCALLY_SOLVED
-    @test ToQUBO.Virtual.encoding(model.source[x[1]]) isa Encoding.DomainWall
+                MOI.optimize!(model)
+
+                y = ToQUBO.Virtual.target(model.slack[c])
+
+                @test MOI.get(model, Attributes.CompilationStatus()) == MOI.LOCALLY_SOLVED
+                @test ToQUBO.Virtual.encoding(model.source[x[1]]) isa Encoding.DomainWall
+                @test ToQUBO.Compiler._indicator_activation(model, x[1]) ==
+                      PBO.PBF{VI,Float64}(y[1]) * (1.0 - PBO.PBF{VI,Float64}(y[2]))
+                @test ToQUBO.Compiler._indicator_activation(model, x[2]) ==
+                      PBO.PBF{VI,Float64}(y[2])
+            end
+        end
+    end
 
     return nothing
 end

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -193,12 +193,47 @@ function test_compiler_constraints_sos1_domain_wall()
     return nothing
 end
 
+function test_compiler_constraints_sos1_domain_wall_indicator_activation()
+    model = ToQUBO.Optimizer{Float64}()
+    x, _  = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), 2))
+
+    MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.SOS1{Float64}([1.0, 2.0]))
+
+    f = MOI.VectorAffineFunction{Float64}(
+        [
+            MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1])),
+            MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x[2])),
+        ],
+        [0.0, 0.0],
+    )
+
+    MOI.add_constraint(
+        model,
+        f,
+        MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan{Float64}(0.0)),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
+    )
+
+    MOI.optimize!(model)
+
+    @test MOI.get(model, Attributes.CompilationStatus()) == MOI.LOCALLY_SOLVED
+    @test ToQUBO.Virtual.encoding(model.source[x[1]]) isa Encoding.DomainWall
+
+    return nothing
+end
+
 function test_compiler_constraints()
     @testset "→ Constraints" verbose = true begin
         test_compiler_constraints_quadratic()
         test_compiler_constraints_linear_penalty()
         test_compiler_constraints_linear_penalty_requires_hint()
         test_compiler_constraints_sos1_domain_wall()
+        test_compiler_constraints_sos1_domain_wall_indicator_activation()
     end
 
     return nothing

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -148,11 +148,57 @@ function test_compiler_constraints_linear_penalty_requires_hint()
     return nothing
 end
 
+function test_compiler_constraints_sos1_domain_wall()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch  = ToQUBO.Compiler.GenericArchitecture()
+    x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 3))
+    s     = MOI.SOS1{Float64}([1.0, 2.0, 3.0])
+    c     = MOI.add_constraint(model.source_model, MOI.VectorOfVariables(x), s)
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    v = model.slack[c]
+    y = ToQUBO.Virtual.target(v)
+
+    @test ToQUBO.Virtual.encoding(v) isa Encoding.DomainWall
+    @test length(y) == 3
+    @test MOI.get(model.target_model, MOI.ListOfVariableIndices()) == y
+    @test ToQUBO.Virtual.expansion(model.source[x[1]]) ==
+          PBO.PBF{VI,Float64}([y[1] => 1.0, y[2] => -1.0])
+    @test ToQUBO.Virtual.expansion(model.source[x[2]]) ==
+          PBO.PBF{VI,Float64}([y[2] => 1.0, y[3] => -1.0])
+    @test ToQUBO.Virtual.expansion(model.source[x[3]]) == PBO.PBF{VI,Float64}(y[3] => 1.0)
+
+    f = MOI.ScalarAffineFunction{Float64}(
+        [
+            MOI.ScalarAffineTerm(1.0, x[1]),
+            MOI.ScalarAffineTerm(2.0, x[2]),
+            MOI.ScalarAffineTerm(3.0, x[3]),
+        ],
+        0.0,
+    )
+    h = PBO.PBF{VI,Float64}()
+
+    ToQUBO.Compiler.parse!(model, h, f, arch)
+
+    @test h == PBO.PBF{VI,Float64}(y[1] => 1.0, y[2] => 1.0, y[3] => 1.0)
+    @test ToQUBO.Compiler.constraint(model, c, MOI.VectorOfVariables(x), s, arch) ==
+          PBO.PBF{VI,Float64}(
+              y[2] => 2.0,
+              y[3] => 2.0,
+              [y[1], y[2]] => -2.0,
+              [y[2], y[3]] => -2.0,
+          )
+
+    return nothing
+end
+
 function test_compiler_constraints()
     @testset "→ Constraints" verbose = true begin
         test_compiler_constraints_quadratic()
         test_compiler_constraints_linear_penalty()
         test_compiler_constraints_linear_penalty_requires_hint()
+        test_compiler_constraints_sos1_domain_wall()
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- Encode eligible binary SOS1 constraints with a shared domain-wall representation during variable compilation.
- Substitute each SOS1 source variable as an adjacent domain-wall difference before objectives and constraints are parsed.
- Keep the existing SOS1 fallback for non-binary, singleton, or overlapping SOS1 cases, and update SOS1 compiler/integration coverage.

## Tests run

- `julia +1.12 --project=. -e 'using Test; import MathOptInterface as MOI; import PseudoBooleanOptimization as PBO; using ToQUBO; using ToQUBO: Attributes, Encoding; const VI = MOI.VariableIndex; include("test/unit/compiler/constraints.jl"); test_compiler_constraints_sos1_domain_wall()'` - passed.
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` - passed, 763/763 tests.
- `git diff --check` - passed.

## Notes

- Local `julia` 1.11.5 and `julia +1.10` could not precompile the checked-out manifest because the cached `PrecompileTools` dependency references `Base.StaticData`; Julia 1.12.6 was used for local validation.

Closes #61
