### PR TITLE
Avoid squaring sign-definite constraint penalties

### DIFF
--- a/docs/src/booklet/4-encoding.md
+++ b/docs/src/booklet/4-encoding.md
@@ -102,7 +102,8 @@ In order to do that, `ToQUBO` multiplies the encoded constraint by a large penal
 Equality constraints use a squared residual penalty by default. If the parsed
 residual is provably nonnegative, the compiler can add the residual directly
 instead of squaring it, preserving the same minimizer at zero while avoiding
-unnecessary higher-order terms. The compiler can also encode an equality
+unnecessary higher-order terms. The usual automatic penalty inference still
+applies to this sign-definite shortcut. The compiler can also encode an equality
 constraint with a signed linear residual through
 [`ToQUBO.Attributes.LinearPenalty`](@ref). This option follows the linear Ising
 penalty method studied by Mirkarimi et al.[^Mirkarimi2024PRR] and demonstrated

--- a/docs/src/booklet/4-encoding.md
+++ b/docs/src/booklet/4-encoding.md
@@ -99,8 +99,11 @@ A QUBO model is unconstrained. So when `ToQUBO` is reformulating a problem, it n
 As constraints are introduced into the objective function, we need to make sure that they won't be violated.
 In order to do that, `ToQUBO` multiplies the encoded constraint by a large penalty ``\rho``, so that any violation would result in a sub-optimal solution to the problem.
 
-Equality constraints use a squared residual penalty by default. The compiler can
-also encode an equality constraint with a signed linear residual through
+Equality constraints use a squared residual penalty by default. If the parsed
+residual is provably nonnegative, the compiler can add the residual directly
+instead of squaring it, preserving the same minimizer at zero while avoiding
+unnecessary higher-order terms. The compiler can also encode an equality
+constraint with a signed linear residual through
 [`ToQUBO.Attributes.LinearPenalty`](@ref). This option follows the linear Ising
 penalty method studied by Mirkarimi et al.[^Mirkarimi2024PRR] and demonstrated
 experimentally for quantum annealing.[^Mirkarimi2024NJP] It is a heuristic

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -35,9 +35,13 @@ ToQUBO.Attributes.StableQuadratization
 ### Constraint Penalty Methods
 
 Equality constraints are encoded with
-[`ToQUBO.Attributes.QuadraticPenalty`](@ref) by default. This squares the
-residual and lets the compiler infer a penalty coefficient when
-[`ToQUBO.Attributes.ConstraintEncodingPenaltyHint`](@ref) is not set.
+[`ToQUBO.Attributes.QuadraticPenalty`](@ref) by default. This normally squares
+the residual and lets the compiler infer a penalty coefficient when
+[`ToQUBO.Attributes.ConstraintEncodingPenaltyHint`](@ref) is not set. When the
+parsed residual is provably nonnegative, the compiler can instead add the
+residual directly to avoid unnecessary higher-order terms while preserving the
+same minimizer at zero. The same automatic penalty inference applies to this
+sign-definite shortcut.
 
 Use [`ToQUBO.Attributes.LinearPenalty`](@ref) only when you want an equality
 constraint encoded as its signed residual. Since this form can make infeasible

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -22,6 +22,11 @@ abstract type ConstraintPenaltyMethod end
     QuadraticPenalty()
 
 Encode equality constraints with the standard squared residual penalty.
+
+If the parsed residual is provably nonnegative, the compiler may use the
+residual directly instead of squaring it. This preserves the same minimizer at
+zero while avoiding unnecessary higher-order terms. Automatic penalty inference
+is still available for this sign-definite shortcut.
 """
 struct QuadraticPenalty <: ConstraintPenaltyMethod end
 

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -109,6 +109,9 @@ into
 \left\Vert(\mathbf{x})\right\Vert_{\left\lbrace{0}\right\rbrace} = \left(\mathbf{a}'\mathbf{x} - b\right)^{2}
 
 ```
+
+If the residual is nonnegative over the encoded domain, the compiler uses the
+residual directly instead of squaring it.
 """
 function constraint(
     model::Virtual.Model{T},
@@ -163,7 +166,9 @@ into
 
 ```
 
-by adding a slack variable ``z``.
+when the residual is not already nonnegative. If it is nonnegative over the
+encoded domain, the compiler uses the residual directly instead of adding a
+slack variable.
 """
 function constraint(
     model::Virtual.Model{T},
@@ -248,7 +253,9 @@ into
 
 ```
 
-by adding a slack variable ``z``.
+when the residual is not already nonpositive. If it is nonpositive over the
+encoded domain, the compiler uses the negated residual directly instead of
+adding a slack variable.
 """
 function constraint(
     model::Virtual.Model{T},
@@ -320,6 +327,8 @@ into
 
 ```
 
+If the residual is nonnegative over the encoded domain, the compiler uses the
+residual directly instead of squaring it.
 """
 function constraint(
     model::Virtual.Model{T},
@@ -383,7 +392,9 @@ into
 
 ```
 
-by adding a slack variable ``z``.
+when the residual is not already nonnegative. If it is nonnegative over the
+encoded domain, the compiler uses the residual directly instead of adding a
+slack variable.
 """
 function constraint(
     model::Virtual.Model{T},
@@ -460,7 +471,9 @@ into
 
 ```
 
-by adding a slack variable ``z``.
+when the residual is not already nonpositive. If it is nonpositive over the
+encoded domain, the compiler uses the negated residual directly instead of
+adding a slack variable.
 """
 function constraint(
     model::Virtual.Model{T},

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -30,8 +30,20 @@ function _is_quadratic_penalty(model::Virtual.Model, ci::CI)::Bool
     return Attributes.constraint_encoding_method(model, ci) isa Attributes.QuadraticPenalty
 end
 
+function _is_nonnegative(g::PBO.PBF{VI,T})::Bool where {T}
+    l, _ = PBO.bounds(g)
+
+    return l >= zero(T)
+end
+
+function _is_nonpositive(g::PBO.PBF{VI,T})::Bool where {T}
+    _, u = PBO.bounds(g)
+
+    return u <= zero(T)
+end
+
 function _equality_penalty(model::Virtual.Model, ci::CI, g::PBO.PBF)
-    if _is_quadratic_penalty(model, ci)
+    if _is_quadratic_penalty(model, ci) && !_is_nonnegative(g)
         return g^2
     else
         return g
@@ -180,6 +192,10 @@ function constraint(
         @warn "Infeasible constraint detected"
     end
 
+    if _is_nonnegative(g)
+        return g
+    end
+
     # Slack Variable
     S = (zero(T), abs(l))
     z = if Attributes.discretize(model)
@@ -261,6 +277,10 @@ function constraint(
         @warn "Infeasible constraint detected"
     end
 
+    if _is_nonpositive(g)
+        return -g
+    end
+
     # Slack Variable
     S = (zero(T), abs(u))
     z = if Attributes.discretize(model)
@@ -331,7 +351,7 @@ function constraint(
         """
     end
 
-    if _is_quadratic_penalty(model, ci)
+    if _is_quadratic_penalty(model, ci) && !_is_nonnegative(g)
         # Tell the compiler that quadratization is necessary
         MOI.set(model, Attributes.Quadratize(), true)
     end
@@ -393,6 +413,10 @@ function constraint(
         Infeasible constraint detected:
         $(f) ≤ $(s.upper)
         """
+    end
+
+    if _is_nonnegative(g)
+        return g
     end
 
     # Slack Variable
@@ -463,6 +487,10 @@ function constraint(
         return nothing
     elseif u < zero(T) # Infeasible
         @warn "Infeasible constraint detected"
+    end
+
+    if _is_nonpositive(g)
+        return -g
     end
 
     # Slack Variable

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -148,6 +148,88 @@ function test_compiler_constraints_linear_penalty_requires_hint()
     return nothing
 end
 
+function test_compiler_constraints_sign_definite_penalty()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch  = ToQUBO.Compiler.GenericArchitecture()
+    x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 3))
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    f_affine = MOI.ScalarAffineFunction{Float64}(
+        [
+            MOI.ScalarAffineTerm(1.0, x[1]),
+            MOI.ScalarAffineTerm(1.0, x[2]),
+        ],
+        0.0,
+    )
+    s_affine = MOI.EqualTo{Float64}(0.0)
+    c_affine = MOI.add_constraint(model.source_model, f_affine, s_affine)
+
+    @test ToQUBO.Compiler.constraint(model, c_affine, f_affine, s_affine, arch) ==
+          PBO.PBF{VI,Float64}(
+              x[1] => 1.0,
+              x[2] => 1.0,
+          )
+
+    s_affine_lt = MOI.LessThan{Float64}(0.0)
+    c_affine_lt = MOI.add_constraint(model.source_model, f_affine, s_affine_lt)
+
+    @test ToQUBO.Compiler.constraint(model, c_affine_lt, f_affine, s_affine_lt, arch) ==
+          PBO.PBF{VI,Float64}(
+              x[1] => 1.0,
+              x[2] => 1.0,
+          )
+
+    f_negative = MOI.ScalarAffineFunction{Float64}(
+        [
+            MOI.ScalarAffineTerm(-1.0, x[1]),
+            MOI.ScalarAffineTerm(-1.0, x[2]),
+        ],
+        0.0,
+    )
+    s_negative = MOI.GreaterThan{Float64}(0.0)
+    c_negative = MOI.add_constraint(model.source_model, f_negative, s_negative)
+
+    @test ToQUBO.Compiler.constraint(model, c_negative, f_negative, s_negative, arch) ==
+          PBO.PBF{VI,Float64}(
+              x[1] => 1.0,
+              x[2] => 1.0,
+          )
+
+    f_quadratic = MOI.ScalarQuadraticFunction{Float64}(
+        [MOI.ScalarQuadraticTerm(1.0, x[1], x[2])],
+        [MOI.ScalarAffineTerm(1.0, x[3])],
+        0.0,
+    )
+    s_quadratic = MOI.EqualTo{Float64}(0.0)
+    c_quadratic = MOI.add_constraint(model.source_model, f_quadratic, s_quadratic)
+
+    @test ToQUBO.Compiler.constraint(model, c_quadratic, f_quadratic, s_quadratic, arch) ==
+          PBO.PBF{VI,Float64}(
+              x[3] => 1.0,
+              [x[1], x[2]] => 1.0,
+          )
+    @test MOI.get(model, Attributes.Quadratize()) === false
+
+    s_quadratic_lt = MOI.LessThan{Float64}(0.0)
+    c_quadratic_lt = MOI.add_constraint(model.source_model, f_quadratic, s_quadratic_lt)
+    g_quadratic_lt = ToQUBO.Compiler.constraint(
+        model,
+        c_quadratic_lt,
+        f_quadratic,
+        s_quadratic_lt,
+        arch,
+    )
+
+    @test g_quadratic_lt ==
+          PBO.PBF{VI,Float64}(
+              x[3] => 1.0,
+              [x[1], x[2]] => 1.0,
+          )
+
+    return nothing
+end
+
 function test_compiler_constraints_sos1_domain_wall()
     model = ToQUBO.Virtual.Model{Float64}()
     arch  = ToQUBO.Compiler.GenericArchitecture()
@@ -258,6 +340,7 @@ function test_compiler_constraints()
         test_compiler_constraints_quadratic()
         test_compiler_constraints_linear_penalty()
         test_compiler_constraints_linear_penalty_requires_hint()
+        test_compiler_constraints_sign_definite_penalty()
         test_compiler_constraints_sos1_domain_wall()
         test_compiler_constraints_sos1_domain_wall_indicator_activation()
     end


### PR DESCRIPTION
Summary
- Adds sign-definite residual detection for compiled pseudo-Boolean constraint penalties.
- Uses the residual directly for nonnegative equality and `LessThan(0)` cases, and uses the negated residual for nonpositive `GreaterThan(0)` cases, avoiding unnecessary slack variables and squared penalties.
- Keeps quadratic sign-definite residuals quadratic by skipping the quadratization flag when no square is introduced.
- Adds unit coverage for affine equality, affine less-than, affine greater-than, quadratic equality, and quadratic less-than sign-definite penalties.

Tests run
- `git diff --check` - passed.
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` - passed, 785 tests.

Notes
- The documented test command was run with Julia 1.12 because the checked-in manifest was resolved for Julia 1.12. Running it with Julia 1.10 failed before tests with an `OpenSSL_jll` manifest/source mismatch.
- The default Julia 1.11 toolchain in this environment failed to precompile `MathOptInterface` because `PrecompileTools` referenced `Base.StaticData`, so it was not used for final validation.

Closes #74
