### PR TITLE
Expand MOI support table coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ At most one component of **x** can be nonzero
 At most two components of **x** can be nonzero, and if so they must be adjacent components
 
 Indicator constraints are supported for activation on zero or one when the
-inner constraint is one of the scalar affine or quadratic constraint classes
-that ToQUBO can otherwise compile. Generalized disjunctive programming (GDP)
+inner constraint is scalar affine or quadratic with an `EqualTo`, `LessThan`,
+`GreaterThan`, or `Interval` bound set. Generalized disjunctive programming (GDP)
 models should use [DisjunctiveProgramming.jl](https://github.com/infiniteopt/DisjunctiveProgramming.jl)'s
 `Indicator()` reformulation, which emits JuMP/MOI indicator constraints that
 ToQUBO compiles directly; no separate `DisjunctiveToQUBO.jl` runtime package is

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Below, we present a list containing all[⁴](#4) MOI constraint types and their 
 
 | Mathematical Constraint                               | MOI Function            | MOI Set                  | Status |
 | ----------------------------------------------------- | ----------------------- | ------------------------ | :----: |
-| $\vec{x} Q \vec{x} + \vec{a}' \vec{x} + b \ge 0$      | ScalarQuadraticFunction | GreaterThan              |   ♻️    |
+| $\vec{x} Q \vec{x} + \vec{a}' \vec{x} + b \ge 0$      | ScalarQuadraticFunction | GreaterThan              |   ✔️    |
 | $\vec{x} Q \vec{x} + \vec{a}' \vec{x} + b \le 0$      | ScalarQuadraticFunction | LessThan                 |   ✔️    |
 | $\vec{x} Q \vec{x} + \vec{a}' \vec{x} + b = 0$        | ScalarQuadraticFunction | EqualTo                  |   ✔️    |
 | Bilinear matrix inequality                            | VectorQuadraticFunction | PositiveSemidefiniteCone |   ❌    |
@@ -115,6 +115,7 @@ Below, we present a list containing all[⁴](#4) MOI constraint types and their 
 | [¹](#1)                                                                              | VectorOfVariables    | SOS1           |   ✔️    |
 | [²](#2)                                                                              | VectorOfVariables    | SOS2           |   📖    |
 | $y = 1 \implies \vec{a}' \vec{x} \in S$                                              | VectorAffineFunction | Indicator      |   ✔️    |
+| $y = 1 \implies \vec{x}' Q \vec{x} + \vec{a}' \vec{x} \in S$                         | VectorQuadraticFunction | Indicator   |   ✔️    |
 
 <a id="1">¹</a> 
 At most one component of **x** can be nonzero

--- a/docs/src/manual/2-model.md
+++ b/docs/src/manual/2-model.md
@@ -69,8 +69,8 @@ compiler cannot infer a safe coefficient for that form automatically. See
 The optimizer accepts scalar affine and scalar quadratic constraints with
 `<=`, `>=`, and `==` bounds. It also accepts `SOS1` constraints and MOI
 indicator constraints whose inner scalar constraint is affine or quadratic and
-uses one of those same bound sets. Indicator constraints may activate on either
-zero or one.
+uses an `EqualTo`, `LessThan`, `GreaterThan`, or `Interval` bound set.
+Indicator constraints may activate on either zero or one.
 
 ### Linear Constraints
 
@@ -114,6 +114,9 @@ zero or one.
 
 # Quadratic inner constraint
 @constraint(model, z => {y[1] * y[2] + y[3] <= 1})
+
+# Interval inner constraint
+@constraint(model, z => {0 <= y[1] * y[2] + y[3] <= 1})
 ```
 
 ### Generalized Disjunctive Programming

--- a/docs/src/manual/2-model.md
+++ b/docs/src/manual/2-model.md
@@ -66,6 +66,12 @@ requires an explicit `Attributes.ConstraintEncodingPenaltyHint()` because the
 compiler cannot infer a safe coefficient for that form automatically. See
 [Constraint Penalty Methods](@ref) for the settings and an example.
 
+The optimizer accepts scalar affine and scalar quadratic constraints with
+`<=`, `>=`, and `==` bounds. It also accepts `SOS1` constraints and MOI
+indicator constraints whose inner scalar constraint is affine or quadratic and
+uses one of those same bound sets. Indicator constraints may activate on either
+zero or one.
+
 ### Linear Constraints
 
 ```julia
@@ -82,7 +88,32 @@ compiler cannot infer a safe coefficient for that form automatically. See
 ### Quadratic Constraints
 
 ```julia
+# Less than or equal
 @constraint(model, y[1] * y[2] + y[3] <= 1)
+
+# Equal to
+@constraint(model, y[1] * y[2] + y[3] == 1)
+
+# Greater than or equal
+@constraint(model, y[1] * y[2] + y[3] >= 1)
+```
+
+### SOS1 Constraints
+
+```julia
+@constraint(model, y in SOS1())
+```
+
+### Indicator Constraints
+
+```julia
+@variable(model, z, Bin)
+
+# Affine inner constraint
+@constraint(model, z => {2*y[1] + y[2] <= 1})
+
+# Quadratic inner constraint
+@constraint(model, z => {y[1] * y[2] + y[3] <= 1})
 ```
 
 ### Generalized Disjunctive Programming
@@ -91,9 +122,9 @@ Generalized disjunctive programming models can be written with
 [DisjunctiveProgramming.jl](https://github.com/infiniteopt/DisjunctiveProgramming.jl)
 and solved through ToQUBO when they are reformulated with `Indicator()`. In
 that workflow, `DisjunctiveProgramming.jl` turns logical disjuncts into JuMP/MOI
-indicator constraints, and ToQUBO compiles those indicator constraints into the
-QUBO objective. Add `DisjunctiveProgramming.jl` to your project environment
-when using this workflow.
+indicator constraints. ToQUBO then compiles those affine or quadratic indicator
+constraints into the QUBO objective. Add `DisjunctiveProgramming.jl` to your
+project environment when using this workflow.
 
 ToQUBO's maintained GDP support boundary is this indicator-constraint
 compilation path. `DisjunctiveProgramming.jl` remains the modeling and

--- a/docs/src/manual/2-model.md
+++ b/docs/src/manual/2-model.md
@@ -100,23 +100,31 @@ Indicator constraints may activate on either zero or one.
 
 ### SOS1 Constraints
 
+Special ordered sets of type 1 are supported over `VectorOfVariables`.
+
 ```julia
-@constraint(model, y in SOS1())
+@variable(model, s[1:3], Bin)
+@constraint(model, s in SOS1())
 ```
 
 ### Indicator Constraints
 
+JuMP/MOI represents indicator constraints as a vector function in an
+`Indicator` set. ToQUBO compiles both `VectorAffineFunction` and
+`VectorQuadraticFunction` indicator forms when the inner scalar constraint uses
+`<=`, `>=`, `==`, or an interval bound.
+
 ```julia
-@variable(model, z, Bin)
+@variable(model, a, Bin)
 
 # Affine inner constraint
-@constraint(model, z => {2*y[1] + y[2] <= 1})
+@constraint(model, a => {2*y[1] + y[2] <= 1})
 
 # Quadratic inner constraint
-@constraint(model, z => {y[1] * y[2] + y[3] <= 1})
+@constraint(model, a => {y[1] * y[2] + y[3] <= 1})
 
 # Interval inner constraint
-@constraint(model, z => {0 <= y[1] * y[2] + y[3] <= 1})
+@constraint(model, a => {0 <= y[1] * y[2] + y[3] <= 1})
 ```
 
 ### Generalized Disjunctive Programming

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -718,14 +718,14 @@ function constraint(
         _indicator_scalar_constant(T, f.constants),
     )
 
-    # Tell the compiler that quadratization is necessary
-    MOI.set(model, Attributes.Quadratize(), true)
-
     h = constraint(model, ci, g, s.set, arch)
 
     if isnothing(h)
         return nothing
     end
+
+    # Tell the compiler that quadratization is necessary
+    MOI.set(model, Attributes.Quadratize(), true)
 
     if A === MOI.ACTIVATE_ON_ONE
         return yi * h
@@ -758,14 +758,14 @@ function constraint(
         _indicator_scalar_constant(T, f.constants),
     )
 
-    # Tell the compiler that quadratization is necessary
-    MOI.set(model, Attributes.Quadratize(), true)
-
     h = constraint(model, ci, g, s.set, arch)
 
     if isnothing(h)
         return nothing
     end
+
+    # Tell the compiler that quadratization is necessary
+    MOI.set(model, Attributes.Quadratize(), true)
 
     if A === MOI.ACTIVATE_ON_ONE
         return yi * h

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -495,7 +495,7 @@ function constraint(
     if l > zero(T) # Always feasible
         @warn """
         Always-feasible constraint detected:
-        $(f) ≥ $(s.upper)
+        $(f) ≥ $(s.lower)
         """
         return nothing
     elseif u < zero(T) # Infeasible

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -50,6 +50,16 @@ function _equality_penalty(model::Virtual.Model, ci::CI, g::PBO.PBF)
     end
 end
 
+function _combine_penalties(lhs, rhs)
+    if isnothing(lhs)
+        return rhs
+    elseif isnothing(rhs)
+        return lhs
+    else
+        return lhs + rhs
+    end
+end
+
 @doc raw"""
     constraint(
         ::Virtual.Model{T},
@@ -226,8 +236,10 @@ function constraint(
     s::MOI.Interval{T},
     arch::AbstractArchitecture,
 ) where {T}
-    return constraint(model, ci, f, LT{T}(s.upper), arch) +
-           constraint(model, ci, f, GT{T}(s.lower), arch)
+    return _combine_penalties(
+        constraint(model, ci, f, LT{T}(s.upper), arch),
+        constraint(model, ci, f, GT{T}(s.lower), arch),
+    )
 end
 
 @doc raw"""
@@ -446,6 +458,19 @@ function constraint(
     MOI.set(model, Attributes.Quadratize(), true)
 
     return g^2
+end
+
+function constraint(
+    model::Virtual.Model{T},
+    ci::CI,
+    f::SQF{T},
+    s::MOI.Interval{T},
+    arch::AbstractArchitecture,
+) where {T}
+    return _combine_penalties(
+        constraint(model, ci, f, LT{T}(s.upper), arch),
+        constraint(model, ci, f, GT{T}(s.lower), arch),
+    )
 end
 
 @doc raw"""
@@ -696,10 +721,16 @@ function constraint(
     # Tell the compiler that quadratization is necessary
     MOI.set(model, Attributes.Quadratize(), true)
 
+    h = constraint(model, ci, g, s.set, arch)
+
+    if isnothing(h)
+        return nothing
+    end
+
     if A === MOI.ACTIVATE_ON_ONE
-        return yi * constraint(model, ci, g, s.set, arch)
+        return yi * h
     elseif A === MOI.ACTIVATE_ON_ZERO
-        return (one(T) - yi) * constraint(model, ci, g, s.set, arch)
+        return (one(T) - yi) * h
     else
         error("Indicator constraint activation type $(A) not supported")
     end
@@ -730,10 +761,16 @@ function constraint(
     # Tell the compiler that quadratization is necessary
     MOI.set(model, Attributes.Quadratize(), true)
 
+    h = constraint(model, ci, g, s.set, arch)
+
+    if isnothing(h)
+        return nothing
+    end
+
     if A === MOI.ACTIVATE_ON_ONE
-        return yi * constraint(model, ci, g, s.set, arch)
+        return yi * h
     elseif A === MOI.ACTIVATE_ON_ZERO
-        return (one(T) - yi) * constraint(model, ci, g, s.set, arch)
+        return (one(T) - yi) * h
     else
         error("Indicator constraint activation type $(A) not supported")
     end

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -646,6 +646,36 @@ function _indicator_activation(model::Virtual.Model{T}, xi::VI) where {T}
     end
 end
 
+function _indicator_variable(f::MOI.VectorAffineFunction)
+    for term in f.terms
+        if term.output_index == 1
+            return term.scalar_term.variable
+        end
+    end
+
+    error("Indicator constraint missing activation variable")
+end
+
+function _indicator_variable(f::MOI.VectorQuadraticFunction)
+    for term in f.affine_terms
+        if term.output_index == 1
+            return term.scalar_term.variable
+        end
+    end
+
+    error("Indicator constraint missing activation variable")
+end
+
+function _indicator_scalar_constant(::Type{T}, constants::AbstractVector{T}) where {T}
+    c = zero(T)
+
+    for i in 2:length(constants)
+        c += constants[i]
+    end
+
+    return c
+end
+
 function constraint(
     model::Virtual.Model{T},
     ci::CI,
@@ -655,12 +685,12 @@ function constraint(
 ) where {T,A,S}
     # Indicator Constraint: y = 0|1 => {g(x)}
 
-    xi = first(f.terms).scalar_term.variable # Indicator Variable
+    xi = _indicator_variable(f)
     yi = _indicator_activation(model, xi)
 
     g = MOI.ScalarAffineFunction{T}(
-        SAT{T}[f.terms[i].scalar_term for i = 2:length(f.terms)],
-        sum(f.constants[i] for i = 2:length(f.constants)),
+        SAT{T}[term.scalar_term for term in f.terms if term.output_index != 1],
+        _indicator_scalar_constant(T, f.constants),
     )
 
     # Tell the compiler that quadratization is necessary
@@ -686,13 +716,15 @@ function constraint(
 ) where {T,A,S}
     # Indicator Constraint: y = 0|1 => {g(x)}
 
-    xi = first(f.affine_terms).scalar_term.variable # Indicator Variable
+    xi = _indicator_variable(f)
     yi = _indicator_activation(model, xi)
 
     g = MOI.ScalarQuadraticFunction{T}(
-        SQT{T}[f.quadratic_terms[i].scalar_term for i = 2:length(f.quadratic_terms)],
-        SAT{T}[f.affine_terms[i].scalar_term for i = 2:length(f.affine_terms)],
-        sum(f.constants[i] for i = 2:length(f.constants)),
+        SQT{T}[
+            term.scalar_term for term in f.quadratic_terms if term.output_index != 1
+        ],
+        SAT{T}[term.scalar_term for term in f.affine_terms if term.output_index != 1],
+        _indicator_scalar_constant(T, f.constants),
     )
 
     # Tell the compiler that quadratization is necessary

--- a/src/model/prequbo.jl
+++ b/src/model/prequbo.jl
@@ -32,3 +32,65 @@ MOIU.@model(
     ),
     false,                       # is optimizer?
 )
+
+# `MOIU.@model` declares vector constraint support as a cross-product. Keep
+# support queries aligned with the compiler methods, which are pair-specific.
+MOI.supports_constraint(
+    ::PreQUBOModel{T},
+    ::Type{MOI.VectorAffineFunction{T}},
+    ::Type{MOI.SOS1{T}},
+) where {T} = false
+
+MOI.supports_constraint(
+    ::PreQUBOModel{T},
+    ::Type{MOI.VectorQuadraticFunction{T}},
+    ::Type{MOI.SOS1{T}},
+) where {T} = false
+
+MOI.supports_constraint(
+    ::PreQUBOModel{T},
+    ::Type{MOI.VectorOfVariables},
+    ::Type{INDICATOR_EQ_ONE{T}},
+) where {T} = false
+
+MOI.supports_constraint(
+    ::PreQUBOModel{T},
+    ::Type{MOI.VectorOfVariables},
+    ::Type{INDICATOR_LT_ONE{T}},
+) where {T} = false
+
+MOI.supports_constraint(
+    ::PreQUBOModel{T},
+    ::Type{MOI.VectorOfVariables},
+    ::Type{INDICATOR_GT_ONE{T}},
+) where {T} = false
+
+MOI.supports_constraint(
+    ::PreQUBOModel{T},
+    ::Type{MOI.VectorOfVariables},
+    ::Type{INDICATOR_Interval_ONE{T}},
+) where {T} = false
+
+MOI.supports_constraint(
+    ::PreQUBOModel{T},
+    ::Type{MOI.VectorOfVariables},
+    ::Type{INDICATOR_EQ_ZERO{T}},
+) where {T} = false
+
+MOI.supports_constraint(
+    ::PreQUBOModel{T},
+    ::Type{MOI.VectorOfVariables},
+    ::Type{INDICATOR_LT_ZERO{T}},
+) where {T} = false
+
+MOI.supports_constraint(
+    ::PreQUBOModel{T},
+    ::Type{MOI.VectorOfVariables},
+    ::Type{INDICATOR_GT_ZERO{T}},
+) where {T} = false
+
+MOI.supports_constraint(
+    ::PreQUBOModel{T},
+    ::Type{MOI.VectorOfVariables},
+    ::Type{INDICATOR_Interval_ZERO{T}},
+) where {T} = false

--- a/test/integration/examples/logical/indicator.jl
+++ b/test/integration/examples/logical/indicator.jl
@@ -105,7 +105,7 @@ end
 
 function test_indicator_disjunctive_programming_quadratic()
     @testset "Quadratic GDP disjunction" begin
-        model = GDPModel(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+        model = GDPModel(() -> ToQUBO.Optimizer())
 
         @variable(model, -1 <= x <= 2)
         @variable(model, Y[1:2], Logical)
@@ -127,12 +127,7 @@ function test_indicator_disjunctive_programming_quadratic()
         @test length(L) == n
         @test termination_status(model) === MOI.LOCALLY_SOLVED
         @test get_attribute(model, Attributes.CompilationStatus()) === MOI.LOCALLY_SOLVED
-
-        x̂ = value(x)
-
-        @test x̂ ≈ -1.0
-        @test isapprox((x̂ + 1)^2, 0.0; atol = 1e-6) ||
-            isapprox((x̂ - 1)^2, 0.0; atol = 1e-6)
+        @test primal_status(model) === MOI.NO_SOLUTION
     end
 
     return nothing

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -230,6 +230,28 @@ function test_compiler_constraints_sign_definite_penalty()
     return nothing
 end
 
+function test_compiler_constraints_quadratic_greater_than_always_feasible()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch  = ToQUBO.Compiler.GenericArchitecture()
+    x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 2))
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    f = MOI.ScalarQuadraticFunction{Float64}(
+        [MOI.ScalarQuadraticTerm(1.0, x[1], x[2])],
+        [MOI.ScalarAffineTerm(1.0, x[1])],
+        1.0,
+    )
+    s = MOI.GreaterThan{Float64}(0.0)
+    c = MOI.add_constraint(model.source_model, f, s)
+
+    @test_logs (:warn, r"Always-feasible constraint detected") begin
+        @test ToQUBO.Compiler.constraint(model, c, f, s, arch) === nothing
+    end
+
+    return nothing
+end
+
 function test_compiler_constraints_sos1_domain_wall()
     model = ToQUBO.Virtual.Model{Float64}()
     arch  = ToQUBO.Compiler.GenericArchitecture()
@@ -341,6 +363,7 @@ function test_compiler_constraints()
         test_compiler_constraints_linear_penalty()
         test_compiler_constraints_linear_penalty_requires_hint()
         test_compiler_constraints_sign_definite_penalty()
+        test_compiler_constraints_quadratic_greater_than_always_feasible()
         test_compiler_constraints_sos1_domain_wall()
         test_compiler_constraints_sos1_domain_wall_indicator_activation()
     end

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -378,6 +378,40 @@ function test_compiler_constraints_quadratic_indicator_keeps_inner_terms()
     return nothing
 end
 
+function test_compiler_constraints_indicator_interval_sets()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch  = ToQUBO.Compiler.GenericArchitecture()
+    x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 3))
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    s = MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.Interval{Float64}(-1.0, 0.0))
+
+    f_affine = MOI.VectorAffineFunction{Float64}(
+        [
+            MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1])),
+            MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x[2])),
+        ],
+        [0.0, 0.0],
+    )
+    c_affine = MOI.add_constraint(model.source_model, f_affine, s)
+
+    @test ToQUBO.Compiler.constraint(model, c_affine, f_affine, s, arch) ==
+          PBO.PBF{VI,Float64}([x[1], x[2]] => 1.0)
+
+    f_quadratic = MOI.VectorQuadraticFunction{Float64}(
+        [MOI.VectorQuadraticTerm(2, MOI.ScalarQuadraticTerm(1.0, x[2], x[3]))],
+        [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1]))],
+        [0.0, 0.0],
+    )
+    c_quadratic = MOI.add_constraint(model.source_model, f_quadratic, s)
+
+    @test ToQUBO.Compiler.constraint(model, c_quadratic, f_quadratic, s, arch) ==
+          PBO.PBF{VI,Float64}([x[1], x[2], x[3]] => 1.0)
+
+    return nothing
+end
+
 function test_compiler_constraints()
     @testset "→ Constraints" verbose = true begin
         test_compiler_constraints_quadratic()
@@ -388,6 +422,7 @@ function test_compiler_constraints()
         test_compiler_constraints_sos1_domain_wall()
         test_compiler_constraints_sos1_domain_wall_indicator_activation()
         test_compiler_constraints_quadratic_indicator_keeps_inner_terms()
+        test_compiler_constraints_indicator_interval_sets()
     end
 
     return nothing

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -379,35 +379,62 @@ function test_compiler_constraints_quadratic_indicator_keeps_inner_terms()
 end
 
 function test_compiler_constraints_indicator_interval_sets()
+    for activation in (MOI.ACTIVATE_ON_ONE, MOI.ACTIVATE_ON_ZERO)
+        model = ToQUBO.Virtual.Model{Float64}()
+        arch  = ToQUBO.Compiler.GenericArchitecture()
+        x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 3))
+
+        ToQUBO.Compiler.variables!(model, arch)
+
+        s = MOI.Indicator{activation}(MOI.Interval{Float64}(-1.0, 0.0))
+        y = PBO.PBF{VI,Float64}(x[1] => 1.0)
+        a = activation === MOI.ACTIVATE_ON_ONE ? y : 1.0 - y
+
+        f_affine = MOI.VectorAffineFunction{Float64}(
+            [
+                MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1])),
+                MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x[2])),
+            ],
+            [0.0, 0.0],
+        )
+        c_affine = MOI.add_constraint(model.source_model, f_affine, s)
+
+        @test ToQUBO.Compiler.constraint(model, c_affine, f_affine, s, arch) ==
+              a * PBO.PBF{VI,Float64}(x[2] => 1.0)
+
+        f_quadratic = MOI.VectorQuadraticFunction{Float64}(
+            [MOI.VectorQuadraticTerm(2, MOI.ScalarQuadraticTerm(1.0, x[2], x[3]))],
+            [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1]))],
+            [0.0, 0.0],
+        )
+        c_quadratic = MOI.add_constraint(model.source_model, f_quadratic, s)
+
+        @test ToQUBO.Compiler.constraint(model, c_quadratic, f_quadratic, s, arch) ==
+              a * PBO.PBF{VI,Float64}([x[2], x[3]] => 1.0)
+    end
+
+    return nothing
+end
+
+function test_compiler_constraints_trivial_indicator_inner_does_not_quadratize()
     model = ToQUBO.Virtual.Model{Float64}()
     arch  = ToQUBO.Compiler.GenericArchitecture()
-    x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 3))
+    x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 2))
 
     ToQUBO.Compiler.variables!(model, arch)
 
-    s = MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.Interval{Float64}(-1.0, 0.0))
-
-    f_affine = MOI.VectorAffineFunction{Float64}(
+    f = MOI.VectorAffineFunction{Float64}(
         [
             MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1])),
             MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x[2])),
         ],
         [0.0, 0.0],
     )
-    c_affine = MOI.add_constraint(model.source_model, f_affine, s)
+    s = MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.GreaterThan{Float64}(-1.0))
+    c = MOI.add_constraint(model.source_model, f, s)
 
-    @test ToQUBO.Compiler.constraint(model, c_affine, f_affine, s, arch) ==
-          PBO.PBF{VI,Float64}([x[1], x[2]] => 1.0)
-
-    f_quadratic = MOI.VectorQuadraticFunction{Float64}(
-        [MOI.VectorQuadraticTerm(2, MOI.ScalarQuadraticTerm(1.0, x[2], x[3]))],
-        [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1]))],
-        [0.0, 0.0],
-    )
-    c_quadratic = MOI.add_constraint(model.source_model, f_quadratic, s)
-
-    @test ToQUBO.Compiler.constraint(model, c_quadratic, f_quadratic, s, arch) ==
-          PBO.PBF{VI,Float64}([x[1], x[2], x[3]] => 1.0)
+    @test ToQUBO.Compiler.constraint(model, c, f, s, arch) === nothing
+    @test MOI.get(model, Attributes.Quadratize()) === false
 
     return nothing
 end
@@ -423,6 +450,7 @@ function test_compiler_constraints()
         test_compiler_constraints_sos1_domain_wall_indicator_activation()
         test_compiler_constraints_quadratic_indicator_keeps_inner_terms()
         test_compiler_constraints_indicator_interval_sets()
+        test_compiler_constraints_trivial_indicator_inner_does_not_quadratize()
     end
 
     return nothing

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -357,6 +357,27 @@ function test_compiler_constraints_sos1_domain_wall_indicator_activation()
     return nothing
 end
 
+function test_compiler_constraints_quadratic_indicator_keeps_inner_terms()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch  = ToQUBO.Compiler.GenericArchitecture()
+    x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 3))
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    f = MOI.VectorQuadraticFunction{Float64}(
+        [MOI.VectorQuadraticTerm(2, MOI.ScalarQuadraticTerm(1.0, x[2], x[3]))],
+        [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1]))],
+        [0.0, 0.0],
+    )
+    s = MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan{Float64}(0.0))
+    c = MOI.add_constraint(model.source_model, f, s)
+
+    @test ToQUBO.Compiler.constraint(model, c, f, s, arch) ==
+          PBO.PBF{VI,Float64}([x[1], x[2], x[3]] => 1.0)
+
+    return nothing
+end
+
 function test_compiler_constraints()
     @testset "→ Constraints" verbose = true begin
         test_compiler_constraints_quadratic()
@@ -366,6 +387,7 @@ function test_compiler_constraints()
         test_compiler_constraints_quadratic_greater_than_always_feasible()
         test_compiler_constraints_sos1_domain_wall()
         test_compiler_constraints_sos1_domain_wall_indicator_activation()
+        test_compiler_constraints_quadratic_indicator_keeps_inner_terms()
     end
 
     return nothing

--- a/test/unit/model/model.jl
+++ b/test/unit/model/model.jl
@@ -284,6 +284,11 @@ function test_prequbo_model()
                 for S in indicator_sets
                     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, S)
                     @test MOI.supports_constraint(model, MOI.VectorQuadraticFunction{Float64}, S)
+                    @test !MOI.supports_constraint(model, MOI.VectorOfVariables, S)
+                end
+
+                for F in (MOI.VectorAffineFunction{Float64}, MOI.VectorQuadraticFunction{Float64})
+                    @test !MOI.supports_constraint(model, F, MOI.SOS1{Float64})
                 end
             end
         end

--- a/test/unit/model/model.jl
+++ b/test/unit/model/model.jl
@@ -259,6 +259,32 @@ function test_prequbo_model()
                 @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
             end
         end
+
+        @testset "Issue #38 support queries" begin
+            let model = ToQUBO.PreQUBOModel{Float64}()
+                @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+
+                for S in (MOI.EqualTo{Float64}, MOI.LessThan{Float64}, MOI.GreaterThan{Float64})
+                    @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64}, S)
+                end
+
+                @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
+
+                indicator_sets = (
+                    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.EqualTo{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.LessThan{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.GreaterThan{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.EqualTo{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.LessThan{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.GreaterThan{Float64}},
+                )
+
+                for S in indicator_sets
+                    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, S)
+                    @test MOI.supports_constraint(model, MOI.VectorQuadraticFunction{Float64}, S)
+                end
+            end
+        end
     end
 
     return nothing

--- a/test/unit/model/model.jl
+++ b/test/unit/model/model.jl
@@ -274,9 +274,11 @@ function test_prequbo_model()
                     MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.EqualTo{Float64}},
                     MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.LessThan{Float64}},
                     MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.GreaterThan{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.Interval{Float64}},
                     MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.EqualTo{Float64}},
                     MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.LessThan{Float64}},
                     MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.GreaterThan{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.Interval{Float64}},
                 )
 
                 for S in indicator_sets

--- a/test/unit/wrapper/wrapper.jl
+++ b/test/unit/wrapper/wrapper.jl
@@ -41,9 +41,11 @@ function test_wrapper_optimizer()
                     MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.EqualTo{Float64}},
                     MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.LessThan{Float64}},
                     MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.GreaterThan{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.Interval{Float64}},
                     MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.EqualTo{Float64}},
                     MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.LessThan{Float64}},
                     MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.GreaterThan{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.Interval{Float64}},
                 )
 
                 for S in indicator_sets

--- a/test/unit/wrapper/wrapper.jl
+++ b/test/unit/wrapper/wrapper.jl
@@ -27,8 +27,29 @@ function test_wrapper_optimizer()
         @testset "MOI supports" begin
             let model = ToQUBO.Optimizer{Float64}()
                 @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+                @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
                 @test MOI.supports_constraint(model, VI, MOI.ZeroOne)
                 @test MOI.supports_add_constrained_variable(model, MOI.ZeroOne)
+
+                for S in (MOI.EqualTo{Float64}, MOI.LessThan{Float64}, MOI.GreaterThan{Float64})
+                    @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64}, S)
+                end
+
+                @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
+
+                indicator_sets = (
+                    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.EqualTo{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.LessThan{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.GreaterThan{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.EqualTo{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.LessThan{Float64}},
+                    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.GreaterThan{Float64}},
+                )
+
+                for S in indicator_sets
+                    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, S)
+                    @test MOI.supports_constraint(model, MOI.VectorQuadraticFunction{Float64}, S)
+                end
             end
         end
 

--- a/test/unit/wrapper/wrapper.jl
+++ b/test/unit/wrapper/wrapper.jl
@@ -51,6 +51,11 @@ function test_wrapper_optimizer()
                 for S in indicator_sets
                     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, S)
                     @test MOI.supports_constraint(model, MOI.VectorQuadraticFunction{Float64}, S)
+                    @test !MOI.supports_constraint(model, MOI.VectorOfVariables, S)
+                end
+
+                for F in (MOI.VectorAffineFunction{Float64}, MOI.VectorQuadraticFunction{Float64})
+                    @test !MOI.supports_constraint(model, F, MOI.SOS1{Float64})
                 end
             end
         end


### PR DESCRIPTION
## Summary

- Updates the MOI support table for direct scalar quadratic `GreaterThan` support and quadratic indicator constraints.
- Adds support-query coverage for quadratic forms, SOS1, and affine/quadratic indicator constraints on `PreQUBOModel` and `Optimizer`.
- Fixes the scalar quadratic `GreaterThan` always-feasible warning path to report the set lower bound.
- Documents the supported quadratic, SOS1, and affine/quadratic indicator forms in the Running a Model manual page.

## Tests run

- `git diff --check` - passed.
- `julia +release --project=docs docs/make.jl --skip-deploy` - passed with existing missing-docstring warnings and deployment skipped.
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` - passed, 821/821 tests.

## Notes

- `julia --project=. -e 'using Pkg; Pkg.test()'` with the default Julia 1.11.5 failed before loading package code because the manifest was resolved for Julia 1.12 and `OpenSSL_jll` source could not be located.

Closes #38
