### PR TITLE
Fix constraint feasibility actions

### DIFF
--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -10,6 +10,13 @@ ToQUBO.Attributes.StableCompilation
 ToQUBO.Attributes.Warnings
 ```
 
+## Constraint Feasibility Actions
+
+```@docs
+ToQUBO.Attributes.IgnoreFeasibleConstraints
+ToQUBO.Attributes.ErrorInfeasibleConstraints
+```
+
 ## Compiler Optimization
 
 ```@docs

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -168,6 +168,70 @@ function warnings(model::Optimizer)::Bool
 end
 
 @doc raw"""
+    IgnoreFeasibleConstraints()
+
+When set, constraints whose encoded residual is provably always feasible are
+ignored instead of being added as penalty terms.
+"""
+struct IgnoreFeasibleConstraints <: CompilerAttribute end
+
+_attribute_from_key(::Val{:ignore_feasible}) = IgnoreFeasibleConstraints
+
+function MOI.get(model::Optimizer, ::IgnoreFeasibleConstraints)::Bool
+    return get(model.compiler_settings, :ignore_feasible, true)
+end
+
+function MOI.set(model::Optimizer, ::IgnoreFeasibleConstraints, flag::Bool)
+    model.compiler_settings[:ignore_feasible] = flag
+
+    return nothing
+end
+
+function MOI.set(model::Optimizer, ::IgnoreFeasibleConstraints, ::Nothing)
+    delete!(model.compiler_settings, :ignore_feasible)
+
+    return nothing
+end
+
+function ignore_feasible_constraints(model::Optimizer)::Bool
+    return MOI.get(model, IgnoreFeasibleConstraints())
+end
+
+@doc raw"""
+    ErrorInfeasibleConstraints()
+
+When set, direct scalar constraints whose encoded residual is provably
+infeasible stop compilation with `MOI.INFEASIBLE`.
+
+This does not make infeasible inner constraints of indicator constraints fail
+the whole model, because those constraints are conditional on the indicator
+activation.
+"""
+struct ErrorInfeasibleConstraints <: CompilerAttribute end
+
+_attribute_from_key(::Val{:error_infeasible}) = ErrorInfeasibleConstraints
+
+function MOI.get(model::Optimizer, ::ErrorInfeasibleConstraints)::Bool
+    return get(model.compiler_settings, :error_infeasible, false)
+end
+
+function MOI.set(model::Optimizer, ::ErrorInfeasibleConstraints, flag::Bool)
+    model.compiler_settings[:error_infeasible] = flag
+
+    return nothing
+end
+
+function MOI.set(model::Optimizer, ::ErrorInfeasibleConstraints, ::Nothing)
+    delete!(model.compiler_settings, :error_infeasible)
+
+    return nothing
+end
+
+function error_infeasible_constraints(model::Optimizer)::Bool
+    return MOI.get(model, ErrorInfeasibleConstraints())
+end
+
+@doc raw"""
     Optimization()
 """
 struct Optimization <: CompilerAttribute end

--- a/src/attributes/solver.jl
+++ b/src/attributes/solver.jl
@@ -101,10 +101,14 @@ function MOI.supports(::Virtual.Model, ::MOI.RawStatusString)
 end
 
 function MOI.get(model::Virtual.Model, attr::MOI.TerminationStatus)
-    if !isnothing(model.optimizer)
+    status = MOI.get(model, Attributes.CompilationStatus())
+
+    if !(status in (MOI.OPTIMIZE_NOT_CALLED, MOI.LOCALLY_SOLVED))
+        return status
+    elseif !isnothing(model.optimizer)
         return MOI.get(model.optimizer, attr)
     else
-        return MOI.get(model, Attributes.CompilationStatus())
+        return status
     end
 end
 

--- a/src/attributes/solver.jl
+++ b/src/attributes/solver.jl
@@ -79,7 +79,12 @@ function MOI.get(
     model::Virtual.Model,
     attr::MOI.RawStatusString,
 )
-    if !isnothing(model.optimizer) && MOI.supports(model.optimizer, attr)
+    status = MOI.get(model, Attributes.CompilationStatus())
+
+    if haskey(model.moi_settings, :raw_status_string) &&
+       !(status in (MOI.OPTIMIZE_NOT_CALLED, MOI.LOCALLY_SOLVED))
+        return model.moi_settings[:raw_status_string]
+    elseif !isnothing(model.optimizer) && MOI.supports(model.optimizer, attr)
         return MOI.get(model.optimizer, attr)
     else
         return get(model.moi_settings, :raw_status_string, "")

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -60,6 +60,58 @@ function _combine_penalties(lhs, rhs)
     end
 end
 
+abstract type _ConstraintFeasibilityContext end
+
+struct _DirectConstraintContext <: _ConstraintFeasibilityContext end
+struct _IndicatorConstraintContext <: _ConstraintFeasibilityContext end
+
+const _DIRECT_CONSTRAINT = _DirectConstraintContext()
+const _INDICATOR_CONSTRAINT = _IndicatorConstraintContext()
+
+function _constraint_message(kind::AbstractString, f, op::AbstractString, rhs)
+    return """
+    $(kind) constraint detected:
+    $(f) $(op) $(rhs)
+    """
+end
+
+function _constraint_warning(model::Virtual.Model, message::AbstractString)
+    if Attributes.warnings(model)
+        @warn message
+    end
+
+    return nothing
+end
+
+function _infeasible_constraint_error!(model::Virtual.Model, message::AbstractString)
+    MOI.set(model, Attributes.CompilationStatus(), MOI.INFEASIBLE)
+    MOI.set(model, MOI.RawStatusString(), message)
+
+    compilation_error(message)
+
+    return nothing
+end
+
+function _handle_feasible_constraint(model::Virtual.Model, message::AbstractString)::Bool
+    _constraint_warning(model, message)
+
+    return Attributes.ignore_feasible_constraints(model)
+end
+
+function _handle_infeasible_constraint(
+    model::Virtual.Model,
+    context::_ConstraintFeasibilityContext,
+    message::AbstractString,
+)
+    _constraint_warning(model, message)
+
+    if context isa _DirectConstraintContext && Attributes.error_infeasible_constraints(model)
+        _infeasible_constraint_error!(model, message)
+    end
+
+    return nothing
+end
+
 @doc raw"""
     constraint(
         ::Virtual.Model{T},
@@ -130,6 +182,17 @@ function constraint(
     s::EQ{T},
     arch::AbstractArchitecture,
 ) where {T}
+    return constraint(model, ci, f, s, arch, _DIRECT_CONSTRAINT)
+end
+
+function constraint(
+    model::Virtual.Model{T},
+    ci::CI,
+    f::SAF{T},
+    s::EQ{T},
+    arch::AbstractArchitecture,
+    context::_ConstraintFeasibilityContext,
+) where {T}
     # Scalar Affine Equality Constraint: g(x) = a'x - b = 0
     g = _parse(model, f, s, arch)
 
@@ -140,14 +203,19 @@ function constraint(
     # Bounds & Slack Variable 
     l, u = PBO.bounds(g)
 
-    if u < zero(T) # Always feasible
-        @warn """
-        Always-feasible constraint detected:
-        $(f) ≤ $(s.value)
-        """
-        return nothing
-    elseif l > zero(T) # Infeasible
-        @warn "Infeasible constraint detected"
+    if l == zero(T) && u == zero(T) # Always feasible
+        if _handle_feasible_constraint(
+            model,
+            _constraint_message("Always-feasible", f, "=", s.value),
+        )
+            return nothing
+        end
+    elseif u < zero(T) || l > zero(T) # Infeasible
+        _handle_infeasible_constraint(
+            model,
+            context,
+            _constraint_message("Infeasible", f, "=", s.value),
+        )
     end
 
     return _equality_penalty(model, ci, g)
@@ -187,6 +255,17 @@ function constraint(
     s::LT{T},
     arch::AbstractArchitecture,
 ) where {T}
+    return constraint(model, ci, f, s, arch, _DIRECT_CONSTRAINT)
+end
+
+function constraint(
+    model::Virtual.Model{T},
+    ci::CI,
+    f::SAF{T},
+    s::LT{T},
+    arch::AbstractArchitecture,
+    context::_ConstraintFeasibilityContext,
+) where {T}
     # Scalar Affine Inequality Constraint: g(x) = a'x - b ≤ 0 
     g = _parse(model, f, s, arch)
 
@@ -197,14 +276,19 @@ function constraint(
     # Bounds & Slack Variable 
     l, u = PBO.bounds(g)
 
-    if u < zero(T) # Always feasible
-        @warn """
-        Always-feasible constraint detected:
-        $(f) ≤ $(s.upper)
-        """
-        return nothing
+    if u <= zero(T) # Always feasible
+        if _handle_feasible_constraint(
+            model,
+            _constraint_message("Always-feasible", f, "<=", s.upper),
+        )
+            return nothing
+        end
     elseif l > zero(T) # Infeasible
-        @warn "Infeasible constraint detected"
+        _handle_infeasible_constraint(
+            model,
+            context,
+            _constraint_message("Infeasible", f, "<=", s.upper),
+        )
     end
 
     if _is_nonnegative(g)
@@ -236,9 +320,20 @@ function constraint(
     s::MOI.Interval{T},
     arch::AbstractArchitecture,
 ) where {T}
+    return constraint(model, ci, f, s, arch, _DIRECT_CONSTRAINT)
+end
+
+function constraint(
+    model::Virtual.Model{T},
+    ci::CI,
+    f::SAF{T},
+    s::MOI.Interval{T},
+    arch::AbstractArchitecture,
+    context::_ConstraintFeasibilityContext,
+) where {T}
     return _combine_penalties(
-        constraint(model, ci, f, LT{T}(s.upper), arch),
-        constraint(model, ci, f, GT{T}(s.lower), arch),
+        constraint(model, ci, f, LT{T}(s.upper), arch, context),
+        constraint(model, ci, f, GT{T}(s.lower), arch, context),
     )
 end
 
@@ -276,6 +371,17 @@ function constraint(
     s::GT{T},
     arch::AbstractArchitecture,
 ) where {T}
+    return constraint(model, ci, f, s, arch, _DIRECT_CONSTRAINT)
+end
+
+function constraint(
+    model::Virtual.Model{T},
+    ci::CI,
+    f::SAF{T},
+    s::GT{T},
+    arch::AbstractArchitecture,
+    context::_ConstraintFeasibilityContext,
+) where {T}
     # Scalar Affine Inequality Constraint: g(x) = a'x - b ≥ 0 
     g = _parse(model, f, s, arch)
 
@@ -286,14 +392,19 @@ function constraint(
     # Bounds & Slack Variable 
     l, u = PBO.bounds(g)
 
-    if l > zero(T) # Always feasible
-        @warn """
-        Always-feasible constraint detected:
-        $(f) ≥ $(s.lower)
-        """
-        return nothing
+    if l >= zero(T) # Always feasible
+        if _handle_feasible_constraint(
+            model,
+            _constraint_message("Always-feasible", f, ">=", s.lower),
+        )
+            return nothing
+        end
     elseif u < zero(T) # Infeasible
-        @warn "Infeasible constraint detected"
+        _handle_infeasible_constraint(
+            model,
+            context,
+            _constraint_message("Infeasible", f, ">=", s.lower),
+        )
     end
 
     if _is_nonpositive(g)
@@ -349,6 +460,17 @@ function constraint(
     s::EQ{T},
     arch::AbstractArchitecture,
 ) where {T}
+    return constraint(model, ci, f, s, arch, _DIRECT_CONSTRAINT)
+end
+
+function constraint(
+    model::Virtual.Model{T},
+    ci::CI,
+    f::SQF{T},
+    s::EQ{T},
+    arch::AbstractArchitecture,
+    context::_ConstraintFeasibilityContext,
+) where {T}
     # Scalar Quadratic Equality Constraint: g(x) = x' Q x + a' x - b = 0
     g = _parse(model, f, s, arch)
 
@@ -359,17 +481,25 @@ function constraint(
     # Bounds & Slack Variable 
     l, u = PBO.bounds(g)
 
-    if u < zero(T) # Always feasible
-        @warn """
-        Always-feasible constraint detected:
-        $(f) ≤ $(s.value)
-        """
-        return nothing
+    if l == zero(T) && u == zero(T) # Always feasible
+        if _handle_feasible_constraint(
+            model,
+            _constraint_message("Always-feasible", f, "=", s.value),
+        )
+            return nothing
+        end
     elseif l > zero(T) # Infeasible
-        @warn """
-        Infeasible constraint detected:
-        $(f) ≤ $(s.value)
-        """
+        _handle_infeasible_constraint(
+            model,
+            context,
+            _constraint_message("Infeasible", f, "=", s.value),
+        )
+    elseif u < zero(T) # Infeasible
+        _handle_infeasible_constraint(
+            model,
+            context,
+            _constraint_message("Infeasible", f, "=", s.value),
+        )
     end
 
     if _is_quadratic_penalty(model, ci) && !_is_nonnegative(g)
@@ -415,6 +545,17 @@ function constraint(
     s::LT{T},
     arch::AbstractArchitecture,
 ) where {T}
+    return constraint(model, ci, f, s, arch, _DIRECT_CONSTRAINT)
+end
+
+function constraint(
+    model::Virtual.Model{T},
+    ci::CI,
+    f::SQF{T},
+    s::LT{T},
+    arch::AbstractArchitecture,
+    context::_ConstraintFeasibilityContext,
+) where {T}
     # Scalar Quadratic Inequality Constraint: g(x) = x' Q x + a' x - b ≤ 0
     g = _parse(model, f, s, arch)
 
@@ -425,17 +566,19 @@ function constraint(
     # Bounds & Slack Variable 
     l, u = PBO.bounds(g)
 
-    if u < zero(T) # Always feasible
-        @warn """
-        Always-feasible constraint detected:
-        $(f) ≤ $(s.upper)
-        """
-        return nothing
+    if u <= zero(T) # Always feasible
+        if _handle_feasible_constraint(
+            model,
+            _constraint_message("Always-feasible", f, "<=", s.upper),
+        )
+            return nothing
+        end
     elseif l > zero(T) # Infeasible
-        @warn """
-        Infeasible constraint detected:
-        $(f) ≤ $(s.upper)
-        """
+        _handle_infeasible_constraint(
+            model,
+            context,
+            _constraint_message("Infeasible", f, "<=", s.upper),
+        )
     end
 
     if _is_nonnegative(g)
@@ -467,9 +610,20 @@ function constraint(
     s::MOI.Interval{T},
     arch::AbstractArchitecture,
 ) where {T}
+    return constraint(model, ci, f, s, arch, _DIRECT_CONSTRAINT)
+end
+
+function constraint(
+    model::Virtual.Model{T},
+    ci::CI,
+    f::SQF{T},
+    s::MOI.Interval{T},
+    arch::AbstractArchitecture,
+    context::_ConstraintFeasibilityContext,
+) where {T}
     return _combine_penalties(
-        constraint(model, ci, f, LT{T}(s.upper), arch),
-        constraint(model, ci, f, GT{T}(s.lower), arch),
+        constraint(model, ci, f, LT{T}(s.upper), arch, context),
+        constraint(model, ci, f, GT{T}(s.lower), arch, context),
     )
 end
 
@@ -507,6 +661,17 @@ function constraint(
     s::GT{T},
     arch::AbstractArchitecture,
 ) where {T}
+    return constraint(model, ci, f, s, arch, _DIRECT_CONSTRAINT)
+end
+
+function constraint(
+    model::Virtual.Model{T},
+    ci::CI,
+    f::SQF{T},
+    s::GT{T},
+    arch::AbstractArchitecture,
+    context::_ConstraintFeasibilityContext,
+) where {T}
     # Scalar Quadratic Inequality Constraint: g(x) = x' Q x + a' x - b ≥ 0
     g = _parse(model, f, s, arch)
 
@@ -517,14 +682,19 @@ function constraint(
     # Bounds & Slack Variable 
     l, u = PBO.bounds(g)
 
-    if l > zero(T) # Always feasible
-        @warn """
-        Always-feasible constraint detected:
-        $(f) ≥ $(s.lower)
-        """
-        return nothing
+    if l >= zero(T) # Always feasible
+        if _handle_feasible_constraint(
+            model,
+            _constraint_message("Always-feasible", f, ">=", s.lower),
+        )
+            return nothing
+        end
     elseif u < zero(T) # Infeasible
-        @warn "Infeasible constraint detected"
+        _handle_infeasible_constraint(
+            model,
+            context,
+            _constraint_message("Infeasible", f, ">=", s.lower),
+        )
     end
 
     if _is_nonpositive(g)
@@ -718,7 +888,7 @@ function constraint(
         _indicator_scalar_constant(T, f.constants),
     )
 
-    h = constraint(model, ci, g, s.set, arch)
+    h = constraint(model, ci, g, s.set, arch, _INDICATOR_CONSTRAINT)
 
     if isnothing(h)
         return nothing
@@ -758,7 +928,7 @@ function constraint(
         _indicator_scalar_constant(T, f.constants),
     )
 
-    h = constraint(model, ci, g, s.set, arch)
+    h = constraint(model, ci, g, s.set, arch, _INDICATOR_CONSTRAINT)
 
     if isnothing(h)
         return nothing

--- a/test/unit/attributes/attributes.jl
+++ b/test/unit/attributes/attributes.jl
@@ -49,6 +49,34 @@ function test_compiler_attributes()
             end
         end
 
+        @testset "IgnoreFeasibleConstraints" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                @test MOI.supports(model, Attributes.IgnoreFeasibleConstraints())
+                @test MOI.get(model, Attributes.IgnoreFeasibleConstraints()) === true
+                @test Attributes.ignore_feasible_constraints(model) === true
+
+                MOI.set(model, Attributes.IgnoreFeasibleConstraints(), false)
+                @test MOI.get(model, Attributes.IgnoreFeasibleConstraints()) === false
+
+                MOI.set(model, Attributes.IgnoreFeasibleConstraints(), nothing)
+                @test MOI.get(model, Attributes.IgnoreFeasibleConstraints()) === true
+            end
+        end
+
+        @testset "ErrorInfeasibleConstraints" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                @test MOI.supports(model, Attributes.ErrorInfeasibleConstraints())
+                @test MOI.get(model, Attributes.ErrorInfeasibleConstraints()) === false
+                @test Attributes.error_infeasible_constraints(model) === false
+
+                MOI.set(model, Attributes.ErrorInfeasibleConstraints(), true)
+                @test MOI.get(model, Attributes.ErrorInfeasibleConstraints()) === true
+
+                MOI.set(model, Attributes.ErrorInfeasibleConstraints(), nothing)
+                @test MOI.get(model, Attributes.ErrorInfeasibleConstraints()) === false
+            end
+        end
+
         @testset "Optimization" begin
             let model = ToQUBO.Optimizer{Float64}()
                 @test MOI.supports(model, Attributes.Optimization())

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -252,6 +252,167 @@ function test_compiler_constraints_quadratic_greater_than_always_feasible()
     return nothing
 end
 
+function test_compiler_constraints_feasibility_actions()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch  = ToQUBO.Compiler.GenericArchitecture()
+    x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 2))
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    feasible_f = MOI.ScalarAffineFunction{Float64}(
+        [MOI.ScalarAffineTerm(1.0, x[1])],
+        0.0,
+    )
+    feasible_s = MOI.LessThan{Float64}(1.0)
+    feasible_c = MOI.add_constraint(model.source_model, feasible_f, feasible_s)
+
+    @test_logs (:warn, r"Always-feasible constraint detected") begin
+        @test ToQUBO.Compiler.constraint(
+            model,
+            feasible_c,
+            feasible_f,
+            feasible_s,
+            arch,
+        ) === nothing
+    end
+
+    MOI.set(model, Attributes.IgnoreFeasibleConstraints(), false)
+
+    feasible_penalty = nothing
+    @test_logs (:warn, r"Always-feasible constraint detected") begin
+        feasible_penalty = ToQUBO.Compiler.constraint(
+            model,
+            feasible_c,
+            feasible_f,
+            feasible_s,
+            arch,
+        )
+    end
+    @test feasible_penalty !== nothing
+    @test haskey(model.slack, feasible_c)
+
+    infeasible_f = MOI.ScalarAffineFunction{Float64}(
+        [MOI.ScalarAffineTerm(1.0, x[2])],
+        1.0,
+    )
+    infeasible_s = MOI.LessThan{Float64}(0.0)
+    infeasible_c = MOI.add_constraint(model.source_model, infeasible_f, infeasible_s)
+
+    infeasible_penalty = nothing
+    @test_logs (:warn, r"Infeasible constraint detected") begin
+        infeasible_penalty = ToQUBO.Compiler.constraint(
+            model,
+            infeasible_c,
+            infeasible_f,
+            infeasible_s,
+            arch,
+        )
+    end
+    @test infeasible_penalty == PBO.PBF{VI,Float64}(1.0, x[2] => 1.0)
+    @test MOI.get(model, Attributes.CompilationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+
+    return nothing
+end
+
+function test_compiler_constraints_strict_infeasible_status()
+    model = ToQUBO.Optimizer{Float64}()
+    x     = MOI.add_variable(model)
+
+    MOI.add_constraint(model, x, MOI.ZeroOne())
+
+    f = MOI.ScalarAffineFunction{Float64}(
+        [MOI.ScalarAffineTerm(1.0, x)],
+        1.0,
+    )
+    MOI.add_constraint(model, f, MOI.LessThan{Float64}(0.0))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
+    )
+    MOI.set(model, Attributes.ErrorInfeasibleConstraints(), true)
+
+    @test_logs (:warn, r"Infeasible constraint detected") begin
+        @test_throws ToQUBO.Compiler.CompilationError MOI.optimize!(model)
+    end
+    @test MOI.get(model, Attributes.CompilationStatus()) == MOI.INFEASIBLE
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
+    @test occursin("Infeasible constraint detected", MOI.get(model, MOI.RawStatusString()))
+
+    return nothing
+end
+
+function test_compiler_constraints_equality_feasibility_classification()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch  = ToQUBO.Compiler.GenericArchitecture()
+    x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 1))
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    zero_f = MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0)
+    zero_s = MOI.EqualTo{Float64}(0.0)
+    zero_c = MOI.add_constraint(model.source_model, zero_f, zero_s)
+
+    @test_logs (:warn, r"Always-feasible constraint detected") begin
+        @test ToQUBO.Compiler.constraint(model, zero_c, zero_f, zero_s, arch) === nothing
+    end
+
+    infeasible_f = MOI.ScalarAffineFunction{Float64}(
+        [MOI.ScalarAffineTerm(1.0, x[1])],
+        0.0,
+    )
+    infeasible_s = MOI.EqualTo{Float64}(2.0)
+    infeasible_c = MOI.add_constraint(model.source_model, infeasible_f, infeasible_s)
+
+    infeasible_penalty = nothing
+    @test_logs (:warn, r"Infeasible constraint detected") begin
+        infeasible_penalty = ToQUBO.Compiler.constraint(
+            model,
+            infeasible_c,
+            infeasible_f,
+            infeasible_s,
+            arch,
+        )
+    end
+    @test infeasible_penalty !== nothing
+
+    return nothing
+end
+
+function test_compiler_constraints_indicator_inner_infeasible_is_gated()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch  = ToQUBO.Compiler.GenericArchitecture()
+    x, _  = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 2))
+
+    ToQUBO.Compiler.variables!(model, arch)
+    MOI.set(model, Attributes.ErrorInfeasibleConstraints(), true)
+
+    f = MOI.VectorAffineFunction{Float64}(
+        [
+            MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x[1])),
+            MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x[2])),
+        ],
+        [0.0, 1.0],
+    )
+    s = MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan{Float64}(0.0))
+    c = MOI.add_constraint(model.source_model, f, s)
+
+    penalty = nothing
+    @test_logs (:warn, r"Infeasible constraint detected") begin
+        penalty = ToQUBO.Compiler.constraint(model, c, f, s, arch)
+    end
+
+    @test penalty == PBO.PBF{VI,Float64}(
+        x[1] => 1.0,
+        [x[1], x[2]] => 1.0,
+    )
+    @test MOI.get(model, Attributes.CompilationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+
+    return nothing
+end
+
 function test_compiler_constraints_sos1_domain_wall()
     model = ToQUBO.Virtual.Model{Float64}()
     arch  = ToQUBO.Compiler.GenericArchitecture()
@@ -446,6 +607,10 @@ function test_compiler_constraints()
         test_compiler_constraints_linear_penalty_requires_hint()
         test_compiler_constraints_sign_definite_penalty()
         test_compiler_constraints_quadratic_greater_than_always_feasible()
+        test_compiler_constraints_feasibility_actions()
+        test_compiler_constraints_strict_infeasible_status()
+        test_compiler_constraints_equality_feasibility_classification()
+        test_compiler_constraints_indicator_inner_infeasible_is_gated()
         test_compiler_constraints_sos1_domain_wall()
         test_compiler_constraints_sos1_domain_wall_indicator_activation()
         test_compiler_constraints_quadratic_indicator_keeps_inner_terms()

--- a/test/unit/compiler/constraints.jl
+++ b/test/unit/compiler/constraints.jl
@@ -315,31 +315,40 @@ function test_compiler_constraints_feasibility_actions()
 end
 
 function test_compiler_constraints_strict_infeasible_status()
-    model = ToQUBO.Optimizer{Float64}()
-    x     = MOI.add_variable(model)
+    function infeasible_model(constructor = nothing)
+        model = ToQUBO.Optimizer{Float64}(constructor)
+        x     = MOI.add_variable(model)
 
-    MOI.add_constraint(model, x, MOI.ZeroOne())
+        MOI.add_constraint(model, x, MOI.ZeroOne())
 
-    f = MOI.ScalarAffineFunction{Float64}(
-        [MOI.ScalarAffineTerm(1.0, x)],
-        1.0,
-    )
-    MOI.add_constraint(model, f, MOI.LessThan{Float64}(0.0))
+        f = MOI.ScalarAffineFunction{Float64}(
+            [MOI.ScalarAffineTerm(1.0, x)],
+            1.0,
+        )
+        MOI.add_constraint(model, f, MOI.LessThan{Float64}(0.0))
 
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-    MOI.set(
-        model,
-        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-        MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
-    )
-    MOI.set(model, Attributes.ErrorInfeasibleConstraints(), true)
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+        MOI.set(
+            model,
+            MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+            MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
+        )
+        MOI.set(model, Attributes.ErrorInfeasibleConstraints(), true)
 
-    @test_logs (:warn, r"Infeasible constraint detected") begin
-        @test_throws ToQUBO.Compiler.CompilationError MOI.optimize!(model)
+        return model
     end
-    @test MOI.get(model, Attributes.CompilationStatus()) == MOI.INFEASIBLE
-    @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
-    @test occursin("Infeasible constraint detected", MOI.get(model, MOI.RawStatusString()))
+
+    for model in (
+        infeasible_model(),
+        infeasible_model(ExactSampler.Optimizer),
+    )
+        @test_logs (:warn, r"Infeasible constraint detected") begin
+            @test_throws ToQUBO.Compiler.CompilationError MOI.optimize!(model)
+        end
+        @test MOI.get(model, Attributes.CompilationStatus()) == MOI.INFEASIBLE
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
+        @test occursin("Infeasible constraint detected", MOI.get(model, MOI.RawStatusString()))
+    end
 
     return nothing
 end


### PR DESCRIPTION
## Summary

- Added compiler attributes to control feasibility actions for provably always-feasible and infeasible scalar constraints.
- Centralized scalar residual feasibility checks and made strict direct infeasibility stop compilation with `MOI.INFEASIBLE`.
- Kept infeasible indicator inner constraints gated by their activation instead of treating them as globally infeasible.

## Tests run

- `julia +1.12 --project=test --startup-file=no -e 'push!(LOAD_PATH, "."); using Test; using JuMP; import MathOptInterface as MOI; const MOIU = MOI.Utilities; const VI = MOI.VariableIndex; const CI{F,S} = MOI.ConstraintIndex{F,S}; using QUBODrivers; using LinearAlgebra; using TOML; using ToQUBO; using ToQUBO: Attributes, Encoding; import QUBOTools; import PseudoBooleanOptimization as PBO; function MOIU.map_indices(::Function, arch::QUBOTools.AbstractArchitecture); return arch; end; function MOIU.map_indices(::Function, quad::PBO.QuadratizationMethod); return quad; end; include("test/unit/compiler/constraints.jl"); include("test/unit/attributes/attributes.jl"); @testset "targeted issue 46" begin test_compiler_constraints(); test_compiler_attributes(); end'`
  - Result: passed, 135/135 assertions.
- `julia +1.12 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`
  - Result: passed, 885/885 tests.

## Notes

- I did not use the local default `julia --project=.` for validation because the default Julia 1.11 environment fails while precompiling MathOptInterface via PrecompileTools (`UndefVarError: StaticData not defined in Base`). Julia 1.12 validation completed successfully.

Closes #46
