### PR TITLE
Clean legacy repository links

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,4 +20,4 @@ title: "ToQUBO.jl"
 version: 0.1.5
 doi: 10.5281/zenodo.7644291
 date-released: 2023-02-15
-url: "https://github.com/psrenergy/ToQUBO.jl"
+url: "https://github.com/JuliaQUBO/ToQUBO.jl"

--- a/docs/src/booklet/7-solvers.md
+++ b/docs/src/booklet/7-solvers.md
@@ -2,15 +2,15 @@
 
 ## Solvers, Annealers & Samplers
 
-[`ToQUBO.jl`](https://github.com/psrenergy/ToQUBO.jl)'s main goal is to make use of parameterized stochastic optimization solvers, particularly those relying on non-conventional hardware such as *Quantum Annealing* and other *Ising Machines*.
-A few `MOI`-compliant interfaces for annealers and samplers are bundled within [`ToQUBO.jl`](https://github.com/psrenergy/ToQUBO.jl) via the [`QUBODrivers.jl`](https://github.com/psrenergy/QUBODrivers.jl) companion package.
+[`ToQUBO.jl`](https://github.com/JuliaQUBO/ToQUBO.jl)'s main goal is to make use of parameterized stochastic optimization solvers, particularly those relying on non-conventional hardware such as *Quantum Annealing* and other *Ising Machines*.
+A few `MOI`-compliant interfaces for annealers and samplers are bundled within [`ToQUBO.jl`](https://github.com/JuliaQUBO/ToQUBO.jl) via the [`QUBODrivers.jl`](https://github.com/JuliaQUBO/QUBODrivers.jl) companion package.
 Some of them are presented below.
 
 ## Simulated Annealing
 
 Provided by D-Wave's open-source code libraries, this [Simulated Annealing](https://en.wikipedia.org/wiki/Simulated_annealing) engine implements some of the features and configurations you would find using the Quantum API.
 Its adoption is recommended for basic usage, tests, and research due to its robustness, simplicity and ease of use.
-The [`DWave.jl`](https://github.com/psrenergy/DWave.jl)'s `DWave.Neal` module uses [`QUBODrivers.jl`](https://github.com/psrenergy/QUBODrivers.jl) to deliver an interface to this sampler.
+The [`DWave.jl`](https://github.com/JuliaQUBO/DWave.jl)'s `DWave.Neal` module uses [`QUBODrivers.jl`](https://github.com/JuliaQUBO/QUBODrivers.jl) to deliver an interface to this sampler.
 
 ## Quantum Annealing
 
@@ -31,5 +31,5 @@ Thus, only problems with at most ``\approxeq 20`` variables should be provided s
 ## Mixed-Integer Quadratic Programming
 
 The most accessible alternative to the forementioned methods are Mixed-Integer Quadratic Programming (MIQP) solvers such as [Gurobi](https://github.com/jump-dev/Gurobi.jl), [CPLEX](https://github.com/jump-dev/CPLEX.jl), [SCIP](https://github.com/scipopt/SCIP.jl) and [BARON](https://github.com/jump-dev/BARON.jl).
-These are not intended to be of regular use alongside [`ToQUBO.jl`](https://github.com/psrenergy/ToQUBO.jl) since providing a QUBO reformulation will usually make things harder for non-specialized solvers.
+These are not intended to be of regular use alongside [`ToQUBO.jl`](https://github.com/JuliaQUBO/ToQUBO.jl) since providing a QUBO reformulation will usually make things harder for non-specialized solvers.
 Yet, there are still a few cases where they may be suitable, such as tests, benchmarks, or any other situation where global optimality is a must.

--- a/docs/src/booklet/8-appendix.md
+++ b/docs/src/booklet/8-appendix.md
@@ -4,7 +4,7 @@
 
 ### Logo
 
-The ideia behind [ToQUBO.jl](https://github.com/psrenergy/ToQUBO.jl)'s logo comes from a wordplay in Portuguese and Spanish.
+The ideia behind [ToQUBO.jl](https://github.com/JuliaQUBO/ToQUBO.jl)'s logo comes from a wordplay in Portuguese and Spanish.
 The package's main purpose is to assemble QUBO Models, which sounds like *cubo*[^1], the translation for *cube*.
 
 ![ToQUBO.jl Logo](../assets/logo.svg)


### PR DESCRIPTION
## Summary

- Replace legacy `github.com/psrenergy` repository links in `CITATION.cff` and booklet docs with canonical `github.com/JuliaQUBO` URLs.

## Tests run

- `rg -n "psrenergy" CITATION.cff docs/src/booklet/7-solvers.md docs/src/booklet/8-appendix.md`: no matches.
- `git diff --check master...HEAD`: passed.
- `julia --project=test -e 'using Test; include("test/unit/docs.jl"); test_docs()'`: passed, 4/4 tests.
- `julia --project -e 'using Pkg; Pkg.test()'`: blocked before running tests on local Julia 1.10.11 because the checked-in root `Manifest.toml` was resolved with Julia 1.12 and `OpenSSL_jll` source could not be located under Julia 1.10.11.
- `julia +1.12 --project -e 'using Pkg; Pkg.test()'`: passed, 967/967 tests before the final amend that removed the temporary docs regression test.
- `julia +1.12 --project=docs docs/make.jl --skip-deploy`: passed before the final amend; docs source links are unchanged by that amend.

## Notes

- No regression test was added for the organization-name replacement; this PR keeps the change as a docs and metadata cleanup.
- The local docs build used `--skip-deploy`; CI runs the same docs build path with deployment enabled.

Closes #118