### PR TITLE
Add Dependabot dependency maintenance config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    groups:
+      docs-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/test"
+    schedule:
+      interval: "weekly"
+    groups:
+      test-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/test/unit/compat.jl
+++ b/test/unit/compat.jl
@@ -3,14 +3,17 @@ function test_compat()
         root = normpath(joinpath(@__DIR__, "..", ".."))
         project = TOML.parsefile(joinpath(root, "Project.toml"))
         docs_project = TOML.parsefile(joinpath(root, "docs", "Project.toml"))
+        test_project = TOML.parsefile(joinpath(root, "test", "Project.toml"))
         compat = project["compat"]
         docs_compat = docs_project["compat"]
+        test_compat = test_project["compat"]
 
         @test compat["julia"] == "1.10"
         @test occursin(r"(^|,\s*)0\.12(\s*(,|$))", compat["QUBOTools"])
         @test docs_compat["PySA"] == "0.3.4"
         @test occursin(r"(^|,\s*)0\.4(\s*(,|$))", docs_compat["QUBODrivers"])
         @test docs_compat["QUBOTools"] == "0.12"
+        @test occursin(r"(^|,\s*)0\.12(\s*(,|$))", test_compat["QUBOTools"])
 
         ci = replace(
             read(joinpath(root, ".github", "workflows", "ci.yml"), String),
@@ -20,11 +23,51 @@ function test_compat()
             read(joinpath(root, ".github", "workflows", "documentation.yml"), String),
             "\r\n" => "\n",
         )
+        dependabot = replace(
+            read(joinpath(root, ".github", "dependabot.yml"), String),
+            "\r\n" => "\n",
+        )
 
         @test occursin(r"(?m)^\s*-\s*version:\s*'1\.10'\s*$", ci)
         @test occursin(r"(?m)^\s*-\s*version:\s*'1'\s*$", ci)
         @test occursin(r"(?m)^\s*version:\s*'1'\s*$", docs)
         @test !occursin(r"(?m)^\s*version:\s*'1\.9'\s*$", docs)
+        @test occursin(
+            """
+              - package-ecosystem: "julia"
+                directory: "/"
+                schedule:
+                  interval: "weekly"
+            """,
+            dependabot,
+        )
+        @test occursin(
+            """
+              - package-ecosystem: "julia"
+                directory: "/docs"
+                schedule:
+                  interval: "weekly"
+            """,
+            dependabot,
+        )
+        @test occursin(
+            """
+              - package-ecosystem: "julia"
+                directory: "/test"
+                schedule:
+                  interval: "weekly"
+            """,
+            dependabot,
+        )
+        @test occursin(
+            """
+              - package-ecosystem: "github-actions"
+                directory: "/"
+                schedule:
+                  interval: "monthly"
+            """,
+            dependabot,
+        )
     end
 
     return nothing


### PR DESCRIPTION
Summary:
- Add `.github/dependabot.yml` following the JuliaQUBO dependency maintenance policy from JuliaQUBO/QUBO.jl#30/#31.
- Configure weekly grouped Julia dependency updates for the root, `docs`, and `test` environments because each maintains `[compat]` bounds.
- Configure monthly GitHub Actions update checks.
- Extend the existing compatibility/CI maintenance test to assert the Dependabot entries.

Permissions and secrets:
- No CompatHelper workflow is added.
- No PAT or cross-repository workflow trigger secret is required for this Dependabot configuration.
- Dependabot can use GitHub's built-in Dependabot service for this public package repository; existing workflows can continue using their current `GITHUB_TOKEN` setup.

Tests:
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`
- `JULIA_DEPOT_PATH=.julia-depot julia --project=test -e 'using Test, TOML; include("test/unit/compat.jl"); test_compat()'`
- `python -m unittest discover -s .github/tests -p "test_*.py"`

Closes #120
