### PR TITLE
[codex] prepare v0.3.1 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## v0.3.1 - 2026-06-03
+
+### Maintenance
+
+- Add Dependabot configuration for the root, documentation, and test Julia environments, plus GitHub Actions workflow updates.
+- Update GitHub Actions dependencies, including `actions/checkout`, `actions/setup-python`, `codecov/codecov-action`, and `julia-actions/setup-julia`.
+- Skip documentation deployment for Dependabot-triggered pull requests while still building the documentation.
+- Add compatibility checks covering the Dependabot configuration and maintenance environments.
+- Allow `TOML` 1.0.3 and QUBODrivers 0.5 in the relevant maintenance environments.
+- Clean legacy repository and default-branch references.
+
 ## v0.3.0 - 2026-05-23
 
 ### Breaking

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name    = "ToQUBO"
 uuid    = "9a412ddf-83fa-43b6-9748-7843c851aa65"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "bernalde <dbernalneira@usra.edu>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 MathOptInterface          = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"


### PR DESCRIPTION
## Summary

- Bump `ToQUBO` from `0.3.0` to `0.3.1`.
- Add release notes for the maintenance changes merged since `v0.3.0`.

## Validation

- `JULIA_DEPOT_PATH=/home/bernalde/repos/ToQUBO.jl/.julia-depot julia +release --project=. -e 'using Pkg; Pkg.test()'`
- Result: 964/964 tests passed.

## Release follow-up

After this PR merges, trigger registration with:

```text
@JuliaRegistrator register
```

TagBot should create the GitHub tag and release after General registry registration completes.
