### PR TITLE
ci: use Codecov files input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v6
         with:
-          file: lcov.info
+          files: lcov.info


### PR DESCRIPTION
## Summary

- Replace the deprecated Codecov action `file` input with `files`.

## Validation

- `git diff --check`
- Confirmed `.github/workflows/ci.yml` now only uses `files: lcov.info` for `codecov/codecov-action@v6`.

The PR CI run should verify that the Codecov warning is gone.
