### PR TITLE
Record reformulation metadata

### DIFF
--- a/docs/src/manual/3-results.md
+++ b/docs/src/manual/3-results.md
@@ -152,13 +152,16 @@ zeta = MOI.get(model, Attributes.SlackVariableEncodingFunction(), constraint_ref
 ### Reformulation Metadata
 
 ToQUBO records JSON-compatible reformulation metadata for downstream tools that
-need to interpret full QUBO states. The metadata is available directly from the
-optimizer and is also attached under `metadata["toqubo"]["reformulation"]` on
-the `QUBOTools` model returned by `QUBOTools.backend`.
+need to interpret full QUBO states. The metadata uses string-keyed dictionaries,
+arrays, primitive values, and finite numeric values. It is available directly
+from the optimizer and is also attached under
+`metadata["toqubo"]["reformulation"]` on the `QUBOTools` model returned by
+`QUBOTools.backend`.
 
 ```julia
-backend = unsafe_backend(model)
-metadata = ToQUBO.reformulation_metadata(backend)
+optimizer = unsafe_backend(model)
+metadata = ToQUBO.reformulation_metadata(optimizer)
+qubo_model = ToQUBO.QUBOTools.backend(optimizer)
 
 original = ToQUBO.original_variables(metadata)
 auxiliary = ToQUBO.auxiliary_variables(metadata)

--- a/docs/src/manual/3-results.md
+++ b/docs/src/manual/3-results.md
@@ -149,7 +149,36 @@ z = MOI.get(model, Attributes.SlackVariableTargetVariables(), constraint_ref)
 zeta = MOI.get(model, Attributes.SlackVariableEncodingFunction(), constraint_ref)
 ```
 
+### Reformulation Metadata
+
+ToQUBO records JSON-compatible reformulation metadata for downstream tools that
+need to interpret full QUBO states. The metadata is available directly from the
+optimizer and is also attached under `metadata["toqubo"]["reformulation"]` on
+the `QUBOTools` model returned by `QUBOTools.backend`.
+
+```julia
+backend = unsafe_backend(model)
+metadata = ToQUBO.reformulation_metadata(backend)
+
+original = ToQUBO.original_variables(metadata)
+auxiliary = ToQUBO.auxiliary_variables(metadata)
+
+qubo_state = [0, 1, 0, 1]
+source_state = ToQUBO.project_original_state(metadata, qubo_state)
+```
+
+The metadata guarantees the original source variable order, target QUBO
+variable order, source-to-target `expansion_variables` and `expansion_terms`,
+constraint/slack ownership for generated target variables, and penalty terms
+recorded by the compiler. This is enough to project a full QUBO state back to
+original variables. Exact auxiliary consistency checks and repair remain
+encoding-specific and are not guaranteed by this metadata contract.
+
 ```@docs
+ToQUBO.reformulation_metadata
+ToQUBO.original_variables
+ToQUBO.auxiliary_variables
+ToQUBO.project_original_state
 ToQUBO.Attributes.CompilationTime
 ToQUBO.Attributes.CompilationStatus
 ToQUBO.Attributes.SourceModel

--- a/src/ToQUBO.jl
+++ b/src/ToQUBO.jl
@@ -76,4 +76,7 @@ include("attributes/compiler.jl")
 # Compiler
 include("compiler/compiler.jl")
 
+# Reformulation metadata
+include("reformulation.jl")
+
 end # module

--- a/src/reformulation.jl
+++ b/src/reformulation.jl
@@ -184,6 +184,8 @@ function _target_metadata(model::Virtual.Model{T}) where {T}
     variables = MOI.get(model.target_model, MOI.ListOfVariableIndices())
     objective = MOI.get(model.target_model, MOI.ObjectiveFunction{SQF{T}}())
 
+    # ToQUBO adds penalty and quadratization terms, but does not rescale the
+    # source objective during reformulation.
     return Dict{String,Any}(
         "num_variables" => length(variables),
         "variable_order" => [vi.value for vi in variables],
@@ -197,6 +199,7 @@ function _variable_encoding_entry(model::Virtual.Model, vi::VI)
     entry = Dict{String,Any}(
         "id" => vi.value,
         "name" => _variable_name(model.source_model, vi),
+        "encoded" => false,
         "target_variables" => Int[],
         "encoding" => nothing,
         "expansion_variables" => Int[],
@@ -208,6 +211,7 @@ function _variable_encoding_entry(model::Virtual.Model, vi::VI)
     if haskey(model.source, vi)
         v = model.source[vi]
 
+        entry["encoded"] = true
         entry["target_variables"] = [yi.value for yi in Virtual.target(v)]
         entry["encoding"] = _encoding_metadata(Virtual.encoding(v))
         entry["expansion_variables"] = _pbf_variable_ids(Virtual.expansion(v))
@@ -460,6 +464,10 @@ function _evaluate_serialized_terms(terms::AbstractVector, state)
     return value
 end
 
+function _serialized_entry_encoded(entry::AbstractDict)
+    return get(entry, "encoded", !isempty(entry["expansion_terms"]))
+end
+
 function project_original_state(model::Virtual.Model, qubo_state)
     values = Dict{VI,Any}()
 
@@ -483,6 +491,10 @@ function project_original_state(metadata::AbstractDict, qubo_state)
     values = Dict{Int,Any}()
 
     for entry in data["original_variables"]
+        if !_serialized_entry_encoded(entry)
+            error("Source variable $(entry["id"]) has not been encoded")
+        end
+
         values[entry["id"]] = _evaluate_serialized_terms(
             entry["expansion_terms"],
             qubo_state,

--- a/src/reformulation.jl
+++ b/src/reformulation.jl
@@ -1,0 +1,497 @@
+const _TOQUBO_METADATA_KEY = "toqubo"
+const _REFORMULATION_METADATA_KEY = "reformulation"
+const _REFORMULATION_SCHEMA_VERSION = 1
+
+@doc raw"""
+    reformulation_metadata(model_or_metadata)
+
+Return JSON-compatible ToQUBO reformulation metadata. For a live
+`ToQUBO.Optimizer`, the metadata is generated from the compiled virtual model.
+For a `QUBOTools.AbstractModel` or a metadata dictionary, the metadata is read
+from `metadata["toqubo"]["reformulation"]`.
+"""
+function reformulation_metadata end
+
+@doc raw"""
+    original_variables(model_or_metadata)
+
+Return the original source variable identities in compiler order.
+
+For a live `ToQUBO.Optimizer`, the result is a vector of `MOI.VariableIndex`
+values. For serialized metadata or a `QUBOTools.AbstractModel`, the result is a
+vector of integer variable ids.
+"""
+function original_variables end
+
+@doc raw"""
+    auxiliary_variables(model_or_metadata)
+
+Return target QUBO variables that are not owned by original source variables.
+
+For a live `ToQUBO.Optimizer`, the result is a vector of `MOI.VariableIndex`
+values. For serialized metadata or a `QUBOTools.AbstractModel`, the result is a
+vector of integer target variable ids.
+"""
+function auxiliary_variables end
+
+@doc raw"""
+    project_original_state(model_or_metadata, qubo_state)
+
+Project a full QUBO state onto the original source variables using the stored
+encoding expansions.
+
+`qubo_state` may be a vector indexed by target QUBO variable id, or a dictionary
+keyed by integer target ids, string target ids, or `MOI.VariableIndex` values.
+For a live `ToQUBO.Optimizer`, the result is keyed by `MOI.VariableIndex`. For
+serialized metadata or a `QUBOTools.AbstractModel`, the result is keyed by
+integer source variable ids.
+"""
+function project_original_state end
+
+function _type_name(x)
+    return string(nameof(typeof(x)))
+end
+
+function _type_path(x)
+    return string(typeof(x))
+end
+
+function _sense_metadata(sense::MOI.OptimizationSense)
+    if sense === MOI.MIN_SENSE
+        return "min"
+    elseif sense === MOI.MAX_SENSE
+        return "max"
+    elseif sense === MOI.FEASIBILITY_SENSE
+        return "feasibility"
+    else
+        return string(sense)
+    end
+end
+
+function _constraint_ref(ci::MOI.ConstraintIndex{F,S}) where {F,S}
+    return Dict{String,Any}(
+        "id" => ci.value,
+        "function_type" => string(F),
+        "set_type" => string(S),
+    )
+end
+
+function _owner_ref(::Nothing)
+    return nothing
+end
+
+function _owner_ref(vi::VI)
+    return Dict{String,Any}("type" => "source_variable", "id" => vi.value)
+end
+
+function _owner_ref(ci::MOI.ConstraintIndex)
+    return Dict{String,Any}("type" => "constraint", "constraint" => _constraint_ref(ci))
+end
+
+_owner_role(::Nothing) = "quadratization"
+_owner_role(::VI) = "source"
+_owner_role(::MOI.ConstraintIndex) = "constraint"
+
+function _variable_name(model::MOI.ModelLike, vi::VI)
+    try
+        name = MOI.get(model, MOI.VariableName(), vi)
+
+        return isempty(name) ? nothing : name
+    catch
+        return nothing
+    end
+end
+
+function _term_variable_ids(term)
+    if term === nothing || isempty(term)
+        return Int[]
+    else
+        return sort!([vi.value for vi in term])
+    end
+end
+
+function _pbf_terms(f::PBO.PBF)
+    terms = Dict{String,Any}[]
+
+    for (term, coefficient) in f
+        iszero(coefficient) && continue
+
+        push!(
+            terms,
+            Dict{String,Any}(
+                "variables" => _term_variable_ids(term),
+                "coefficient" => coefficient,
+            ),
+        )
+    end
+
+    sort!(terms; by = term -> (length(term["variables"]), join(term["variables"], ",")))
+
+    return terms
+end
+
+function _pbf_variable_ids(f::PBO.PBF)
+    ids = Set{Int}()
+
+    for (term, coefficient) in f
+        iszero(coefficient) && continue
+
+        union!(ids, _term_variable_ids(term))
+    end
+
+    return sort!(collect(ids))
+end
+
+function _encoding_metadata(e::Encoding.VariableEncodingMethod)
+    return Dict{String,Any}(
+        "type" => _type_name(e),
+        "julia_type" => _type_path(e),
+    )
+end
+
+function _constraint_penalty_method_metadata(method::Attributes.ConstraintPenaltyMethod)
+    return Dict{String,Any}(
+        "type" => _type_name(method),
+        "julia_type" => _type_path(method),
+    )
+end
+
+function _constraint_order(model::MOI.ModelLike)
+    constraints = Dict{String,Any}[]
+
+    for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
+        for ci in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+            push!(constraints, _constraint_ref(ci))
+        end
+    end
+
+    sort!(constraints; by = ci -> (ci["id"], ci["function_type"], ci["set_type"]))
+
+    return constraints
+end
+
+function _source_metadata(model::Virtual.Model)
+    variables = original_variables(model)
+
+    return Dict{String,Any}(
+        "num_variables" => length(variables),
+        "variable_order" => [vi.value for vi in variables],
+        "constraints" => _constraint_order(model.source_model),
+    )
+end
+
+function _target_metadata(model::Virtual.Model{T}) where {T}
+    variables = MOI.get(model.target_model, MOI.ListOfVariableIndices())
+    objective = MOI.get(model.target_model, MOI.ObjectiveFunction{SQF{T}}())
+
+    return Dict{String,Any}(
+        "num_variables" => length(variables),
+        "variable_order" => [vi.value for vi in variables],
+        "sense" => _sense_metadata(MOI.get(model.target_model, MOI.ObjectiveSense())),
+        "scale" => one(T),
+        "offset" => objective.constant,
+    )
+end
+
+function _variable_encoding_entry(model::Virtual.Model, vi::VI)
+    entry = Dict{String,Any}(
+        "id" => vi.value,
+        "name" => _variable_name(model.source_model, vi),
+        "target_variables" => Int[],
+        "encoding" => nothing,
+        "expansion_variables" => Int[],
+        "expansion_terms" => Dict{String,Any}[],
+        "penalty" => nothing,
+        "penalty_terms" => nothing,
+    )
+
+    if haskey(model.source, vi)
+        v = model.source[vi]
+
+        entry["target_variables"] = [yi.value for yi in Virtual.target(v)]
+        entry["encoding"] = _encoding_metadata(Virtual.encoding(v))
+        entry["expansion_variables"] = _pbf_variable_ids(Virtual.expansion(v))
+        entry["expansion_terms"] = _pbf_terms(Virtual.expansion(v))
+
+        if haskey(model.h, vi)
+            entry["penalty"] = get(model.θ, vi, nothing)
+            entry["penalty_terms"] = _pbf_terms(model.h[vi])
+        end
+    end
+
+    return entry
+end
+
+function _original_variable_entries(model::Virtual.Model)
+    return [_variable_encoding_entry(model, vi) for vi in original_variables(model)]
+end
+
+function _target_variable_entries(model::Virtual.Model)
+    entries = Dict{String,Any}[]
+
+    for vi in MOI.get(model.target_model, MOI.ListOfVariableIndices())
+        v = get(model.target, vi, nothing)
+        owner = isnothing(v) ? nothing : Virtual.source(v)
+
+        push!(
+            entries,
+            Dict{String,Any}(
+                "id" => vi.value,
+                "role" => _owner_role(owner),
+                "owner" => _owner_ref(owner),
+                "encoding" => isnothing(v) ? nothing : _encoding_metadata(Virtual.encoding(v)),
+            ),
+        )
+    end
+
+    sort!(entries; by = entry -> entry["id"])
+
+    return entries
+end
+
+function _auxiliary_variable_entries(target_variables)
+    return [entry for entry in target_variables if entry["role"] != "source"]
+end
+
+function _constraint_sort_key(ci::MOI.ConstraintIndex)
+    ref = _constraint_ref(ci)
+
+    return (ref["id"], ref["function_type"], ref["set_type"])
+end
+
+function _slack_variable_entries(model::Virtual.Model)
+    entries = Dict{String,Any}[]
+
+    for (ci, v) in sort!(collect(model.slack); by = pair -> _constraint_sort_key(first(pair)))
+        entry = Dict{String,Any}(
+            "constraint" => _constraint_ref(ci),
+            "target_variables" => [vi.value for vi in Virtual.target(v)],
+            "encoding" => _encoding_metadata(Virtual.encoding(v)),
+            "expansion_variables" => _pbf_variable_ids(Virtual.expansion(v)),
+            "expansion_terms" => _pbf_terms(Virtual.expansion(v)),
+            "penalty" => get(model.η, ci, nothing),
+            "penalty_terms" => nothing,
+        )
+
+        if haskey(model.s, ci)
+            entry["penalty_terms"] = _pbf_terms(model.s[ci])
+        end
+
+        push!(entries, entry)
+    end
+
+    return entries
+end
+
+function _constraint_encoding_entries(model::Virtual.Model)
+    entries = Dict{String,Any}[]
+
+    for (ci, terms) in sort!(collect(model.g); by = pair -> _constraint_sort_key(first(pair)))
+        push!(
+            entries,
+            Dict{String,Any}(
+                "constraint" => _constraint_ref(ci),
+                "method" => _constraint_penalty_method_metadata(
+                    Attributes.constraint_encoding_method(model, ci),
+                ),
+                "penalty" => get(model.ρ, ci, nothing),
+                "terms" => _pbf_terms(terms),
+            ),
+        )
+    end
+
+    return entries
+end
+
+function reformulation_metadata(model::Virtual.Model)
+    target_variables = _target_variable_entries(model)
+
+    return Dict{String,Any}(
+        "schema_version" => _REFORMULATION_SCHEMA_VERSION,
+        "package" => Dict{String,Any}(
+            "name" => "ToQUBO",
+            "version" => string(__version__()),
+        ),
+        "source" => _source_metadata(model),
+        "target" => _target_metadata(model),
+        "original_variables" => _original_variable_entries(model),
+        "target_variables" => target_variables,
+        "auxiliary_variables" => _auxiliary_variable_entries(target_variables),
+        "slack_variables" => _slack_variable_entries(model),
+        "constraint_encodings" => _constraint_encoding_entries(model),
+        "guarantees" => Dict{String,Any}(
+            "project_original_state" => true,
+            "auxiliary_consistency" => "encoding-specific",
+            "auxiliary_repair" => "not provided",
+        ),
+    )
+end
+
+function reformulation_metadata(model::QUBOTools.AbstractModel)
+    return reformulation_metadata(QUBOTools.metadata(model))
+end
+
+function reformulation_metadata(metadata::AbstractDict)
+    if haskey(metadata, _TOQUBO_METADATA_KEY)
+        toqubo = metadata[_TOQUBO_METADATA_KEY]
+
+        if toqubo isa AbstractDict && haskey(toqubo, _REFORMULATION_METADATA_KEY)
+            return toqubo[_REFORMULATION_METADATA_KEY]
+        end
+    elseif haskey(metadata, "schema_version") &&
+           haskey(metadata, "original_variables") &&
+           haskey(metadata, "target_variables")
+        return metadata
+    end
+
+    error("No ToQUBO reformulation metadata was found")
+end
+
+function _attach_reformulation_metadata!(
+    target::QUBOTools.AbstractModel,
+    source::Virtual.Model,
+)
+    metadata = QUBOTools.metadata(target)
+    toqubo = get!(metadata, _TOQUBO_METADATA_KEY, Dict{String,Any}())
+
+    if !(toqubo isa Dict{String,Any})
+        toqubo = Dict{String,Any}("previous" => toqubo)
+        metadata[_TOQUBO_METADATA_KEY] = toqubo
+    end
+
+    toqubo[_REFORMULATION_METADATA_KEY] = reformulation_metadata(source)
+
+    return target
+end
+
+function original_variables(model::Virtual.Model)
+    return collect(MOI.get(model.source_model, MOI.ListOfVariableIndices()))
+end
+
+function original_variables(model::QUBOTools.AbstractModel)
+    return original_variables(reformulation_metadata(model))
+end
+
+function original_variables(metadata::AbstractDict)
+    data = reformulation_metadata(metadata)
+
+    return [entry["id"] for entry in data["original_variables"]]
+end
+
+function auxiliary_variables(model::Virtual.Model)
+    data = reformulation_metadata(model)
+
+    return VI[VI(entry["id"]) for entry in data["auxiliary_variables"]]
+end
+
+function auxiliary_variables(model::QUBOTools.AbstractModel)
+    return auxiliary_variables(reformulation_metadata(model))
+end
+
+function auxiliary_variables(metadata::AbstractDict)
+    data = reformulation_metadata(metadata)
+
+    return [entry["id"] for entry in data["auxiliary_variables"]]
+end
+
+function _state_value(state::AbstractVector, id::Integer)
+    if !(1 <= id <= length(state))
+        error("QUBO state is missing target variable id $id")
+    end
+
+    return state[id]
+end
+
+function _state_value(state::AbstractDict, id::Integer)
+    if haskey(state, id)
+        return state[id]
+    elseif haskey(state, VI(id))
+        return state[VI(id)]
+    elseif haskey(state, string(id))
+        return state[string(id)]
+    else
+        error("QUBO state is missing target variable id $id")
+    end
+end
+
+function _state_value(state, vi::VI)
+    return _state_value(state, vi.value)
+end
+
+function _state_value(state::AbstractDict, vi::VI)
+    if haskey(state, vi)
+        return state[vi]
+    else
+        return _state_value(state, vi.value)
+    end
+end
+
+function _evaluate_pbf(f::PBO.PBF{VI,T}, state) where {T}
+    value = zero(T)
+
+    for (term, coefficient) in f
+        term_value = coefficient
+
+        if term !== nothing
+            for vi in term
+                term_value *= _state_value(state, vi)
+            end
+        end
+
+        value += term_value
+    end
+
+    return value
+end
+
+function _evaluate_serialized_terms(terms::AbstractVector, state)
+    value = 0
+
+    for term in terms
+        term_value = term["coefficient"]
+
+        for id in term["variables"]
+            term_value *= _state_value(state, id)
+        end
+
+        value += term_value
+    end
+
+    return value
+end
+
+function project_original_state(model::Virtual.Model, qubo_state)
+    values = Dict{VI,Any}()
+
+    for vi in original_variables(model)
+        if !haskey(model.source, vi)
+            error("Source variable $(vi) has not been encoded")
+        end
+
+        values[vi] = _evaluate_pbf(Virtual.expansion(model.source[vi]), qubo_state)
+    end
+
+    return values
+end
+
+function project_original_state(model::QUBOTools.AbstractModel, qubo_state)
+    return project_original_state(reformulation_metadata(model), qubo_state)
+end
+
+function project_original_state(metadata::AbstractDict, qubo_state)
+    data = reformulation_metadata(metadata)
+    values = Dict{Int,Any}()
+
+    for entry in data["original_variables"]
+        values[entry["id"]] = _evaluate_serialized_terms(
+            entry["expansion_terms"],
+            qubo_state,
+        )
+    end
+
+    return values
+end
+
+function project_original_state(model_or_metadata, sample::QUBOTools.AbstractSample)
+    return project_original_state(model_or_metadata, QUBOTools.state(sample))
+end

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -158,5 +158,9 @@ function Base.show(io::IO, model::Optimizer)
 end
 
 function QUBOTools.backend(model::Optimizer{T}) where {T}
-    return QUBOTools.Model{T}(model.target_model)
+    qubo_model = QUBOTools.Model{T}(model.target_model)
+
+    _attach_reformulation_metadata!(qubo_model, model)
+
+    return qubo_model
 end

--- a/test/unit/reformulation.jl
+++ b/test/unit/reformulation.jl
@@ -1,0 +1,125 @@
+function _json_compatible(value)
+    if value === nothing ||
+       value isa String ||
+       value isa Bool ||
+       value isa Integer ||
+       value isa AbstractFloat
+        return true
+    elseif value isa AbstractVector
+        return all(_json_compatible, value)
+    elseif value isa AbstractDict
+        return all(key isa String && _json_compatible(val) for (key, val) in value)
+    else
+        return false
+    end
+end
+
+function _reformulation_test_model()
+    model = ToQUBO.Optimizer{Float64}()
+    x = MOI.add_variable(model)
+    MOI.add_constraint(model, x, MOI.Integer())
+    MOI.add_constraint(model, x, MOI.Interval(0.0, 3.0))
+    y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+
+    c = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(1.0, x),
+                MOI.ScalarAffineTerm{Float64}(1.0, y),
+            ],
+            0.0,
+        ),
+        MOI.LessThan(2.0),
+    )
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
+    )
+
+    MOI.optimize!(model)
+
+    return model, x, y, c
+end
+
+function _target_state(model, x, y)
+    n = MOI.get(model.target_model, MOI.NumberOfVariables())
+    state = zeros(Int, n)
+
+    for vi in (x, y)
+        for target in MOI.get(model, Attributes.VariableTargetVariables(), vi)
+            state[target.value] = 1
+        end
+    end
+
+    return state
+end
+
+function test_reformulation_metadata()
+    @testset "→ Reformulation Metadata" begin
+        model, x, y, c = _reformulation_test_model()
+        metadata = ToQUBO.reformulation_metadata(model)
+
+        @test _json_compatible(metadata)
+        @test metadata["schema_version"] == 1
+        @test metadata["source"]["variable_order"] == [x.value, y.value]
+        @test metadata["target"]["num_variables"] ==
+              MOI.get(model.target_model, MOI.NumberOfVariables())
+
+        x_entry = only(entry for entry in metadata["original_variables"] if entry["id"] == x.value)
+        y_entry = only(entry for entry in metadata["original_variables"] if entry["id"] == y.value)
+        @test x_entry["expansion_variables"] == x_entry["target_variables"]
+        @test y_entry["expansion_variables"] == y_entry["target_variables"]
+
+        @test ToQUBO.original_variables(model) == VI[x, y]
+        @test ToQUBO.original_variables(metadata) == [x.value, y.value]
+
+        auxiliary = ToQUBO.auxiliary_variables(metadata)
+        @test !isempty(auxiliary)
+        @test auxiliary == [entry["id"] for entry in metadata["auxiliary_variables"]]
+        @test any(
+            entry -> entry["owner"]["type"] == "constraint",
+            metadata["auxiliary_variables"],
+        )
+        @test any(
+            entry -> entry["constraint"]["id"] == c.value,
+            metadata["constraint_encodings"],
+        )
+        @test any(
+            entry -> entry["constraint"]["id"] == c.value,
+            metadata["slack_variables"],
+        )
+
+        state = _target_state(model, x, y)
+        projected = ToQUBO.project_original_state(model, state)
+        @test projected[x] == 3.0
+        @test projected[y] == 1.0
+
+        serialized_projected = ToQUBO.project_original_state(metadata, state)
+        @test serialized_projected[x.value] == 3.0
+        @test serialized_projected[y.value] == 1.0
+
+        dict_state = Dict(VI(i) => state[i] for i = 1:length(state))
+        dict_projected = ToQUBO.project_original_state(model, dict_state)
+        @test dict_projected[x] == 3.0
+        @test dict_projected[y] == 1.0
+
+        backend = QUBOTools.backend(model)
+        backend_metadata = QUBOTools.metadata(backend)
+        backend_reformulation = ToQUBO.reformulation_metadata(backend)
+
+        @test _json_compatible(backend_metadata)
+        @test backend_reformulation["source"]["variable_order"] == [x.value, y.value]
+        @test ToQUBO.original_variables(backend) == [x.value, y.value]
+        @test ToQUBO.auxiliary_variables(backend) == auxiliary
+
+        backend_projected = ToQUBO.project_original_state(backend, state)
+        @test backend_projected[x.value] == 3.0
+        @test backend_projected[y.value] == 1.0
+    end
+
+    return nothing
+end

--- a/test/unit/reformulation.jl
+++ b/test/unit/reformulation.jl
@@ -2,9 +2,10 @@ function _json_compatible(value)
     if value === nothing ||
        value isa String ||
        value isa Bool ||
-       value isa Integer ||
-       value isa AbstractFloat
+       value isa Integer
         return true
+    elseif value isa AbstractFloat
+        return isfinite(value)
     elseif value isa AbstractVector
         return all(_json_compatible, value)
     elseif value isa AbstractDict
@@ -73,6 +74,9 @@ function test_reformulation_metadata()
         y_entry = only(entry for entry in metadata["original_variables"] if entry["id"] == y.value)
         @test x_entry["expansion_variables"] == x_entry["target_variables"]
         @test y_entry["expansion_variables"] == y_entry["target_variables"]
+        @test x_entry["encoded"] === true
+        @test y_entry["encoded"] === true
+        @test !_json_compatible(Dict{String,Any}("value" => Inf))
 
         @test ToQUBO.original_variables(model) == VI[x, y]
         @test ToQUBO.original_variables(metadata) == [x.value, y.value]
@@ -101,6 +105,15 @@ function test_reformulation_metadata()
         serialized_projected = ToQUBO.project_original_state(metadata, state)
         @test serialized_projected[x.value] == 3.0
         @test serialized_projected[y.value] == 1.0
+
+        unencoded_metadata = deepcopy(metadata)
+        unencoded_entry = only(
+            entry for entry in unencoded_metadata["original_variables"] if entry["id"] == x.value
+        )
+        unencoded_entry["encoded"] = false
+        unencoded_entry["expansion_variables"] = Int[]
+        unencoded_entry["expansion_terms"] = Dict{String,Any}[]
+        @test_throws ErrorException ToQUBO.project_original_state(unencoded_metadata, state)
 
         dict_state = Dict(VI(i) => state[i] for i = 1:length(state))
         dict_projected = ToQUBO.project_original_state(model, dict_state)

--- a/test/unit/unit.jl
+++ b/test/unit/unit.jl
@@ -6,6 +6,7 @@ include("virtual/virtual.jl")
 include("model/model.jl")
 include("wrapper/wrapper.jl")
 include("attributes/attributes.jl")
+include("reformulation.jl")
 
 function test_unit()
     @testset "⊚ Unit Tests" verbose = true begin
@@ -17,6 +18,7 @@ function test_unit()
         test_model()
         test_wrapper()
         test_attributes()
+        test_reformulation_metadata()
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- Add JSON-compatible ToQUBO reformulation metadata with schema versioning, source/target variable order, expansion terms, auxiliary ownership, slack encodings, and compiler penalty terms.
- Attach reformulation metadata to the `QUBOTools.backend` model under `metadata["toqubo"]["reformulation"]`.
- Add helper APIs for reading original variables, auxiliary variables, and projecting a full QUBO state back onto original variables.
- Document the metadata guarantees and the encoding-specific limits around auxiliary consistency/repair.

## Tests

- `julia +release --project=. -e 'using Test; import MathOptInterface as MOI; using ToQUBO; using ToQUBO: Attributes; import QUBOTools; const VI = MOI.VariableIndex; include("test/unit/reformulation.jl"); test_reformulation_metadata()'`
- `julia +release --project=. -e 'import Pkg; Pkg.test()'`
- `julia +release --project=docs docs/make.jl`

Refs #132
