### PR TITLE
Parameterize penalty heuristic and expose applied penalties

### DIFF
--- a/docs/src/manual/3-results.md
+++ b/docs/src/manual/3-results.md
@@ -172,10 +172,12 @@ source_state = ToQUBO.project_original_state(metadata, qubo_state)
 
 The metadata guarantees the original source variable order, target QUBO
 variable order, source-to-target `expansion_variables` and `expansion_terms`,
-constraint/slack ownership for generated target variables, and penalty terms
-recorded by the compiler. This is enough to project a full QUBO state back to
-original variables. Exact auxiliary consistency checks and repair remain
-encoding-specific and are not guaranteed by this metadata contract.
+constraint/slack ownership for generated target variables, penalty terms
+recorded by the compiler, and an `applied_penalties` section with the applied
+constraint, variable-encoding, and slack-variable penalty coefficients. This is
+enough to project a full QUBO state back to original variables. Exact auxiliary
+consistency checks and repair remain encoding-specific and are not guaranteed by
+this metadata contract.
 
 ```@docs
 ToQUBO.reformulation_metadata
@@ -192,6 +194,7 @@ ToQUBO.Attributes.VariableTargetVariables
 ToQUBO.Attributes.VariableEncodingFunction
 ToQUBO.Attributes.VariableEncodingPenaltyFunction
 ToQUBO.Attributes.ConstraintEncodingFunction
+ToQUBO.Attributes.AppliedPenalty
 ToQUBO.Attributes.SlackVariableTargetVariables
 ToQUBO.Attributes.SlackVariableEncodingFunction
 ToQUBO.Attributes.SlackVariableEncodingPenaltyFunction
@@ -206,6 +209,9 @@ Constraints are converted to penalty terms in QUBO. You can retrieve the penalty
 ```julia
 # Get the penalty used for a specific constraint
 rho = MOI.get(model, Attributes.ConstraintEncodingPenalty(), constraint_ref)
+
+# Equivalent reporting-oriented alias
+rho = MOI.get(model, Attributes.AppliedPenalty(), constraint_ref)
 ```
 
 ### Variable Encoding Penalties

--- a/docs/src/manual/3-results.md
+++ b/docs/src/manual/3-results.md
@@ -174,10 +174,11 @@ The metadata guarantees the original source variable order, target QUBO
 variable order, source-to-target `expansion_variables` and `expansion_terms`,
 constraint/slack ownership for generated target variables, penalty terms
 recorded by the compiler, and an `applied_penalties` section with the applied
-constraint, variable-encoding, and slack-variable penalty coefficients. This is
-enough to project a full QUBO state back to original variables. Exact auxiliary
-consistency checks and repair remain encoding-specific and are not guaranteed by
-this metadata contract.
+constraint, variable-encoding, and slack-variable penalty coefficients.
+`applied_penalties` is a convenience view of values also stored on the
+corresponding metadata records. This is enough to project a full QUBO state back
+to original variables. Exact auxiliary consistency checks and repair remain
+encoding-specific and are not guaranteed by this metadata contract.
 
 ```@docs
 ToQUBO.reformulation_metadata

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -39,6 +39,53 @@ ToQUBO.Attributes.StableQuadratization
 
 ## Variable & Constraint Encoding
 
+### Penalty Heuristic
+
+When a constraint, variable encoding, or slack-variable encoding needs a penalty
+coefficient and no explicit hint is set, ToQUBO uses the automatic heuristic
+
+```math
+\rho = s \cdot \sigma \cdot \left(\frac{\delta}{\epsilon} + \beta\right)
+```
+
+where `s` is [`ToQUBO.Attributes.PenaltyScale`](@ref), `β` is
+[`ToQUBO.Attributes.PenaltyOffset`](@ref), `σ` is `1` for minimization models
+and `-1` for maximization models, `δ` is the objective gap estimate, and `ϵ` is
+the smallest positive gap in the generated penalty function.
+
+The precedence is:
+
+1. Explicit hints such as
+   [`ToQUBO.Attributes.ConstraintEncodingPenaltyHint`](@ref) are used as-is.
+2. Constraint overrides
+   [`ToQUBO.Attributes.ConstraintPenaltyScale`](@ref) and
+   [`ToQUBO.Attributes.ConstraintPenaltyOffset`](@ref) apply to the source
+   constraint and to the slack-variable encoding penalty generated for that
+   constraint.
+3. Global [`ToQUBO.Attributes.PenaltyScale`](@ref) and
+   [`ToQUBO.Attributes.PenaltyOffset`](@ref) apply everywhere else.
+
+The defaults are `PenaltyScale() == 1.0` and `PenaltyOffset() == 1.0`, matching
+the previous heuristic. For feasibility tuning, start by sweeping
+`PenaltyScale()` while keeping explicit hints unset:
+
+```julia
+using JuMP
+using ToQUBO
+using ToQUBO: Attributes
+
+model = Model(ToQUBO.Optimizer)
+set_attribute(model, Attributes.PenaltyScale(), 2.0)
+set_attribute(model, Attributes.PenaltyOffset(), 1.0)
+
+# Override one source constraint if it needs a different automatic penalty.
+set_attribute(my_constraint, Attributes.ConstraintPenaltyScale(), 5.0)
+```
+
+Very small `ϵ` values can produce large penalties. That usually means the
+penalty function has nearly tied infeasible states, so treat the heuristic as a
+starting point and compare feasibility across several scales.
+
 ### Constraint Penalty Methods
 
 Equality constraints are encoded with
@@ -115,6 +162,10 @@ ToQUBO.Attributes.SlackVariableEncodingATol
 ToQUBO.Attributes.SlackVariableEncodingBits
 ToQUBO.Attributes.SlackVariableEncodingPenaltyHint
 ToQUBO.Attributes.SlackVariableEncodingPenalty
+ToQUBO.Attributes.PenaltyOffset
+ToQUBO.Attributes.PenaltyScale
+ToQUBO.Attributes.ConstraintPenaltyOffset
+ToQUBO.Attributes.ConstraintPenaltyScale
 ToQUBO.Attributes.QuadraticPenalty
 ToQUBO.Attributes.LinearPenalty
 ToQUBO.Attributes.DefaultConstraintEncodingMethod

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -1148,18 +1148,6 @@ function MOI.get(model::Optimizer, ::AppliedPenalty, ci::CI)
     return MOI.get(model, ConstraintEncodingPenalty(), ci)
 end
 
-function MOI.set(model::Optimizer{T}, ::AppliedPenalty, ci::CI, ρ) where {T}
-    MOI.set(model, ConstraintEncodingPenalty(), ci, convert(T, ρ))
-
-    return nothing
-end
-
-function MOI.set(model::Optimizer, ::AppliedPenalty, ci::CI, ::Nothing)
-    MOI.set(model, ConstraintEncodingPenalty(), ci, nothing)
-
-    return nothing
-end
-
 @doc raw"""
     ConstraintPenaltyOffset()
 

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -242,6 +242,77 @@ function ignore_feasible_constraints(model::Optimizer)::Bool
 end
 
 @doc raw"""
+    PenaltyOffset()
+
+Set the global offset ``\beta`` used by the automatic penalty heuristic.
+
+When no explicit penalty hint is set, ToQUBO infers penalty coefficients as
+``scale * sigma * (delta / epsilon + beta)``. The default is `1.0`, which
+preserves the original heuristic. Use [`ConstraintPenaltyOffset`](@ref) to
+override this value for a specific source constraint and its slack-variable
+encoding penalty.
+"""
+struct PenaltyOffset <: CompilerAttribute end
+
+_attribute_from_key(::Val{:penalty_offset}) = PenaltyOffset
+
+function MOI.get(model::Optimizer{T}, ::PenaltyOffset)::T where {T}
+    return get(model.compiler_settings, :penalty_offset, one(T))
+end
+
+function MOI.set(model::Optimizer{T}, ::PenaltyOffset, β::Any) where {T}
+    model.compiler_settings[:penalty_offset] = convert(T, β)
+
+    return nothing
+end
+
+function MOI.set(model::Optimizer, ::PenaltyOffset, ::Nothing)
+    delete!(model.compiler_settings, :penalty_offset)
+
+    return nothing
+end
+
+function penalty_offset(model::Optimizer)
+    return MOI.get(model, PenaltyOffset())
+end
+
+@doc raw"""
+    PenaltyScale()
+
+Set the global multiplier applied to automatically inferred penalty
+coefficients.
+
+When no explicit penalty hint is set, ToQUBO infers penalty coefficients as
+``scale * sigma * (delta / epsilon + beta)``. The default is `1.0`, which
+preserves the original heuristic. Use [`ConstraintPenaltyScale`](@ref) to
+override this value for a specific source constraint and its slack-variable
+encoding penalty.
+"""
+struct PenaltyScale <: CompilerAttribute end
+
+_attribute_from_key(::Val{:penalty_scale}) = PenaltyScale
+
+function MOI.get(model::Optimizer{T}, ::PenaltyScale)::T where {T}
+    return get(model.compiler_settings, :penalty_scale, one(T))
+end
+
+function MOI.set(model::Optimizer{T}, ::PenaltyScale, scale::Any) where {T}
+    model.compiler_settings[:penalty_scale] = convert(T, scale)
+
+    return nothing
+end
+
+function MOI.set(model::Optimizer, ::PenaltyScale, ::Nothing)
+    delete!(model.compiler_settings, :penalty_scale)
+
+    return nothing
+end
+
+function penalty_scale(model::Optimizer)
+    return MOI.get(model, PenaltyScale())
+end
+
+@doc raw"""
     ErrorInfeasibleConstraints()
 
 When set, direct scalar constraints whose encoded residual is provably
@@ -1055,6 +1126,150 @@ function MOI.set(
     delete!(model.ρ, ci)
 
     return nothing
+end
+
+@doc raw"""
+    AppliedPenalty()
+
+Return the applied source-constraint penalty coefficient after compilation.
+
+This is an alias for [`ConstraintEncodingPenalty`](@ref) intended for reporting
+code that wants a generic "applied penalty" query.
+"""
+struct AppliedPenalty <: CompilerConstraintAttribute end
+
+MOI.is_set_by_optimize(::AppliedPenalty) = true
+
+function applied_penalty(model::Optimizer, ci::CI)
+    return MOI.get(model, AppliedPenalty(), ci)
+end
+
+function MOI.get(model::Optimizer, ::AppliedPenalty, ci::CI)
+    return MOI.get(model, ConstraintEncodingPenalty(), ci)
+end
+
+function MOI.set(model::Optimizer{T}, ::AppliedPenalty, ci::CI, ρ) where {T}
+    MOI.set(model, ConstraintEncodingPenalty(), ci, convert(T, ρ))
+
+    return nothing
+end
+
+function MOI.set(model::Optimizer, ::AppliedPenalty, ci::CI, ::Nothing)
+    MOI.set(model, ConstraintEncodingPenalty(), ci, nothing)
+
+    return nothing
+end
+
+@doc raw"""
+    ConstraintPenaltyOffset()
+
+Override [`PenaltyOffset`](@ref) for a specific source constraint.
+
+The override applies to automatically inferred source-constraint penalties and
+to the slack-variable encoding penalty generated for the same source
+constraint. Explicit penalty hints still take precedence.
+"""
+struct ConstraintPenaltyOffset <: CompilerConstraintAttribute end
+
+_attribute_from_key(::Val{:constraint_penalty_offset}) = ConstraintPenaltyOffset
+
+function MOI.get(model::Optimizer{T}, ::ConstraintPenaltyOffset, ci::CI) where {T}
+    attr = :constraint_penalty_offset
+
+    if !haskey(model.constraint_settings, attr) ||
+       !haskey(model.constraint_settings[attr], ci)
+        return nothing
+    else
+        return model.constraint_settings[attr][ci]::T
+    end
+end
+
+function MOI.set(model::Optimizer{T}, ::ConstraintPenaltyOffset, ci::CI, β) where {T}
+    attr = :constraint_penalty_offset
+
+    if !haskey(model.constraint_settings, attr)
+        model.constraint_settings[attr] = Dict{CI,Any}()
+    end
+
+    model.constraint_settings[attr][ci] = convert(T, β)
+
+    return nothing
+end
+
+function MOI.set(model::Optimizer, ::ConstraintPenaltyOffset, ci::CI, ::Nothing)
+    attr = :constraint_penalty_offset
+
+    if haskey(model.constraint_settings, attr)
+        delete!(model.constraint_settings[attr], ci)
+    end
+
+    return nothing
+end
+
+function constraint_penalty_offset(model::Optimizer, ci::CI)
+    β = MOI.get(model, ConstraintPenaltyOffset(), ci)
+
+    if isnothing(β)
+        return MOI.get(model, PenaltyOffset())
+    else
+        return β
+    end
+end
+
+@doc raw"""
+    ConstraintPenaltyScale()
+
+Override [`PenaltyScale`](@ref) for a specific source constraint.
+
+The override applies to automatically inferred source-constraint penalties and
+to the slack-variable encoding penalty generated for the same source
+constraint. Explicit penalty hints still take precedence.
+"""
+struct ConstraintPenaltyScale <: CompilerConstraintAttribute end
+
+_attribute_from_key(::Val{:constraint_penalty_scale}) = ConstraintPenaltyScale
+
+function MOI.get(model::Optimizer{T}, ::ConstraintPenaltyScale, ci::CI) where {T}
+    attr = :constraint_penalty_scale
+
+    if !haskey(model.constraint_settings, attr) ||
+       !haskey(model.constraint_settings[attr], ci)
+        return nothing
+    else
+        return model.constraint_settings[attr][ci]::T
+    end
+end
+
+function MOI.set(model::Optimizer{T}, ::ConstraintPenaltyScale, ci::CI, scale) where {T}
+    attr = :constraint_penalty_scale
+
+    if !haskey(model.constraint_settings, attr)
+        model.constraint_settings[attr] = Dict{CI,Any}()
+    end
+
+    model.constraint_settings[attr][ci] = convert(T, scale)
+
+    return nothing
+end
+
+function MOI.set(model::Optimizer, ::ConstraintPenaltyScale, ci::CI, ::Nothing)
+    attr = :constraint_penalty_scale
+
+    if haskey(model.constraint_settings, attr)
+        delete!(model.constraint_settings[attr], ci)
+    end
+
+    return nothing
+end
+
+function constraint_penalty_scale(model::Optimizer, ci::CI)
+    scale = MOI.get(model, ConstraintPenaltyScale(), ci)
+
+    if isnothing(scale)
+        return MOI.get(model, PenaltyScale())
+    else
+        return scale
+    end
 end
 
 @doc raw"""

--- a/src/compiler/penalties.jl
+++ b/src/compiler/penalties.jl
@@ -3,11 +3,14 @@ function _uses_linear_equality_penalty(model::Virtual.Model, ci::CI)::Bool
            Attributes.constraint_encoding_method(model, ci) isa Attributes.LinearPenalty
 end
 
+function _inferred_penalty_factor(sign, δ, ϵ, scale, offset)
+    return scale * sign * (δ / ϵ + offset)
+end
+
 function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
     # Adjust Sign
     σ = MOI.get(model, MOI.ObjectiveSense()) === MOI.MAX_SENSE ? -1 : 1
 
-    β = one(T) # TODO: This should be made a parameter too? Yes!
     δ = PBO.maxgap(model.f)
 
     for (ci, g) in model.g
@@ -23,7 +26,13 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
             end
 
             ϵ = PBO.mingap(g)
-            ρ = σ * (δ / ϵ + β)
+            ρ = _inferred_penalty_factor(
+                σ,
+                δ,
+                ϵ,
+                Attributes.constraint_penalty_scale(model, ci),
+                Attributes.constraint_penalty_offset(model, ci),
+            )
         end
 
         MOI.set(model, Attributes.ConstraintEncodingPenalty(), ci, ρ)
@@ -34,7 +43,13 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
 
         if isnothing(θ)
             ϵ = PBO.mingap(h)
-            θ = σ * (δ / ϵ + β)
+            θ = _inferred_penalty_factor(
+                σ,
+                δ,
+                ϵ,
+                Attributes.penalty_scale(model),
+                Attributes.penalty_offset(model),
+            )
         end
 
         MOI.set(model, Attributes.VariableEncodingPenalty(), vi, θ)
@@ -45,7 +60,13 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
 
         if isnothing(η)
             ϵ = PBO.mingap(s)
-            η = σ * (δ / ϵ + β)
+            η = _inferred_penalty_factor(
+                σ,
+                δ,
+                ϵ,
+                Attributes.constraint_penalty_scale(model, ci),
+                Attributes.constraint_penalty_offset(model, ci),
+            )
         end
 
         MOI.set(model, Attributes.SlackVariableEncodingPenalty(), ci, η)

--- a/src/reformulation.jl
+++ b/src/reformulation.jl
@@ -307,6 +307,50 @@ function _constraint_encoding_entries(model::Virtual.Model)
     return entries
 end
 
+function _applied_penalty_metadata(model::Virtual.Model)
+    constraints = Dict{String,Any}[]
+
+    for (ci, ρ) in sort!(collect(model.ρ); by = pair -> _constraint_sort_key(first(pair)))
+        push!(
+            constraints,
+            Dict{String,Any}(
+                "constraint" => _constraint_ref(ci),
+                "penalty" => ρ,
+            ),
+        )
+    end
+
+    variables = Dict{String,Any}[]
+
+    for (vi, θ) in sort!(collect(model.θ); by = pair -> first(pair).value)
+        push!(
+            variables,
+            Dict{String,Any}(
+                "variable" => vi.value,
+                "penalty" => θ,
+            ),
+        )
+    end
+
+    slack_variables = Dict{String,Any}[]
+
+    for (ci, η) in sort!(collect(model.η); by = pair -> _constraint_sort_key(first(pair)))
+        push!(
+            slack_variables,
+            Dict{String,Any}(
+                "constraint" => _constraint_ref(ci),
+                "penalty" => η,
+            ),
+        )
+    end
+
+    return Dict{String,Any}(
+        "constraints" => constraints,
+        "variables" => variables,
+        "slack_variables" => slack_variables,
+    )
+end
+
 function reformulation_metadata(model::Virtual.Model)
     target_variables = _target_variable_entries(model)
 
@@ -323,6 +367,7 @@ function reformulation_metadata(model::Virtual.Model)
         "auxiliary_variables" => _auxiliary_variable_entries(target_variables),
         "slack_variables" => _slack_variable_entries(model),
         "constraint_encodings" => _constraint_encoding_entries(model),
+        "applied_penalties" => _applied_penalty_metadata(model),
         "guarantees" => Dict{String,Any}(
             "project_original_state" => true,
             "auxiliary_consistency" => "encoding-specific",

--- a/src/reformulation.jl
+++ b/src/reformulation.jl
@@ -9,6 +9,10 @@ Return JSON-compatible ToQUBO reformulation metadata. For a live
 `ToQUBO.Optimizer`, the metadata is generated from the compiled virtual model.
 For a `QUBOTools.AbstractModel` or a metadata dictionary, the metadata is read
 from `metadata["toqubo"]["reformulation"]`.
+
+The `applied_penalties` section is a convenience view. Its entries duplicate
+the applied penalty coefficients also attached to the corresponding variable,
+constraint, and slack-variable metadata records.
 """
 function reformulation_metadata end
 

--- a/test/unit/compiler/compiler.jl
+++ b/test/unit/compiler/compiler.jl
@@ -2,6 +2,7 @@ include("constraints.jl")
 include("error.jl")
 include("analysis.jl")
 include("variables.jl")
+include("penalties.jl")
 
 function test_compiler()
     @testset "□ Compiler" verbose = true begin
@@ -9,6 +10,7 @@ function test_compiler()
         test_compiler_error()
         test_compiler_analysis()
         test_compiler_variables()
+        test_compiler_penalties()
     end
 
     return nothing

--- a/test/unit/compiler/penalties.jl
+++ b/test/unit/compiler/penalties.jl
@@ -132,6 +132,12 @@ function test_compiler_penalty_scale_and_offset()
     )
     @test MOI.get(hinted_model, Attributes.ConstraintEncodingPenalty(), hinted_c) == -7.0
     @test MOI.get(hinted_model, Attributes.AppliedPenalty(), hinted_c) == -7.0
+    @test_throws MOI.SetAttributeNotAllowed MOI.set(
+        hinted_model,
+        Attributes.AppliedPenalty(),
+        hinted_c,
+        -8.0,
+    )
 
     default_variable_model, default_x = _variable_penalty_test_model()
     scaled_variable_model, scaled_x = _variable_penalty_test_model(;

--- a/test/unit/compiler/penalties.jl
+++ b/test/unit/compiler/penalties.jl
@@ -1,0 +1,184 @@
+function _constraint_penalty_test_model(;
+    scale = nothing,
+    offset = nothing,
+    constraint_scale = nothing,
+    constraint_offset = nothing,
+    hint = nothing,
+    slack_encoding = nothing,
+)
+    model = ToQUBO.Optimizer{Float64}()
+    x = [MOI.add_variable(model) for _ = 1:2]
+
+    for xi in x
+        MOI.add_constraint(model, xi, MOI.ZeroOne())
+    end
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(1.0, x[1]),
+                MOI.ScalarAffineTerm{Float64}(1.0, x[2]),
+            ],
+            0.0,
+        ),
+    )
+
+    c = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(1.0, x[1]),
+                MOI.ScalarAffineTerm{Float64}(1.0, x[2]),
+            ],
+            0.0,
+        ),
+        MOI.LessThan{Float64}(1.0),
+    )
+
+    !isnothing(scale) && MOI.set(model, Attributes.PenaltyScale(), scale)
+    !isnothing(offset) && MOI.set(model, Attributes.PenaltyOffset(), offset)
+    !isnothing(constraint_scale) &&
+        MOI.set(model, Attributes.ConstraintPenaltyScale(), c, constraint_scale)
+    !isnothing(constraint_offset) &&
+        MOI.set(model, Attributes.ConstraintPenaltyOffset(), c, constraint_offset)
+    !isnothing(hint) && MOI.set(model, Attributes.ConstraintEncodingPenaltyHint(), c, hint)
+    !isnothing(slack_encoding) &&
+        MOI.set(model, Attributes.SlackVariableEncodingMethod(), c, slack_encoding)
+
+    MOI.optimize!(model)
+
+    return model, c
+end
+
+function _variable_penalty_test_model(; scale = nothing, offset = nothing)
+    model = ToQUBO.Optimizer{Float64}()
+    x = MOI.add_variable(model)
+
+    MOI.add_constraint(model, x, MOI.Integer())
+    MOI.add_constraint(model, x, MOI.Interval{Float64}(0.0, 3.0))
+    MOI.set(model, Attributes.VariableEncodingMethod(), x, Encoding.OneHot())
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
+    )
+
+    !isnothing(scale) && MOI.set(model, Attributes.PenaltyScale(), scale)
+    !isnothing(offset) && MOI.set(model, Attributes.PenaltyOffset(), offset)
+
+    MOI.optimize!(model)
+
+    return model, x
+end
+
+function test_compiler_penalty_defaults_match_previous_heuristic()
+    default_model, default_c = _constraint_penalty_test_model()
+    explicit_model, explicit_c = _constraint_penalty_test_model(; scale = 1.0, offset = 1.0)
+
+    @test MOI.get(default_model, Attributes.ConstraintEncodingPenalty(), default_c) ==
+          MOI.get(explicit_model, Attributes.ConstraintEncodingPenalty(), explicit_c)
+    @test MOI.get(default_model, Attributes.CompiledHamiltonian()) ==
+          MOI.get(explicit_model, Attributes.CompiledHamiltonian())
+
+    return nothing
+end
+
+function test_compiler_penalty_scale_and_offset()
+    default_model, default_c = _constraint_penalty_test_model()
+    default_penalty = MOI.get(default_model, Attributes.ConstraintEncodingPenalty(), default_c)
+    base_gap_ratio = abs(default_penalty) - 1.0
+
+    scaled_model, scaled_c = _constraint_penalty_test_model(; scale = 2.0, offset = 3.0)
+    @test MOI.get(scaled_model, Attributes.ConstraintEncodingPenalty(), scaled_c) ==
+          -2.0 * (base_gap_ratio + 3.0)
+
+    override_model, override_c = _constraint_penalty_test_model(;
+        scale = 10.0,
+        offset = 10.0,
+        constraint_scale = 2.0,
+        constraint_offset = 3.0,
+    )
+    @test MOI.get(override_model, Attributes.ConstraintEncodingPenalty(), override_c) ==
+          MOI.get(scaled_model, Attributes.ConstraintEncodingPenalty(), scaled_c)
+
+    scaled_slack_model, scaled_slack_c = _constraint_penalty_test_model(;
+        scale = 2.0,
+        offset = 3.0,
+        slack_encoding = Encoding.OneHot(),
+    )
+    override_slack_model, override_slack_c = _constraint_penalty_test_model(;
+        scale = 10.0,
+        offset = 10.0,
+        constraint_scale = 2.0,
+        constraint_offset = 3.0,
+        slack_encoding = Encoding.OneHot(),
+    )
+    @test MOI.get(
+        override_slack_model,
+        Attributes.SlackVariableEncodingPenalty(),
+        override_slack_c,
+    ) == MOI.get(scaled_slack_model, Attributes.SlackVariableEncodingPenalty(), scaled_slack_c)
+
+    hinted_model, hinted_c = _constraint_penalty_test_model(;
+        scale = 10.0,
+        offset = 10.0,
+        constraint_scale = 2.0,
+        constraint_offset = 3.0,
+        hint = -7.0,
+    )
+    @test MOI.get(hinted_model, Attributes.ConstraintEncodingPenalty(), hinted_c) == -7.0
+    @test MOI.get(hinted_model, Attributes.AppliedPenalty(), hinted_c) == -7.0
+
+    default_variable_model, default_x = _variable_penalty_test_model()
+    scaled_variable_model, scaled_x = _variable_penalty_test_model(;
+        scale = 2.0,
+        offset = 3.0,
+    )
+    default_variable_penalty =
+        MOI.get(default_variable_model, Attributes.VariableEncodingPenalty(), default_x)
+    variable_gap_ratio = default_variable_penalty - 1.0
+    @test MOI.get(scaled_variable_model, Attributes.VariableEncodingPenalty(), scaled_x) ==
+          2.0 * (variable_gap_ratio + 3.0)
+
+    return nothing
+end
+
+function test_compiler_applied_penalty_metadata()
+    model, c = _constraint_penalty_test_model(;
+        scale = 2.0,
+        offset = 3.0,
+        slack_encoding = Encoding.OneHot(),
+    )
+    penalty = MOI.get(model, Attributes.AppliedPenalty(), c)
+    metadata = ToQUBO.reformulation_metadata(model)
+
+    @test metadata["applied_penalties"]["constraints"] == [
+        Dict{String,Any}(
+            "constraint" => Dict{String,Any}(
+                "function_type" => "MathOptInterface.ScalarAffineFunction{Float64}",
+                "id" => c.value,
+                "set_type" => "MathOptInterface.LessThan{Float64}",
+            ),
+            "penalty" => penalty,
+        ),
+    ]
+    @test only(metadata["constraint_encodings"])["penalty"] == penalty
+    @test only(metadata["applied_penalties"]["slack_variables"])["penalty"] ==
+          MOI.get(model, Attributes.SlackVariableEncodingPenalty(), c)
+
+    return nothing
+end
+
+function test_compiler_penalties()
+    @testset "Penalty heuristic" begin
+        test_compiler_penalty_defaults_match_previous_heuristic()
+        test_compiler_penalty_scale_and_offset()
+        test_compiler_applied_penalty_metadata()
+    end
+
+    return nothing
+end


### PR DESCRIPTION
## Summary

- Adds global `PenaltyScale()` and `PenaltyOffset()` compiler attributes for inferred penalties.
- Adds per-constraint `ConstraintPenaltyScale()` and `ConstraintPenaltyOffset()` overrides for source-constraint and slack-variable inferred penalties.
- Adds `AppliedPenalty()` as a reporting alias for applied source-constraint penalties and records an `applied_penalties` section in reformulation metadata.
- Documents the penalty formula, precedence, and tuning workflow; adds focused compiler tests for defaults, overrides, hint precedence, JuMP access, and metadata.

## Penalty Precedence

| Situation | Applied coefficient |
| --- | --- |
| Explicit source-constraint hint | `ConstraintEncodingPenaltyHint()` value, unchanged |
| Explicit variable/slack hint | `VariableEncodingPenaltyHint()` or `SlackVariableEncodingPenaltyHint()` value, unchanged |
| Source constraint without hint | `ConstraintPenaltyScale() * sigma * (delta / epsilon + ConstraintPenaltyOffset())`, falling back to global values when unset |
| Slack-variable penalty without hint | Same source-constraint override precedence as its owning constraint |
| Variable-encoding penalty without hint | `PenaltyScale() * sigma * (delta / epsilon + PenaltyOffset())` |

## Tests

- `julia --project=test -e 'pushfirst!(LOAD_PATH, pwd()); include("test/runtests.jl")'`
  - Passed: 1009 / 1009 tests.
- `julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd())'`
  - Passed: docs environment already up to date.
- `julia --project=docs docs/make.jl --skip-deploy`
  - Passed.
- `julia --project=test -e 'pushfirst!(LOAD_PATH, pwd()); using JuMP, ToQUBO; using ToQUBO: Attributes; model = Model(ToQUBO.Optimizer); @variable(model, x[1:2], Bin); @objective(model, Max, x[1] + x[2]); c = @constraint(model, x[1] + x[2] <= 1); set_attribute(model, Attributes.PenaltyScale(), 2.0); set_attribute(c, Attributes.ConstraintPenaltyOffset(), 3.0); optimize!(model); @assert get_attribute(model, Attributes.PenaltyScale()) == 2.0; @assert get_attribute(c, Attributes.ConstraintPenaltyOffset()) == 3.0; @assert get_attribute(c, Attributes.AppliedPenalty()) == get_attribute(c, Attributes.ConstraintEncodingPenalty())'`
  - Passed.

## Branch Hygiene

- Base branch: `main`
- Head branch: `fix/issue-137-penalty-heuristic`
- Source branch point: `c68cf99508d676be454e00335fea03450fcc796f` (`origin/main`)
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #137
