### PR TITLE
Add post-sampling feasibility reporting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,14 @@ QUBOTools                 = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 Random                    = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TOML                      = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
+[weakdeps]
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+
+[extensions]
+ToQUBOJuMPExt = "JuMP"
+
 [compat]
+JuMP = "1"
 MathOptInterface = "1"
 PseudoBooleanOptimization = "0.2"
 QUBOTools = "0.11, 0.12, 0.13"

--- a/docs/src/manual/3-results.md
+++ b/docs/src/manual/3-results.md
@@ -70,6 +70,65 @@ end
 !!! tip "Best Solution"
     By default (without specifying `result`), `value` returns the best solution found.
 
+## Feasibility and Constraint Violations
+
+For constrained models, inspect feasibility separately from the objective value.
+`violations` reports the source constraints violated by a sampled result after
+projecting the QUBO solution back to the source variables. `is_feasible` checks
+one result, and `feasibility_report` summarizes one or more results.
+
+```julia
+violated = ToQUBO.violations(model; result = 1, atol = 1e-6)
+ok = ToQUBO.is_feasible(model; result = 1)
+report = ToQUBO.feasibility_report(model)
+```
+
+For JuMP models, pass the `JuMP.Model` directly. For low-level MOI usage, pass
+the `ToQUBO.Optimizer`.
+
+```@example feasibility-results
+using JuMP
+using QUBODrivers
+using ToQUBO
+using ToQUBO: Attributes
+
+model = Model(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+@variable(model, x[1:2], Bin)
+@objective(model, Max, 3x[1] + 3x[2])
+capacity = @constraint(model, x[1] + x[2] <= 1)
+
+# Deliberately undersize this penalty to demonstrate infeasibility reporting.
+set_attribute(capacity, Attributes.ConstraintEncodingPenaltyHint(), -0.1)
+
+optimize!(model)
+
+violated = ToQUBO.violations(model; result = 1)
+first(violated).violation
+```
+
+The feasibility helpers use the same `result` indexing as `value` and
+`objective_value`, so sampling runs can be summarized as rates:
+
+```@example feasibility-results
+report = ToQUBO.feasibility_report(model; result = 1:result_count(model))
+report.feasible_count / report.result_count
+```
+
+Constraint violations are measured as follows:
+
+| Source constraint type | Violation measure |
+|:--|:--|
+| Variable bounds and scalar affine/quadratic `EqualTo`, `LessThan`, `GreaterThan`, `Interval` | `MOI.Utilities.distance_to_set(value, set)` |
+| `VectorOfVariables` in `SOS1` | Sum of absolute values outside the largest-magnitude entry |
+| Affine/quadratic `Indicator` | Zero when inactive; otherwise the inner scalar-set violation |
+
+Each `ConstraintViolation` includes the source constraint index, function type,
+set type, evaluated source-function value, raw residual, nonnegative violation
+magnitude, and projected values for variables referenced by that constraint.
+For encoded integer variables, the projected source values are the compiler's
+decoded values for the sampled binary state; continuous discretizations report
+the decoded grid value.
+
 ## Objective Value
 
 ### Single Solution
@@ -185,6 +244,12 @@ ToQUBO.reformulation_metadata
 ToQUBO.original_variables
 ToQUBO.auxiliary_variables
 ToQUBO.project_original_state
+ToQUBO.ConstraintViolation
+ToQUBO.FeasibilityResult
+ToQUBO.FeasibilityReport
+ToQUBO.violations
+ToQUBO.is_feasible
+ToQUBO.feasibility_report
 ToQUBO.Attributes.CompilationTime
 ToQUBO.Attributes.CompilationStatus
 ToQUBO.Attributes.SourceModel

--- a/ext/ToQUBOJuMPExt.jl
+++ b/ext/ToQUBOJuMPExt.jl
@@ -1,0 +1,18 @@
+module ToQUBOJuMPExt
+
+import JuMP
+import ToQUBO
+
+function ToQUBO.violations(model::JuMP.Model; kwargs...)
+    return ToQUBO.violations(JuMP.unsafe_backend(model); kwargs...)
+end
+
+function ToQUBO.is_feasible(model::JuMP.Model; kwargs...)
+    return ToQUBO.is_feasible(JuMP.unsafe_backend(model); kwargs...)
+end
+
+function ToQUBO.feasibility_report(model::JuMP.Model; kwargs...)
+    return ToQUBO.feasibility_report(JuMP.unsafe_backend(model); kwargs...)
+end
+
+end

--- a/src/ToQUBO.jl
+++ b/src/ToQUBO.jl
@@ -1,5 +1,12 @@
 module ToQUBO
 
+export ConstraintViolation,
+    FeasibilityResult,
+    FeasibilityReport,
+    violations,
+    is_feasible,
+    feasibility_report
+
 using MathOptInterface
 const MOI = MathOptInterface
 
@@ -78,5 +85,8 @@ include("compiler/compiler.jl")
 
 # Reformulation metadata
 include("reformulation.jl")
+
+# Post-sampling analysis
+include("analysis/feasibility.jl")
 
 end # module

--- a/src/analysis/feasibility.jl
+++ b/src/analysis/feasibility.jl
@@ -1,0 +1,414 @@
+@doc raw"""
+    ConstraintViolation
+
+A measured source-constraint residual for one sampled result.
+
+`constraint` is the source `MOI.ConstraintIndex`, `function_type` and
+`set_type` identify the constraint family, `value` is the original constraint
+function evaluated on the projected source-variable values, `raw_residual` is
+the set-specific residual before applying tolerances, `violation` is the
+nonnegative distance to the set, and `variable_values` contains the projected
+values for variables referenced by the constraint function.
+"""
+struct ConstraintViolation
+    constraint::MOI.ConstraintIndex
+    function_type::DataType
+    set_type::DataType
+    value::Any
+    raw_residual::Any
+    violation::Float64
+    variable_values::Dict{VI,Any}
+end
+
+@doc raw"""
+    FeasibilityResult
+
+Summary of source-constraint feasibility for one sampled result.
+"""
+struct FeasibilityResult
+    result::Int
+    feasible::Bool
+    violation_count::Int
+    max_violation::Float64
+    total_violation::Float64
+    by_constraint_type::Dict{String,Any}
+end
+
+@doc raw"""
+    FeasibilityReport
+
+Per-result source-constraint feasibility summary returned by
+[`feasibility_report`](@ref).
+"""
+struct FeasibilityReport
+    result_count::Int
+    feasible_count::Int
+    max_violation::Float64
+    total_violation::Float64
+    results::Vector{FeasibilityResult}
+end
+
+@doc raw"""
+    violations(model; result::Int = 1, atol::Real = 0.0)
+
+Return source constraints violated by sampled result `result`.
+
+The sampled QUBO result is projected back to the original source variables
+using the compiler's virtual mapping, then each source constraint is evaluated
+and measured against its MOI set. Scalar sets use
+`MOI.Utilities.distance_to_set`. Indicator constraints are considered violated
+only when their activation value triggers the inner set; SOS1 constraints use
+the distance to the nearest one-nonzero vector under the ``\ell_1`` projection
+convention.
+"""
+function violations(model; result::Integer = 1, atol::Real = 0.0)
+    return violations(_toqubo_model(model); result, atol)
+end
+
+function violations(model::Virtual.Model; result::Integer = 1, atol::Real = 0.0)
+    return filter(
+        measurement -> measurement.violation > Float64(atol),
+        _constraint_measurements(model, Int(result)),
+    )
+end
+
+@doc raw"""
+    is_feasible(model; result::Int = 1, atol::Real = 1e-6)
+
+Return `true` if every source constraint is satisfied by sampled result
+`result` within absolute tolerance `atol`.
+"""
+function is_feasible(model; result::Integer = 1, atol::Real = 1e-6)
+    return isempty(violations(model; result, atol))
+end
+
+@doc raw"""
+    feasibility_report(model; result = nothing, atol::Real = 1e-6)
+
+Return a [`FeasibilityReport`](@ref) summarizing source-constraint feasibility.
+
+If `result` is `nothing`, all available solver results are summarized. Pass an
+integer or iterable of result indices to summarize selected samples.
+"""
+function feasibility_report(model; result = nothing, atol::Real = 1e-6)
+    return feasibility_report(_toqubo_model(model); result, atol)
+end
+
+function feasibility_report(model::Virtual.Model; result = nothing, atol::Real = 1e-6)
+    results = [
+        _feasibility_result(model, i, Float64(atol)) for i in _result_indices(model, result)
+    ]
+
+    max_violation = isempty(results) ? 0.0 : maximum(r.max_violation for r in results)
+    total_violation = sum(r.total_violation for r in results; init = 0.0)
+
+    return FeasibilityReport(
+        length(results),
+        count(r -> r.feasible, results),
+        max_violation,
+        total_violation,
+        results,
+    )
+end
+
+function _toqubo_model(model::Virtual.Model)
+    return model
+end
+
+function _toqubo_model(model)
+    backend = _unsafe_backend(model)
+
+    if !isnothing(backend) && backend !== model
+        return _toqubo_model(backend)
+    end
+
+    error(
+        "Feasibility analysis requires a ToQUBO.Optimizer result. " *
+        "For JuMP models, load JuMP and pass the JuMP.Model directly.",
+    )
+end
+
+function _unsafe_backend(model)
+    mod = parentmodule(typeof(model))
+
+    if !isdefined(mod, :unsafe_backend)
+        return nothing
+    end
+
+    unsafe_backend = getfield(mod, :unsafe_backend)
+
+    if !(unsafe_backend isa Function)
+        return nothing
+    end
+
+    try
+        return unsafe_backend(model)
+    catch
+        return nothing
+    end
+end
+
+function _result_count(model::Virtual.Model)
+    return MOI.get(model, MOI.ResultCount())
+end
+
+function _check_result_index(model::Virtual.Model, result::Int)
+    result >= 1 || error("Result index must be positive; got $result")
+
+    n = _result_count(model)
+
+    if n == 0
+        error("No primal results are available; optimize with a QUBO solver first")
+    elseif result > n
+        error("Result index $result is unavailable; model has $n result(s)")
+    end
+
+    return nothing
+end
+
+function _result_indices(model::Virtual.Model, ::Nothing)
+    n = _result_count(model)
+
+    n > 0 || error("No primal results are available; optimize with a QUBO solver first")
+
+    return collect(1:n)
+end
+
+function _result_indices(model::Virtual.Model, result::Integer)
+    index = Int(result)
+
+    _check_result_index(model, index)
+
+    return [index]
+end
+
+function _result_indices(model::Virtual.Model, results)
+    indices = Int.(collect(results))
+
+    for index in indices
+        _check_result_index(model, index)
+    end
+
+    return indices
+end
+
+function _projected_result_values(model::Virtual.Model, result::Int)
+    _check_result_index(model, result)
+
+    attr = MOI.VariablePrimal(result)
+
+    return Dict{VI,Any}(
+        vi => MOI.get(model, attr, vi) for vi in MOI.get(model.source_model, MOI.ListOfVariableIndices())
+    )
+end
+
+function _constraint_measurements(model::Virtual.Model, result::Int)
+    values = _projected_result_values(model, result)
+    measurements = ConstraintViolation[]
+
+    for (F, S) in MOI.get(model.source_model, MOI.ListOfConstraintTypesPresent())
+        for ci in MOI.get(model.source_model, MOI.ListOfConstraintIndices{F,S}())
+            f = MOI.get(model.source_model, MOI.ConstraintFunction(), ci)
+            s = MOI.get(model.source_model, MOI.ConstraintSet(), ci)
+
+            push!(measurements, _constraint_violation(model.source_model, ci, f, s, values))
+        end
+    end
+
+    sort!(
+        measurements;
+        by = measurement -> (
+            measurement.constraint.value,
+            string(measurement.function_type),
+            string(measurement.set_type),
+        ),
+    )
+
+    return measurements
+end
+
+function _feasibility_result(model::Virtual.Model, result::Int, atol::Float64)
+    measurements = _constraint_measurements(model, result)
+    max_violation = isempty(measurements) ? 0.0 : maximum(m.violation for m in measurements)
+    total_violation = sum(m.violation for m in measurements; init = 0.0)
+    violation_count = count(m -> m.violation > atol, measurements)
+
+    return FeasibilityResult(
+        result,
+        max_violation <= atol,
+        violation_count,
+        max_violation,
+        total_violation,
+        _summarize_by_constraint_type(measurements, atol),
+    )
+end
+
+function _constraint_type_label(measurement::ConstraintViolation)
+    return "$(measurement.function_type) in $(measurement.set_type)"
+end
+
+function _summarize_by_constraint_type(measurements, atol::Float64)
+    summary = Dict{String,Any}()
+
+    for measurement in measurements
+        key = _constraint_type_label(measurement)
+        previous = get(
+            summary,
+            key,
+            (count = 0, violation_count = 0, max_violation = 0.0, total_violation = 0.0),
+        )
+        violation_count = previous.violation_count + (measurement.violation > atol ? 1 : 0)
+
+        summary[key] = (
+            count = previous.count + 1,
+            violation_count = violation_count,
+            max_violation = max(previous.max_violation, measurement.violation),
+            total_violation = previous.total_violation + measurement.violation,
+        )
+    end
+
+    return summary
+end
+
+function _constraint_violation(
+    source_model::MOI.ModelLike,
+    ci::MOI.ConstraintIndex{F,S},
+    f::F,
+    set::S,
+    values::AbstractDict{VI},
+) where {F,S}
+    value = MOIU.eval_variables(source_model, f) do vi
+        return _projected_value(values, vi)
+    end
+
+    violation, raw_residual = _violation_and_residual(value, set)
+
+    return ConstraintViolation(
+        ci,
+        F,
+        S,
+        value,
+        raw_residual,
+        Float64(violation),
+        _referenced_variable_values(f, values),
+    )
+end
+
+function _projected_value(values::AbstractDict{VI}, vi::VI)
+    haskey(values, vi) || error("Projected source state is missing variable $vi")
+
+    return values[vi]
+end
+
+_set_value(value, ::MOI.LessThan{T}) where {T} = convert(T, value)
+_set_value(value, ::MOI.GreaterThan{T}) where {T} = convert(T, value)
+_set_value(value, ::MOI.EqualTo{T}) where {T} = convert(T, value)
+_set_value(value, ::MOI.Interval{T}) where {T} = convert(T, value)
+_set_value(value, ::MOI.Semicontinuous{T}) where {T} = convert(T, value)
+_set_value(value, ::MOI.Semiinteger{T}) where {T} = convert(T, value)
+_set_value(value, set) = value
+
+function _distance_to_set(value, set)
+    return MOIU.distance_to_set(_set_value(value, set), set)
+end
+
+function _violation_and_residual(value, set)
+    return _distance_to_set(value, set), _raw_residual(value, set)
+end
+
+_raw_residual(value, set) = _distance_to_set(value, set)
+_raw_residual(value, set::MOI.LessThan) = _set_value(value, set) - set.upper
+_raw_residual(value, set::MOI.GreaterThan) = set.lower - _set_value(value, set)
+_raw_residual(value, set::MOI.EqualTo) = _set_value(value, set) - set.value
+
+function _raw_residual(value, set::MOI.Interval)
+    x = _set_value(value, set)
+
+    if x < set.lower
+        return set.lower - x
+    elseif x > set.upper
+        return x - set.upper
+    else
+        return zero(x)
+    end
+end
+
+function _violation_and_residual(value::AbstractVector, set::MOI.SOS1)
+    magnitudes = abs.(value)
+
+    if isempty(magnitudes)
+        return 0.0, 0.0
+    end
+
+    residual = sum(magnitudes; init = zero(eltype(magnitudes))) - maximum(magnitudes)
+
+    return residual, residual
+end
+
+function _violation_and_residual(value::AbstractVector, set::MOI.Indicator{A,S}) where {A,S}
+    active = if A === MOI.ACTIVATE_ON_ONE
+        value[1] >= 0.5
+    elseif A === MOI.ACTIVATE_ON_ZERO
+        value[1] < 0.5
+    else
+        error("Unsupported indicator activation type $A")
+    end
+
+    if !active
+        return 0.0, 0.0
+    end
+
+    inner_value = length(value) == 2 ? value[2] : value[2:end]
+
+    return _violation_and_residual(inner_value, set.set)
+end
+
+_function_variables(vi::VI) = VI[vi]
+
+function _function_variables(f::MOI.ScalarAffineFunction)
+    return _sort_variables([term.variable for term in f.terms])
+end
+
+function _function_variables(f::MOI.ScalarQuadraticFunction)
+    variables = VI[]
+
+    append!(variables, [term.variable for term in f.affine_terms])
+
+    for term in f.quadratic_terms
+        push!(variables, term.variable_1)
+        push!(variables, term.variable_2)
+    end
+
+    return _sort_variables(variables)
+end
+
+function _function_variables(f::MOI.VectorOfVariables)
+    return _sort_variables(f.variables)
+end
+
+function _function_variables(f::MOI.VectorAffineFunction)
+    return _sort_variables([term.scalar_term.variable for term in f.terms])
+end
+
+function _function_variables(f::MOI.VectorQuadraticFunction)
+    variables = VI[]
+
+    append!(variables, [term.scalar_term.variable for term in f.affine_terms])
+
+    for term in f.quadratic_terms
+        push!(variables, term.scalar_term.variable_1)
+        push!(variables, term.scalar_term.variable_2)
+    end
+
+    return _sort_variables(variables)
+end
+
+_function_variables(::MOI.AbstractFunction) = VI[]
+
+function _sort_variables(variables)
+    return sort!(collect(Set(variables)); by = vi -> vi.value)
+end
+
+function _referenced_variable_values(f::MOI.AbstractFunction, values::AbstractDict{VI})
+    return Dict{VI,Any}(vi => _projected_value(values, vi) for vi in _function_variables(f))
+end

--- a/src/analysis/feasibility.jl
+++ b/src/analysis/feasibility.jl
@@ -20,6 +20,11 @@ struct ConstraintViolation
     variable_values::Dict{VI,Any}
 end
 
+const ConstraintTypeSummary = NamedTuple{
+    (:count, :violation_count, :max_violation, :total_violation),
+    Tuple{Int,Int,Float64,Float64},
+}
+
 @doc raw"""
     FeasibilityResult
 
@@ -31,7 +36,7 @@ struct FeasibilityResult
     violation_count::Int
     max_violation::Float64
     total_violation::Float64
-    by_constraint_type::Dict{String,Any}
+    by_constraint_type::Dict{String,ConstraintTypeSummary}
 end
 
 @doc raw"""
@@ -49,7 +54,7 @@ struct FeasibilityReport
 end
 
 @doc raw"""
-    violations(model; result::Int = 1, atol::Real = 0.0)
+    violations(model; result::Int = 1, atol::Real = 1e-6)
 
 Return source constraints violated by sampled result `result`.
 
@@ -61,11 +66,11 @@ only when their activation value triggers the inner set; SOS1 constraints use
 the distance to the nearest one-nonzero vector under the ``\ell_1`` projection
 convention.
 """
-function violations(model; result::Integer = 1, atol::Real = 0.0)
+function violations(model; result::Integer = 1, atol::Real = 1e-6)
     return violations(_toqubo_model(model); result, atol)
 end
 
-function violations(model::Virtual.Model; result::Integer = 1, atol::Real = 0.0)
+function violations(model::Virtual.Model; result::Integer = 1, atol::Real = 1e-6)
     return filter(
         measurement -> measurement.violation > Float64(atol),
         _constraint_measurements(model, Int(result)),
@@ -141,11 +146,11 @@ function _unsafe_backend(model)
         return nothing
     end
 
-    try
-        return unsafe_backend(model)
-    catch
+    if !hasmethod(unsafe_backend, Tuple{typeof(model)})
         return nothing
     end
+
+    return unsafe_backend(model)
 end
 
 function _result_count(model::Virtual.Model)
@@ -248,14 +253,14 @@ function _constraint_type_label(measurement::ConstraintViolation)
 end
 
 function _summarize_by_constraint_type(measurements, atol::Float64)
-    summary = Dict{String,Any}()
+    summary = Dict{String,ConstraintTypeSummary}()
 
     for measurement in measurements
         key = _constraint_type_label(measurement)
         previous = get(
             summary,
             key,
-            (count = 0, violation_count = 0, max_violation = 0.0, total_violation = 0.0),
+            _empty_constraint_type_summary(),
         )
         violation_count = previous.violation_count + (measurement.violation > atol ? 1 : 0)
 
@@ -268,6 +273,10 @@ function _summarize_by_constraint_type(measurements, atol::Float64)
     end
 
     return summary
+end
+
+function _empty_constraint_type_summary()::ConstraintTypeSummary
+    return (count = 0, violation_count = 0, max_violation = 0.0, total_violation = 0.0)
 end
 
 function _constraint_violation(

--- a/test/unit/feasibility.jl
+++ b/test/unit/feasibility.jl
@@ -1,3 +1,13 @@
+module FeasibilityBackendProbe
+
+struct Model end
+
+function unsafe_backend(::Model)
+    error("backend failed")
+end
+
+end
+
 function _measure_constraint(model, ci, values)
     f = MOI.get(model.source_model, MOI.ConstraintFunction(), ci)
     s = MOI.get(model.source_model, MOI.ConstraintSet(), ci)
@@ -172,11 +182,39 @@ function test_feasibility_public_api()
     @test any(v -> v.violation ≈ 1.0, result_violations)
 
     report = ToQUBO.feasibility_report(model; result = 1:min(result_count(model), 4))
+    all_report = ToQUBO.feasibility_report(model)
 
     @test report.result_count == min(result_count(model), 4)
     @test report.feasible_count < report.result_count
     @test report.max_violation >= 1.0
     @test !isempty(first(report.results).by_constraint_type)
+    @test all_report.result_count == result_count(model)
+    @test all_report.feasible_count <= all_report.result_count
+    @test first(values(first(report.results).by_constraint_type)) isa ToQUBO.ConstraintTypeSummary
+
+    return nothing
+end
+
+function test_feasibility_error_paths()
+    model = Model(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+    @variable(model, x, Bin)
+    @objective(model, Min, x)
+
+    @test_throws ErrorException ToQUBO.feasibility_report(model)
+
+    optimize!(model)
+
+    @test_throws ErrorException ToQUBO.violations(model; result = 0)
+    @test_throws ErrorException ToQUBO.violations(model; result = result_count(model) + 1)
+    @test_throws ErrorException ToQUBO.violations(nothing)
+
+    try
+        ToQUBO.violations(FeasibilityBackendProbe.Model())
+        @test false
+    catch err
+        @test occursin("backend failed", sprint(showerror, err))
+    end
 
     return nothing
 end
@@ -186,6 +224,7 @@ function test_feasibility()
         test_feasibility_scalar_measurements()
         test_feasibility_vector_measurements()
         test_feasibility_public_api()
+        test_feasibility_error_paths()
     end
 
     return nothing

--- a/test/unit/feasibility.jl
+++ b/test/unit/feasibility.jl
@@ -1,0 +1,192 @@
+function _measure_constraint(model, ci, values)
+    f = MOI.get(model.source_model, MOI.ConstraintFunction(), ci)
+    s = MOI.get(model.source_model, MOI.ConstraintSet(), ci)
+
+    return ToQUBO._constraint_violation(model.source_model, ci, f, s, values)
+end
+
+function _measure_function(model, f, s, values)
+    ci = MOI.ConstraintIndex{typeof(f),typeof(s)}(0)
+
+    return ToQUBO._constraint_violation(model.source_model, ci, f, s, values)
+end
+
+function test_feasibility_scalar_measurements()
+    model = ToQUBO.Optimizer{Float64}()
+    x_zero_one = MOI.add_variable(model)
+    x_integer = MOI.add_variable(model)
+    x_interval = MOI.add_variable(model)
+    x_upper = MOI.add_variable(model)
+    z_lower = MOI.add_variable(model)
+    x = MOI.add_variable(model)
+    y = MOI.add_variable(model)
+    z = MOI.add_variable(model)
+
+    values = Dict{VI,Any}(
+        x_zero_one => 1.25,
+        x_integer => 1.25,
+        x_interval => 1.25,
+        x_upper => 1.25,
+        z_lower => 0.0,
+        x => 1.25,
+        y => 1.0,
+        z => 0.0,
+    )
+
+    c_zero_one = MOI.add_constraint(model, x_zero_one, MOI.ZeroOne())
+    c_integer = MOI.add_constraint(model, x_integer, MOI.Integer())
+    c_interval_variable =
+        MOI.add_constraint(model, x_interval, MOI.Interval{Float64}(0.0, 1.0))
+    c_upper_variable = MOI.add_constraint(model, x_upper, MOI.LessThan{Float64}(1.0))
+    c_lower_variable = MOI.add_constraint(model, z_lower, MOI.GreaterThan{Float64}(1.0))
+
+    f_affine = MOI.ScalarAffineFunction{Float64}(
+        [
+            MOI.ScalarAffineTerm(1.0, x),
+            MOI.ScalarAffineTerm(1.0, y),
+        ],
+        0.0,
+    )
+    c_affine_eq = MOI.add_constraint(model, f_affine, MOI.EqualTo{Float64}(3.0))
+    c_affine_lt = MOI.add_constraint(model, f_affine, MOI.LessThan{Float64}(2.0))
+    c_affine_gt = MOI.add_constraint(model, f_affine, MOI.GreaterThan{Float64}(3.0))
+    affine_interval_set = MOI.Interval{Float64}(0.0, 2.0)
+
+    f_quadratic = MOI.ScalarQuadraticFunction{Float64}(
+        [MOI.ScalarQuadraticTerm(1.0, x, y)],
+        [MOI.ScalarAffineTerm(1.0, z)],
+        0.0,
+    )
+    c_quadratic_eq = MOI.add_constraint(model, f_quadratic, MOI.EqualTo{Float64}(1.0))
+    c_quadratic_lt = MOI.add_constraint(model, f_quadratic, MOI.LessThan{Float64}(1.0))
+    c_quadratic_gt = MOI.add_constraint(model, f_quadratic, MOI.GreaterThan{Float64}(2.0))
+    quadratic_interval_set = MOI.Interval{Float64}(2.0, 3.0)
+
+    @test _measure_constraint(model, c_zero_one, values).violation ≈ 0.25
+    @test _measure_constraint(model, c_integer, values).violation ≈ 0.25
+    @test _measure_constraint(model, c_interval_variable, values).violation ≈ 0.25
+    @test _measure_constraint(model, c_upper_variable, values).raw_residual ≈ 0.25
+    @test _measure_constraint(model, c_lower_variable, values).violation ≈ 1.0
+
+    affine_eq = _measure_constraint(model, c_affine_eq, values)
+    @test affine_eq.value ≈ 2.25
+    @test affine_eq.raw_residual ≈ -0.75
+    @test affine_eq.violation ≈ 0.75
+
+    @test _measure_constraint(model, c_affine_lt, values).violation ≈ 0.25
+    @test _measure_constraint(model, c_affine_gt, values).violation ≈ 0.75
+    @test _measure_function(model, f_affine, affine_interval_set, values).violation ≈ 0.25
+
+    @test _measure_constraint(model, c_quadratic_eq, values).violation ≈ 0.25
+    @test _measure_constraint(model, c_quadratic_lt, values).violation ≈ 0.25
+    @test _measure_constraint(model, c_quadratic_gt, values).violation ≈ 0.75
+    @test _measure_function(model, f_quadratic, quadratic_interval_set, values).violation ≈ 0.75
+
+    return nothing
+end
+
+function test_feasibility_vector_measurements()
+    model = ToQUBO.Optimizer{Float64}()
+    a = MOI.add_variable(model)
+    x = MOI.add_variable(model)
+    y = MOI.add_variable(model)
+
+    values = Dict{VI,Any}(a => 1.0, x => 1.0, y => 1.0)
+    inactive_values = Dict{VI,Any}(a => 0.0, x => 1.0, y => 1.0)
+
+    c_sos = MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables([x, y]),
+        MOI.SOS1{Float64}([1.0, 2.0]),
+    )
+
+    f_indicator = MOI.VectorAffineFunction{Float64}(
+        [
+            MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, a)),
+            MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x)),
+            MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, y)),
+        ],
+        [0.0, 0.0],
+    )
+    c_indicator_eq = MOI.add_constraint(
+        model,
+        f_indicator,
+        MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.EqualTo{Float64}(1.0)),
+    )
+    c_indicator_lt = MOI.add_constraint(
+        model,
+        f_indicator,
+        MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan{Float64}(1.0)),
+    )
+    c_indicator_gt = MOI.add_constraint(
+        model,
+        f_indicator,
+        MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.GreaterThan{Float64}(3.0)),
+    )
+    c_indicator_interval = MOI.add_constraint(
+        model,
+        f_indicator,
+        MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.Interval{Float64}(3.0, 4.0)),
+    )
+
+    f_quadratic_indicator = MOI.VectorQuadraticFunction{Float64}(
+        [MOI.VectorQuadraticTerm(2, MOI.ScalarQuadraticTerm(1.0, x, y))],
+        [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, a))],
+        [0.0, 0.0],
+    )
+    c_quadratic_indicator = MOI.add_constraint(
+        model,
+        f_quadratic_indicator,
+        MOI.Indicator{MOI.ACTIVATE_ON_ZERO}(MOI.LessThan{Float64}(0.0)),
+    )
+
+    sos = _measure_constraint(model, c_sos, values)
+    @test sos.value ≈ [1.0, 1.0]
+    @test sos.violation ≈ 1.0
+
+    @test _measure_constraint(model, c_indicator_eq, values).violation ≈ 1.0
+    @test _measure_constraint(model, c_indicator_lt, values).violation ≈ 1.0
+    @test _measure_constraint(model, c_indicator_gt, values).violation ≈ 1.0
+    @test _measure_constraint(model, c_indicator_interval, values).violation ≈ 1.0
+    @test _measure_constraint(model, c_indicator_lt, inactive_values).violation ≈ 0.0
+    @test _measure_constraint(model, c_quadratic_indicator, inactive_values).violation ≈ 1.0
+
+    return nothing
+end
+
+function test_feasibility_public_api()
+    model = Model(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+    @variable(model, x[1:2], Bin)
+    @objective(model, Max, 3x[1] + 3x[2])
+    c = @constraint(model, x[1] + x[2] <= 1)
+
+    set_attribute(c, Attributes.ConstraintEncodingPenaltyHint(), -0.1)
+
+    optimize!(model)
+
+    result_violations = ToQUBO.violations(model; result = 1)
+
+    @test !isempty(result_violations)
+    @test !ToQUBO.is_feasible(model; result = 1)
+    @test any(v -> v.violation ≈ 1.0, result_violations)
+
+    report = ToQUBO.feasibility_report(model; result = 1:min(result_count(model), 4))
+
+    @test report.result_count == min(result_count(model), 4)
+    @test report.feasible_count < report.result_count
+    @test report.max_violation >= 1.0
+    @test !isempty(first(report.results).by_constraint_type)
+
+    return nothing
+end
+
+function test_feasibility()
+    @testset "→ Feasibility Analysis" verbose = true begin
+        test_feasibility_scalar_measurements()
+        test_feasibility_vector_measurements()
+        test_feasibility_public_api()
+    end
+
+    return nothing
+end

--- a/test/unit/unit.jl
+++ b/test/unit/unit.jl
@@ -7,6 +7,7 @@ include("model/model.jl")
 include("wrapper/wrapper.jl")
 include("attributes/attributes.jl")
 include("reformulation.jl")
+include("feasibility.jl")
 
 function test_unit()
     @testset "⊚ Unit Tests" verbose = true begin
@@ -19,6 +20,7 @@ function test_unit()
         test_wrapper()
         test_attributes()
         test_reformulation_metadata()
+        test_feasibility()
     end
 
     return nothing


### PR DESCRIPTION
Summary
- Add exported post-sampling feasibility APIs: `violations`, `is_feasible`, `feasibility_report`, `ConstraintViolation`, `FeasibilityResult`, and `FeasibilityReport`.
- Evaluate source constraints on projected sampled results, using `MOI.Utilities.distance_to_set` for scalar sets and explicit conventions for SOS1 and indicator constraints.
- Add JuMP model support through a weak extension plus a dependency-free backend fallback, and document the workflow in the results manual.
- Add unit coverage for scalar, SOS1, indicator, multi-result, and low-penalty infeasible-sample reporting.

Tests
- `julia --project=test -e 'pushfirst!(LOAD_PATH, "."); using Test; using JuMP; const MOI = JuMP.MOI; const VI = MOI.VariableIndex; using QUBODrivers; using ToQUBO; using ToQUBO: Attributes, Encoding; include("test/unit/feasibility.jl"); test_feasibility()'` passed.
- `julia --project=test -e 'pushfirst!(LOAD_PATH, "."); include("test/runtests.jl")'` passed: 1045/1045.
- `julia --project=docs docs/make.jl --skip-deploy` passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` passed: 1045/1045.

Notes
- The external QOBLib market-split checkpoint was not run locally because that dataset/harness is not part of this repository.

Branch Hygiene
- Base branch: `main`
- Source branch: `fix/issue-138-feasibility-report`
- Source branch point: `8bfc5e2231d00c7cca98198113f90d8a1fb9dbc9` (`origin/main`)
- Stacked status: not stacked; branch was created from current `origin/main`
- Prerequisite PRs: none

Refs #138
