### PR TITLE
Attribute QOBLib Birkhoff coefficient gap

### DIFF
--- a/benchmarks/qoblib/README.md
+++ b/benchmarks/qoblib/README.md
@@ -43,7 +43,8 @@ The pilot follows QOBLIB's integer-linear Birkhoff formulation:
 - enforce activation with `lambda_i <= scale * z_i`;
 - minimize `sum(z_i)`.
 
-The known incumbent is evaluated on the source model only. This pilot does not
-claim that QOBLIB's canonical QUBO artifact and ToQUBO's generated QUBO use the
-same encoding or penalty scaling. The coefficient-range delta found by the
-pilot is tracked in <https://github.com/JuliaQUBO/ToQUBO.jl/issues/148>.
+The known incumbent is evaluated on the source model only. The native ToQUBO
+upper-triangular coefficient range is reported alongside the QOBLIB-style
+symmetrized convention used by QOBLIB's generated QS writer. The Birkhoff pilot
+attributes the native maximum-coefficient delta to that off-diagonal reporting
+convention, not to a penalty-scaling change.

--- a/benchmarks/qoblib/birkhoff_pilot.jl
+++ b/benchmarks/qoblib/birkhoff_pilot.jl
@@ -60,14 +60,26 @@ const QOBLIB_CONVERTER_EVIDENCE = Dict{String,Any}(
     "canonical_artifact_available_at_commit" => false,
     "canonical_artifact_note" =>
         "The pinned QOBLIB tree contains 03-birkhoff/models/integer_linear/metrics_qs_files.csv but no stored bhS-3-001.qs or bhS-3-001.qs.xz artifact, so this commit exposes the canonical coefficient range as a metrics-table row.",
+    "manual_verification" => true,
     "converter_path" => "misc/convert_lp2qubo.py",
+    "converter_line_refs" => [
+        "misc/convert_lp2qubo.py:60-65",
+        "misc/convert_lp2qubo.py:82-89",
+    ],
     "converter_convention" =>
         "QOBLIB converts the LP with Qiskit QuadraticProgramToQubo, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.",
+    "metrics_line_ref" => "03-birkhoff/models/integer_linear/metrics_qs_files.csv:42",
 )
 
 const SOURCE_LP_COMPARISON = Dict{String,Any}(
     "lp_artifact" =>
         "03-birkhoff/models/integer_linear/lp_files/bhS-03/bhS-03-001.lp.xz",
+    "manual_verification" => true,
+    "lp_line_refs" => [
+        "decompressed LP lines 15-21",
+        "decompressed LP lines 22-39",
+        "decompressed LP lines 40-64",
+    ],
     "matches_qoblib_lp_after_column_renaming" => true,
     "column_renaming" => [
         "lambda[1:4] match LP x#1:x#4",
@@ -220,6 +232,7 @@ function _qubo_terms(target::MOI.ModelLike)
 end
 
 function _qoblib_symmetric_coefficient(key::Tuple{Int,Int}, coefficient::Float64)
+    # ToQUBO stores each full off-diagonal cross-term on one triangle.
     return first(key) == last(key) ? coefficient : coefficient / 2
 end
 
@@ -471,13 +484,17 @@ function _coefficient_attribution(target, metadata::AbstractDict, permutations)
         _annotate_term_records(target["native_max_coeff_terms"], metadata, permutations)
     qoblib_max_terms =
         _annotate_term_records(target["qoblib_symmetric_max_coeff_terms"], metadata, permutations)
+    constraint_penalties = sort!(
+        unique(Float64(entry["penalty"]) for entry in metadata["applied_penalties"]["constraints"]),
+    )
 
     return Dict{String,Any}(
         "upstream_evidence" => copy(QOBLIB_CONVERTER_EVIDENCE),
         "source_lp_comparison" => copy(SOURCE_LP_COMPARISON),
         "native_max_terms" => native_max_terms,
         "qoblib_symmetric_max_terms" => qoblib_max_terms,
-        "penalty" => 7.0,
+        "constraint_penalties" => constraint_penalties,
+        "penalty" => only(constraint_penalties),
         "ownership_decision" => "documentation-only",
         "conclusion" =>
             "The max-coefficient delta is a coefficient-reporting convention difference. ToQUBO's native upper-triangular terms keep full off-diagonal cross-term weights, while the QOBLIB writer symmetrizes Q and reports half of each off-diagonal cross term. Under the QOBLIB symmetrized convention, ToQUBO matches the canonical QUBO min/max coefficient row.",
@@ -662,6 +679,10 @@ function write_markdown_report(io::IO, report::AbstractDict)
     )
     write(
         io,
+        "- Upstream verification: manually checked QOBLIB commit `$(provenance["qoblib_commit"])`; converter refs $(join(upstream["converter_line_refs"], ", ")); metrics ref $(upstream["metrics_line_ref"]); LP refs $(join(source_lp["lp_line_refs"], ", ")).\n",
+    )
+    write(
+        io,
         "- Source LP comparison: `$(source_lp["lp_artifact"])` matches the pilot model after permutation-column renaming; $(join(source_lp["column_renaming"], "; ")).\n",
     )
     write(
@@ -670,7 +691,7 @@ function write_markdown_report(io::IO, report::AbstractDict)
     )
     write(
         io,
-        "- Applied penalty: $(_fmt(attribution["penalty"])) for every source constraint, matching Qiskit's automatic `sum(abs(objective)) + 1` scale for `min sum(z)`.\n",
+        "- Distinct applied constraint penalties from ToQUBO metadata: $(join(_fmt.(attribution["constraint_penalties"]), ", ")); this matches Qiskit's automatic `sum(abs(objective)) + 1` scale for `min sum(z)`.\n",
     )
 
     write(io, "- ToQUBO native maximum coefficient terms:\n")

--- a/benchmarks/qoblib/birkhoff_pilot.jl
+++ b/benchmarks/qoblib/birkhoff_pilot.jl
@@ -56,6 +56,35 @@ const QOBLIB_QUBO_METRICS = Dict{String,Any}(
     "max_coeff" => 7000001.0,
 )
 
+const QOBLIB_CONVERTER_EVIDENCE = Dict{String,Any}(
+    "canonical_artifact_available_at_commit" => false,
+    "canonical_artifact_note" =>
+        "The pinned QOBLIB tree contains 03-birkhoff/models/integer_linear/metrics_qs_files.csv but no stored bhS-3-001.qs or bhS-3-001.qs.xz artifact, so this commit exposes the canonical coefficient range as a metrics-table row.",
+    "converter_path" => "misc/convert_lp2qubo.py",
+    "converter_convention" =>
+        "QOBLIB converts the LP with Qiskit QuadraticProgramToQubo, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.",
+)
+
+const SOURCE_LP_COMPARISON = Dict{String,Any}(
+    "lp_artifact" =>
+        "03-birkhoff/models/integer_linear/lp_files/bhS-03/bhS-03-001.lp.xz",
+    "matches_qoblib_lp_after_column_renaming" => true,
+    "column_renaming" => [
+        "lambda[1:4] match LP x#1:x#4",
+        "lambda[5] matches LP x#6",
+        "lambda[6] matches LP x#5",
+        "z selectors follow the same permutation-column renaming",
+    ],
+    "matched_structure" => [
+        "objective min sum(z)",
+        "six integer lambda variables bounded in [0, scale]",
+        "six integer selector variables bounded in [0, 1]",
+        "one scale equality",
+        "nine matrix-entry equalities",
+        "six activation inequalities lambda_i <= scale * z_i",
+    ],
+)
+
 const KNOWN_INCUMBENT = Dict{String,Any}(
     "source_objective" => 2,
     "source_feasible" => true,
@@ -190,12 +219,45 @@ function _qubo_terms(target::MOI.ModelLike)
     return objective, terms
 end
 
+function _qoblib_symmetric_coefficient(key::Tuple{Int,Int}, coefficient::Float64)
+    return first(key) == last(key) ? coefficient : coefficient / 2
+end
+
+function _coefficient_term_records(terms, target_coefficient; qoblib_symmetric = false)
+    records = Vector{Dict{String,Any}}()
+
+    for (key, coefficient) in sort(collect(terms))
+        qoblib_coefficient = _qoblib_symmetric_coefficient(key, coefficient)
+        comparison_coefficient = qoblib_symmetric ? qoblib_coefficient : coefficient
+
+        if comparison_coefficient == target_coefficient
+            push!(
+                records,
+                Dict{String,Any}(
+                    "variables" => [first(key), last(key)],
+                    "native_coefficient" => coefficient,
+                    "qoblib_symmetric_coefficient" => qoblib_coefficient,
+                ),
+            )
+        end
+    end
+
+    return records
+end
+
 function _target_metrics(optimizer)
     target = MOI.get(optimizer, Attributes.TargetModel())
     objective, terms = _qubo_terms(target)
     n = MOI.get(target, MOI.NumberOfVariables())
     coefficients = collect(values(terms))
+    qoblib_coefficients = [
+        _qoblib_symmetric_coefficient(key, coefficient) for (key, coefficient) in terms
+    ]
     total_slots = n * (n + 1) / 2
+    min_coeff = isempty(coefficients) ? 0.0 : minimum(coefficients)
+    max_coeff = isempty(coefficients) ? 0.0 : maximum(coefficients)
+    qoblib_min_coeff = isempty(qoblib_coefficients) ? 0.0 : minimum(qoblib_coefficients)
+    qoblib_max_coeff = isempty(qoblib_coefficients) ? 0.0 : maximum(qoblib_coefficients)
 
     return Dict{String,Any}(
         "num_variables" => n,
@@ -203,8 +265,13 @@ function _target_metrics(optimizer)
         "num_linear_terms" => count(key -> first(key) == last(key), keys(terms)),
         "num_quadratic_terms" => count(key -> first(key) != last(key), keys(terms)),
         "density" => isempty(terms) ? 0.0 : length(terms) / total_slots,
-        "min_coeff" => isempty(coefficients) ? 0.0 : minimum(coefficients),
-        "max_coeff" => isempty(coefficients) ? 0.0 : maximum(coefficients),
+        "min_coeff" => min_coeff,
+        "max_coeff" => max_coeff,
+        "native_max_coeff_terms" => _coefficient_term_records(terms, max_coeff),
+        "qoblib_symmetric_min_coeff" => qoblib_min_coeff,
+        "qoblib_symmetric_max_coeff" => qoblib_max_coeff,
+        "qoblib_symmetric_max_coeff_terms" =>
+            _coefficient_term_records(terms, qoblib_max_coeff; qoblib_symmetric = true),
         "objective_offset" => Float64(objective.constant),
     )
 end
@@ -261,7 +328,10 @@ function _known_incumbent_summary(permutations)
 end
 
 function _metadata_summary(optimizer)
-    metadata = ToQUBO.reformulation_metadata(optimizer)
+    return _metadata_summary(ToQUBO.reformulation_metadata(optimizer))
+end
+
+function _metadata_summary(metadata::AbstractDict)
     penalties = metadata["applied_penalties"]
 
     return Dict{String,Any}(
@@ -291,6 +361,126 @@ function _comparison(toqubo_metrics)
             toqubo_metrics["min_coeff"] - QOBLIB_QUBO_METRICS["min_coeff"],
         "max_coeff_delta_vs_qoblib_qs" =>
             toqubo_metrics["max_coeff"] - QOBLIB_QUBO_METRICS["max_coeff"],
+        "qoblib_symmetric_min_coeff_delta_vs_qoblib_qs" =>
+            toqubo_metrics["qoblib_symmetric_min_coeff"] -
+            QOBLIB_QUBO_METRICS["min_coeff"],
+        "qoblib_symmetric_max_coeff_delta_vs_qoblib_qs" =>
+            toqubo_metrics["qoblib_symmetric_max_coeff"] -
+            QOBLIB_QUBO_METRICS["max_coeff"],
+    )
+end
+
+function _num_permutations()
+    return factorial(INSTANCE["n"])
+end
+
+function _source_variable_label(id::Integer)
+    num_permutations = _num_permutations()
+
+    if 1 <= id <= num_permutations
+        return "lambda[$(id)]"
+    elseif id <= 2 * num_permutations
+        return "z[$(id - num_permutations)]"
+    else
+        return "source[$(id)]"
+    end
+end
+
+function _target_variable_source(metadata::AbstractDict, target_variable::Integer)
+    for original in metadata["original_variables"]
+        for term in original["expansion_terms"]
+            if term["variables"] == [target_variable]
+                return Dict{String,Any}(
+                    "kind" => "original",
+                    "id" => original["id"],
+                    "label" => _source_variable_label(original["id"]),
+                    "expansion_coefficient" => Float64(term["coefficient"]),
+                )
+            end
+        end
+    end
+
+    for slack in metadata["slack_variables"]
+        for term in slack["expansion_terms"]
+            if term["variables"] == [target_variable]
+                constraint = slack["constraint"]
+
+                return Dict{String,Any}(
+                    "kind" => "slack",
+                    "constraint_id" => constraint["id"],
+                    "label" => "slack[$(constraint["id"])]",
+                    "expansion_coefficient" => Float64(term["coefficient"]),
+                )
+            end
+        end
+    end
+
+    return Dict{String,Any}(
+        "kind" => "target",
+        "label" => "target[$(target_variable)]",
+        "expansion_coefficient" => 1.0,
+    )
+end
+
+function _lambda_constraint_labels(index::Integer, permutation::Vector{Int})
+    labels = ["scale equality: sum(lambda) == scale"]
+
+    for row in eachindex(permutation)
+        push!(labels, "matrix equality: row $(row), column $(permutation[row])")
+    end
+
+    push!(labels, "activation inequality: lambda[$(index)] <= scale * z[$(index)]")
+
+    return labels
+end
+
+function _annotate_term_records(records, metadata::AbstractDict, permutations)
+    annotated = Vector{Dict{String,Any}}()
+
+    for record in records
+        sources = [
+            _target_variable_source(metadata, target_variable) for
+            target_variable in record["variables"]
+        ]
+        source_id = first(sources)["kind"] == "original" ? first(sources)["id"] : nothing
+
+        constraints =
+            !isnothing(source_id) &&
+            all(
+                source -> source["kind"] == "original" && source["id"] == source_id,
+                sources,
+            ) &&
+            1 <= source_id <= length(permutations) ?
+            _lambda_constraint_labels(source_id, permutations[source_id]) :
+            String[]
+
+        push!(
+            annotated,
+            merge(
+                copy(record),
+                Dict{String,Any}("sources" => sources, "contributing_constraints" => constraints),
+            ),
+        )
+    end
+
+    return annotated
+end
+
+function _coefficient_attribution(target, metadata::AbstractDict, permutations)
+    native_max_terms =
+        _annotate_term_records(target["native_max_coeff_terms"], metadata, permutations)
+    qoblib_max_terms =
+        _annotate_term_records(target["qoblib_symmetric_max_coeff_terms"], metadata, permutations)
+
+    return Dict{String,Any}(
+        "upstream_evidence" => copy(QOBLIB_CONVERTER_EVIDENCE),
+        "source_lp_comparison" => copy(SOURCE_LP_COMPARISON),
+        "native_max_terms" => native_max_terms,
+        "qoblib_symmetric_max_terms" => qoblib_max_terms,
+        "penalty" => 7.0,
+        "ownership_decision" => "documentation-only",
+        "conclusion" =>
+            "The max-coefficient delta is a coefficient-reporting convention difference. ToQUBO's native upper-triangular terms keep full off-diagonal cross-term weights, while the QOBLIB writer symmetrizes Q and reports half of each off-diagonal cross term. Under the QOBLIB symmetrized convention, ToQUBO matches the canonical QUBO min/max coefficient row.",
     )
 end
 
@@ -300,6 +490,7 @@ function run_birkhoff_pilot()
     MOI.optimize!(model)
 
     target = _target_metrics(model)
+    metadata = ToQUBO.reformulation_metadata(model)
 
     return Dict{String,Any}(
         "provenance" => copy(PROVENANCE),
@@ -317,12 +508,14 @@ function run_birkhoff_pilot()
         "qoblib_qubo_metrics" => copy(QOBLIB_QUBO_METRICS),
         "toqubo" => Dict{String,Any}(
             "target" => target,
-            "metadata" => _metadata_summary(model),
+            "metadata" => _metadata_summary(metadata),
         ),
+        "coefficient_attribution" =>
+            _coefficient_attribution(target, metadata, permutations),
         "known_incumbent" => _known_incumbent_summary(permutations),
         "comparison" => _comparison(target),
         "follow_up" =>
-            "The pilot records a coefficient-range delta: ToQUBO's maximum coefficient is above the canonical QOBLIB metrics row for this instance. Track the penalty-scaling investigation in JuliaQUBO/ToQUBO.jl#148 before expanding class coverage.",
+            "The pilot's native max-coefficient delta is explained by the off-diagonal coefficient convention. Under QOBLIB's symmetrized QS writer convention, ToQUBO matches the canonical coefficient range for this instance; no ToQUBO penalty-scaling change is indicated.",
     )
 end
 
@@ -340,6 +533,22 @@ function _metric_row(metric, source, canonical, generated)
     return "| $(metric) | $(_fmt(source)) | $(_fmt(canonical)) | $(_fmt(generated)) |\n"
 end
 
+function _term_pair(record)
+    variables = record["variables"]
+
+    return "($(variables[1]), $(variables[2]))"
+end
+
+function _term_source_summary(record)
+    return join(
+        [
+            "$(source["label"]) bit $(_fmt(source["expansion_coefficient"]))" for
+            source in record["sources"]
+        ],
+        " x ",
+    )
+end
+
 function write_markdown_report(io::IO, report::AbstractDict)
     provenance = report["provenance"]
     instance = report["instance"]
@@ -350,6 +559,7 @@ function write_markdown_report(io::IO, report::AbstractDict)
     metadata = report["toqubo"]["metadata"]
     incumbent = report["known_incumbent"]
     comparison = report["comparison"]
+    attribution = report["coefficient_attribution"]
 
     write(io, "# QOBLib Birkhoff Reformulation Pilot\n\n")
     write(
@@ -437,6 +647,66 @@ function write_markdown_report(io::IO, report::AbstractDict)
         _metric_row("quadratic terms", "n/a", "n/a", target["num_quadratic_terms"]),
     )
 
+    write(io, "\n## Coefficient Range Attribution\n\n")
+
+    upstream = attribution["upstream_evidence"]
+    source_lp = attribution["source_lp_comparison"]
+
+    write(
+        io,
+        "- Canonical artifact check: $(upstream["canonical_artifact_note"])\n",
+    )
+    write(
+        io,
+        "- QOBLIB converter convention: `$(upstream["converter_path"])` records this workflow: $(upstream["converter_convention"])\n",
+    )
+    write(
+        io,
+        "- Source LP comparison: `$(source_lp["lp_artifact"])` matches the pilot model after permutation-column renaming; $(join(source_lp["column_renaming"], "; ")).\n",
+    )
+    write(
+        io,
+        "- Matched source structure: $(join(source_lp["matched_structure"], "; ")).\n",
+    )
+    write(
+        io,
+        "- Applied penalty: $(_fmt(attribution["penalty"])) for every source constraint, matching Qiskit's automatic `sum(abs(objective)) + 1` scale for `min sum(z)`.\n",
+    )
+
+    write(io, "- ToQUBO native maximum coefficient terms:\n")
+
+    for record in attribution["native_max_terms"]
+        write(
+            io,
+            "  - Target term `$(_term_pair(record))`: native `$(_fmt(record["native_coefficient"]))`, QOBLIB-style `$(_fmt(record["qoblib_symmetric_coefficient"]))`; source bits: $(_term_source_summary(record)).\n",
+        )
+
+        if !isempty(record["contributing_constraints"])
+            write(
+                io,
+                "    - Contributing constraints: $(join(record["contributing_constraints"], "; ")).\n",
+            )
+        end
+    end
+
+    write(io, "- QOBLIB-style maximum coefficient terms:\n")
+
+    for record in attribution["qoblib_symmetric_max_terms"]
+        write(
+            io,
+            "  - Target term `$(_term_pair(record))`: native `$(_fmt(record["native_coefficient"]))`, QOBLIB-style `$(_fmt(record["qoblib_symmetric_coefficient"]))`; source bits: $(_term_source_summary(record)).\n",
+        )
+    end
+
+    write(
+        io,
+        "- QOBLIB-style coefficient range: minimum `$(_fmt(target["qoblib_symmetric_min_coeff"]))`, maximum `$(_fmt(target["qoblib_symmetric_max_coeff"]))`.\n",
+    )
+    write(
+        io,
+        "- Ownership decision: $(attribution["ownership_decision"]). $(attribution["conclusion"])\n",
+    )
+
     write(io, "\n## Reformulation Metadata\n\n")
     write(io, "- Metadata schema version: $(metadata["schema_version"])\n")
     write(io, "- Source variables: $(metadata["source_variable_count"])\n")
@@ -471,6 +741,14 @@ function write_markdown_report(io::IO, report::AbstractDict)
     write(
         io,
         "- Maximum coefficient delta vs QOBLIB canonical QUBO metrics: $(_fmt(comparison["max_coeff_delta_vs_qoblib_qs"]))\n",
+    )
+    write(
+        io,
+        "- QOBLIB-style minimum coefficient delta vs QOBLIB canonical QUBO metrics: $(_fmt(comparison["qoblib_symmetric_min_coeff_delta_vs_qoblib_qs"]))\n",
+    )
+    write(
+        io,
+        "- QOBLIB-style maximum coefficient delta vs QOBLIB canonical QUBO metrics: $(_fmt(comparison["qoblib_symmetric_max_coeff_delta_vs_qoblib_qs"]))\n",
     )
 
     write(io, "\n## Follow-Up\n\n")

--- a/benchmarks/qoblib/reports/birkhoff_pilot.md
+++ b/benchmarks/qoblib/reports/birkhoff_pilot.md
@@ -45,6 +45,28 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 | QUBO terms | n/a | n/a | 2886 |
 | quadratic terms | n/a | n/a | 2760 |
 
+## Coefficient Range Attribution
+
+- Canonical artifact check: The pinned QOBLIB tree contains 03-birkhoff/models/integer_linear/metrics_qs_files.csv but no stored bhS-3-001.qs or bhS-3-001.qs.xz artifact, so this commit exposes the canonical coefficient range as a metrics-table row.
+- QOBLIB converter convention: `misc/convert_lp2qubo.py` records this workflow: QOBLIB converts the LP with Qiskit QuadraticProgramToQubo, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.
+- Source LP comparison: `03-birkhoff/models/integer_linear/lp_files/bhS-03/bhS-03-001.lp.xz` matches the pilot model after permutation-column renaming; lambda[1:4] match LP x#1:x#4; lambda[5] matches LP x#6; lambda[6] matches LP x#5; z selectors follow the same permutation-column renaming.
+- Matched source structure: objective min sum(z); six integer lambda variables bounded in [0, scale]; six integer selector variables bounded in [0, 1]; one scale equality; nine matrix-entry equalities; six activation inequalities lambda_i <= scale * z_i.
+- Applied penalty: 7.0 for every source constraint, matching Qiskit's automatic `sum(abs(objective)) + 1` scale for `min sum(z)`.
+- ToQUBO native maximum coefficient terms:
+  - Target term `(29, 30)`: native `8.76288e6`, QOBLIB-style `4.38144e6`; source bits: lambda[3] bit 256.0 x lambda[3] bit 489.0.
+    - Contributing constraints: scale equality: sum(lambda) == scale; matrix equality: row 1, column 2; matrix equality: row 2, column 1; matrix equality: row 3, column 3; activation inequality: lambda[3] <= scale * z[3].
+  - Target term `(59, 60)`: native `8.76288e6`, QOBLIB-style `4.38144e6`; source bits: lambda[6] bit 256.0 x lambda[6] bit 489.0.
+    - Contributing constraints: scale equality: sum(lambda) == scale; matrix equality: row 1, column 3; matrix equality: row 2, column 2; matrix equality: row 3, column 1; activation inequality: lambda[6] <= scale * z[6].
+- QOBLIB-style maximum coefficient terms:
+  - Target term `(61, 61)`: native `7.000001e6`, QOBLIB-style `7.000001e6`; source bits: z[1] bit 1.0 x z[1] bit 1.0.
+  - Target term `(62, 62)`: native `7.000001e6`, QOBLIB-style `7.000001e6`; source bits: z[2] bit 1.0 x z[2] bit 1.0.
+  - Target term `(63, 63)`: native `7.000001e6`, QOBLIB-style `7.000001e6`; source bits: z[3] bit 1.0 x z[3] bit 1.0.
+  - Target term `(64, 64)`: native `7.000001e6`, QOBLIB-style `7.000001e6`; source bits: z[4] bit 1.0 x z[4] bit 1.0.
+  - Target term `(65, 65)`: native `7.000001e6`, QOBLIB-style `7.000001e6`; source bits: z[5] bit 1.0 x z[5] bit 1.0.
+  - Target term `(66, 66)`: native `7.000001e6`, QOBLIB-style `7.000001e6`; source bits: z[6] bit 1.0 x z[6] bit 1.0.
+- QOBLIB-style coefficient range: minimum `-1.3346277e7`, maximum `7.000001e6`.
+- Ownership decision: documentation-only. The max-coefficient delta is a coefficient-reporting convention difference. ToQUBO's native upper-triangular terms keep full off-diagonal cross-term weights, while the QOBLIB writer symmetrizes Q and reports half of each off-diagonal cross term. Under the QOBLIB symmetrized convention, ToQUBO matches the canonical QUBO min/max coefficient row.
+
 ## Reformulation Metadata
 
 - Metadata schema version: 1
@@ -69,7 +91,9 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Density delta vs QOBLIB canonical QUBO metrics: 0.0
 - Minimum coefficient delta vs QOBLIB canonical QUBO metrics: 0.0
 - Maximum coefficient delta vs QOBLIB canonical QUBO metrics: 1.762879e6
+- QOBLIB-style minimum coefficient delta vs QOBLIB canonical QUBO metrics: 0.0
+- QOBLIB-style maximum coefficient delta vs QOBLIB canonical QUBO metrics: 0.0
 
 ## Follow-Up
 
-The pilot records a coefficient-range delta: ToQUBO's maximum coefficient is above the canonical QOBLIB metrics row for this instance. Track the penalty-scaling investigation in JuliaQUBO/ToQUBO.jl#148 before expanding class coverage.
+The pilot's native max-coefficient delta is explained by the off-diagonal coefficient convention. Under QOBLIB's symmetrized QS writer convention, ToQUBO matches the canonical coefficient range for this instance; no ToQUBO penalty-scaling change is indicated.

--- a/benchmarks/qoblib/reports/birkhoff_pilot.md
+++ b/benchmarks/qoblib/reports/birkhoff_pilot.md
@@ -49,9 +49,10 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 
 - Canonical artifact check: The pinned QOBLIB tree contains 03-birkhoff/models/integer_linear/metrics_qs_files.csv but no stored bhS-3-001.qs or bhS-3-001.qs.xz artifact, so this commit exposes the canonical coefficient range as a metrics-table row.
 - QOBLIB converter convention: `misc/convert_lp2qubo.py` records this workflow: QOBLIB converts the LP with Qiskit QuadraticProgramToQubo, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.
+- Upstream verification: manually checked QOBLIB commit `a686aaa09fe14651294f744f34d453d5dce9cf57`; converter refs misc/convert_lp2qubo.py:60-65, misc/convert_lp2qubo.py:82-89; metrics ref 03-birkhoff/models/integer_linear/metrics_qs_files.csv:42; LP refs decompressed LP lines 15-21, decompressed LP lines 22-39, decompressed LP lines 40-64.
 - Source LP comparison: `03-birkhoff/models/integer_linear/lp_files/bhS-03/bhS-03-001.lp.xz` matches the pilot model after permutation-column renaming; lambda[1:4] match LP x#1:x#4; lambda[5] matches LP x#6; lambda[6] matches LP x#5; z selectors follow the same permutation-column renaming.
 - Matched source structure: objective min sum(z); six integer lambda variables bounded in [0, scale]; six integer selector variables bounded in [0, 1]; one scale equality; nine matrix-entry equalities; six activation inequalities lambda_i <= scale * z_i.
-- Applied penalty: 7.0 for every source constraint, matching Qiskit's automatic `sum(abs(objective)) + 1` scale for `min sum(z)`.
+- Distinct applied constraint penalties from ToQUBO metadata: 7.0; this matches Qiskit's automatic `sum(abs(objective)) + 1` scale for `min sum(z)`.
 - ToQUBO native maximum coefficient terms:
   - Target term `(29, 30)`: native `8.76288e6`, QOBLIB-style `4.38144e6`; source bits: lambda[3] bit 256.0 x lambda[3] bit 489.0.
     - Contributing constraints: scale equality: sum(lambda) == scale; matrix equality: row 1, column 2; matrix equality: row 2, column 1; matrix equality: row 3, column 3; activation inequality: lambda[3] <= scale * z[3].

--- a/test/unit/qoblib_benchmark.jl
+++ b/test/unit/qoblib_benchmark.jl
@@ -46,8 +46,14 @@ function test_qoblib_benchmark_pilot()
         attribution = report["coefficient_attribution"]
         @test attribution["upstream_evidence"]["canonical_artifact_available_at_commit"] ===
               false
+        @test attribution["upstream_evidence"]["manual_verification"] === true
+        @test attribution["upstream_evidence"]["metrics_line_ref"] ==
+              "03-birkhoff/models/integer_linear/metrics_qs_files.csv:42"
         @test attribution["source_lp_comparison"]["matches_qoblib_lp_after_column_renaming"] ===
               true
+        @test attribution["source_lp_comparison"]["manual_verification"] === true
+        @test attribution["constraint_penalties"] == [7.0]
+        @test attribution["penalty"] == 7.0
         @test attribution["ownership_decision"] == "documentation-only"
         @test length(attribution["native_max_terms"]) == 2
         @test all(
@@ -81,6 +87,7 @@ function test_qoblib_benchmark_pilot()
         @test occursin("QOBLib Birkhoff Reformulation Pilot", markdown)
         @test occursin("bhS-03-001.lp", markdown)
         @test occursin("Coefficient Range Attribution", markdown)
+        @test occursin("Upstream verification", markdown)
         @test occursin("documentation-only", markdown)
         @test markdown == _normalized_file(report_path)
     end

--- a/test/unit/qoblib_benchmark.jl
+++ b/test/unit/qoblib_benchmark.jl
@@ -24,12 +24,40 @@ function test_qoblib_benchmark_pilot()
         @test target["num_terms"] > 0
         @test target["num_quadratic_terms"] > 0
         @test target["density"] > 0
+        @test target["max_coeff"] == 8_762_880.0
+        @test target["qoblib_symmetric_min_coeff"] ==
+              report["qoblib_qubo_metrics"]["min_coeff"]
+        @test target["qoblib_symmetric_max_coeff"] ==
+              report["qoblib_qubo_metrics"]["max_coeff"]
+        @test Set(Tuple(term["variables"]) for term in target["native_max_coeff_terms"]) ==
+              Set([(29, 30), (59, 60)])
 
         metadata = report["toqubo"]["metadata"]
         @test metadata["source_variable_count"] == 12
         @test metadata["target_variable_count"] == target["num_variables"]
         @test metadata["constraint_penalty_count"] > 0
         @test !isempty(metadata["encoding_types"])
+
+        comparison = report["comparison"]
+        @test comparison["max_coeff_delta_vs_qoblib_qs"] == 1_762_879.0
+        @test comparison["qoblib_symmetric_min_coeff_delta_vs_qoblib_qs"] == 0.0
+        @test comparison["qoblib_symmetric_max_coeff_delta_vs_qoblib_qs"] == 0.0
+
+        attribution = report["coefficient_attribution"]
+        @test attribution["upstream_evidence"]["canonical_artifact_available_at_commit"] ===
+              false
+        @test attribution["source_lp_comparison"]["matches_qoblib_lp_after_column_renaming"] ===
+              true
+        @test attribution["ownership_decision"] == "documentation-only"
+        @test length(attribution["native_max_terms"]) == 2
+        @test all(
+            term -> term["qoblib_symmetric_coefficient"] == 4_381_440.0,
+            attribution["native_max_terms"],
+        )
+        @test all(
+            term -> term["native_coefficient"] == 7_000_001.0,
+            attribution["qoblib_symmetric_max_terms"],
+        )
 
         incumbent = report["known_incumbent"]
         @test incumbent["source_objective"] == 2
@@ -52,6 +80,8 @@ function test_qoblib_benchmark_pilot()
         @test occursin("not a canonical QOBLIB artifact", markdown)
         @test occursin("QOBLib Birkhoff Reformulation Pilot", markdown)
         @test occursin("bhS-03-001.lp", markdown)
+        @test occursin("Coefficient Range Attribution", markdown)
+        @test occursin("documentation-only", markdown)
         @test markdown == _normalized_file(report_path)
     end
 


### PR DESCRIPTION
## Summary

- Add generated attribution evidence to the QOBLib Birkhoff pilot report.
- Document that the native max-coefficient delta comes from ToQUBO's full off-diagonal upper-triangular coefficient convention versus QOBLIB's symmetrized QS writer convention.
- Record the upstream LP/model comparison, exact native max terms, QOBLIB-style coefficient range, and documentation-only ownership decision.
- Extend the QOBLib pilot unit test around the resolved convention deltas and regenerated Markdown report.

## Tests

- `julia --project=. -e 'using Test; include("test/unit/qoblib_benchmark.jl"); test_qoblib_benchmark_pilot()'` passed, 36/36.
- `julia --project=. -e 'import Pkg; Pkg.test()'` passed, 1089/1089.
- `git diff --check` passed.

Note: local Julia commands required filesystem approval for Juliaup's lockfile under `~/.julia` in this sandbox.

## Branch Hygiene

- Base branch: `main`
- Base commit: `origin/main` at `5e25962df0498a94759d20c9f341bc7468562c76`
- Head branch: `fix/issue-148-qoblib-birkhoff-gap`
- Source branch point: `5e25962df0498a94759d20c9f341bc7468562c76`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #148
