### PR TITLE
[codex] Add JuMP QUBO extraction API

### DIFF
--- a/docs/src/manual/3-results.md
+++ b/docs/src/manual/3-results.md
@@ -218,9 +218,10 @@ from the optimizer and is also attached under
 `QUBOTools.backend`.
 
 ```julia
-optimizer = unsafe_backend(model)
-metadata = ToQUBO.reformulation_metadata(optimizer)
-qubo_model = ToQUBO.QUBOTools.backend(optimizer)
+using ToQUBO: QUBOTools
+
+qubo_model = QUBOTools.backend(model)
+metadata = ToQUBO.reformulation_metadata(qubo_model)
 
 original = ToQUBO.original_variables(metadata)
 auxiliary = ToQUBO.auxiliary_variables(metadata)
@@ -244,6 +245,7 @@ ToQUBO.reformulation_metadata
 ToQUBO.original_variables
 ToQUBO.auxiliary_variables
 ToQUBO.project_original_state
+ToQUBO.qubo
 ToQUBO.ConstraintViolation
 ToQUBO.FeasibilityResult
 ToQUBO.FeasibilityReport
@@ -324,13 +326,22 @@ end
 
 ## Working with QUBOTools
 
-ToQUBO.jl integrates with [QUBOTools.jl](https://github.com/JuliaQUBO/QUBOTools.jl) for advanced QUBO manipulation. You can extract the underlying QUBO model:
+ToQUBO.jl integrates with [QUBOTools.jl](https://github.com/JuliaQUBO/QUBOTools.jl) for advanced QUBO manipulation. You can extract the compiled QUBO from a JuMP model after `optimize!`:
 
 ```julia
+using JuMP
+using ToQUBO
 using ToQUBO: QUBOTools
 
-# Get the QUBO backend from the attached MOI optimizer
-qubo_model = QUBOTools.backend(unsafe_backend(model))
+model = Model(ToQUBO.Optimizer)
+@variable(model, x[1:2], Bin)
+@constraint(model, x[1] + x[2] <= 1)
+@objective(model, Min, x[1] - 2x[2])
+
+optimize!(model)
+
+qubo_model = QUBOTools.backend(model)
+n, linear, quadratic, scale, offset = ToQUBO.qubo(model, :dense)
 ```
 
 This allows you to:

--- a/ext/ToQUBOJuMPExt.jl
+++ b/ext/ToQUBOJuMPExt.jl
@@ -1,7 +1,12 @@
 module ToQUBOJuMPExt
 
 import JuMP
+import QUBOTools
 import ToQUBO
+
+function QUBOTools.backend(model::JuMP.Model)
+    return QUBOTools.backend(JuMP.unsafe_backend(model))
+end
 
 function ToQUBO.violations(model::JuMP.Model; kwargs...)
     return ToQUBO.violations(JuMP.unsafe_backend(model); kwargs...)

--- a/ext/ToQUBOJuMPExt.jl
+++ b/ext/ToQUBOJuMPExt.jl
@@ -4,6 +4,8 @@ import JuMP
 import QUBOTools
 import ToQUBO
 
+# Intentional extension glue: ToQUBO owns the compiler result, while
+# QUBOTools owns the backend/export surface used to inspect it.
 function QUBOTools.backend(model::JuMP.Model)
     return QUBOTools.backend(JuMP.unsafe_backend(model))
 end

--- a/src/ToQUBO.jl
+++ b/src/ToQUBO.jl
@@ -5,13 +5,28 @@ export ConstraintViolation,
     FeasibilityReport,
     violations,
     is_feasible,
-    feasibility_report
+    feasibility_report,
+    qubo
 
 using MathOptInterface
 const MOI = MathOptInterface
 
 import PseudoBooleanOptimization as PBO
 import QUBOTools
+
+@doc raw"""
+    qubo(model, args...; kwargs...)
+
+Return the compiled QUBO representation for a model supported by
+`QUBOTools`.
+
+This is a public ToQUBO convenience wrapper around `QUBOTools.qubo`. For a
+JuMP model using `ToQUBO.Optimizer`, call `optimize!` first, then pass the
+`JuMP.Model` directly.
+"""
+function qubo(model, args...; kwargs...)
+    return QUBOTools.qubo(model, args...; kwargs...)
+end
 
 # Versioning
 import TOML

--- a/src/ToQUBO.jl
+++ b/src/ToQUBO.jl
@@ -20,9 +20,9 @@ import QUBOTools
 Return the compiled QUBO representation for a model supported by
 `QUBOTools`.
 
-This is a public ToQUBO convenience wrapper around `QUBOTools.qubo`. For a
-JuMP model using `ToQUBO.Optimizer`, call `optimize!` first, then pass the
-`JuMP.Model` directly.
+This is a thin public ToQUBO re-export of `QUBOTools.qubo`. For a JuMP model
+using `ToQUBO.Optimizer`, call `optimize!` first, then pass the `JuMP.Model`
+directly.
 """
 function qubo(model, args...; kwargs...)
     return QUBOTools.qubo(model, args...; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,10 +23,6 @@ function MOIU.map_indices(::Function, quad::PBO.QuadratizationMethod)
     return quad
 end
 
-function QUBOTools.backend(model::JuMP.Model)
-    return QUBOTools.backend(JuMP.unsafe_backend(model))
-end
-
 include("unit/unit.jl")
 include("integration/integration.jl")
 

--- a/test/unit/wrapper/wrapper.jl
+++ b/test/unit/wrapper/wrapper.jl
@@ -76,6 +76,27 @@ function test_wrapper_optimizer()
                 backend = QUBOTools.backend(model)
                 @test backend isa QUBOTools.Model
             end
+
+            let model = Model(ToQUBO.Optimizer)
+                @variable(model, x[1:2], Bin)
+                @constraint(model, x[1] + x[2] <= 1)
+                @objective(model, Min, x[1] - 2x[2])
+
+                optimize!(model)
+
+                backend = QUBOTools.backend(model)
+                @test backend isa QUBOTools.Model
+                @test haskey(QUBOTools.metadata(backend), "toqubo")
+
+                n, L, Q, α, β = QUBOTools.qubo(model, :dense)
+                n′, L′, Q′, α′, β′ = ToQUBO.qubo(model, :dense)
+
+                @test n == n′
+                @test L ≈ L′
+                @test Q ≈ Q′
+                @test α ≈ α′
+                @test β ≈ β′
+            end
         end
 
         @testset "Solver Name and Version" begin


### PR DESCRIPTION
## Summary

Adds a supported public QUBO extraction path for JuMP models compiled with `ToQUBO.Optimizer`.

- Exports `ToQUBO.qubo(model, args...; kwargs...)` as a convenience wrapper around `QUBOTools.qubo`.
- Defines `QUBOTools.backend(::JuMP.Model)` in the JuMP extension, so callers can pass a compiled JuMP model directly.
- Removes the test-only JuMP backend monkey patch and covers the public extension path in wrapper tests.
- Updates the results manual with a small JuMP + ToQUBO extraction example and metadata access through the QUBOTools model.

Closes #158

## Tests

- `git diff --check` passed.
- `julia --project -e 'using Pkg; Pkg.test()'` passed: 1250/1250 tests.
- `julia --project=docs docs/make.jl --skip-deploy` passed.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `1cf5e8803984d62791e2ac395463420454d9e002`
- Head branch: `fix/issue-158-qubo-extraction-api`
- Stacked status: not stacked
- Prerequisite PRs: none
