### PR TITLE
Avoid eager backend reformulation metadata

### DIFF
--- a/benchmarks/tsp_backend_extraction.jl
+++ b/benchmarks/tsp_backend_extraction.jl
@@ -1,0 +1,143 @@
+module TSPBackendExtractionBenchmark
+
+import MathOptInterface as MOI
+import QUBOTools
+import ToQUBO
+
+const VI = MOI.VariableIndex
+const SAF{T} = MOI.ScalarAffineFunction{T}
+const SAT{T} = MOI.ScalarAffineTerm{T}
+const SQF{T} = MOI.ScalarQuadraticFunction{T}
+const SQT{T} = MOI.ScalarQuadraticTerm{T}
+
+const DEFAULT_N = 30
+const DEFAULT_BACKEND_ALLOCATION_BUDGET_BYTES = 256 * 1024^2
+
+function _env_bool(name::AbstractString; default::Bool = false)
+    value = lowercase(get(ENV, name, default ? "true" : "false"))
+
+    return value in ("1", "true", "yes")
+end
+
+function _distance(i::Int, j::Int)
+    return Float64(abs(i - j) + 1)
+end
+
+function build_tsp_style_model(n::Int)
+    model = ToQUBO.Optimizer{Float64}()
+    x = Matrix{VI}(undef, n, n)
+
+    for i = 1:n, j = 1:n
+        x[i, j], _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+    end
+
+    for i = 1:n
+        terms = [SAT{Float64}(1.0, x[i, j]) for j = 1:n]
+        MOI.add_constraint(model, SAF{Float64}(terms, 0.0), MOI.EqualTo(1.0))
+    end
+
+    for j = 1:n
+        terms = [SAT{Float64}(1.0, x[i, j]) for i = 1:n]
+        MOI.add_constraint(model, SAF{Float64}(terms, 0.0), MOI.EqualTo(1.0))
+    end
+
+    quadratic_terms = SQT{Float64}[]
+
+    for position = 1:n
+        next_position = position == n ? 1 : position + 1
+
+        for from = 1:n, to = 1:n
+            from == to && continue
+
+            push!(
+                quadratic_terms,
+                SQT{Float64}(_distance(from, to), x[position, from], x[next_position, to]),
+            )
+        end
+    end
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{SQF{Float64}}(),
+        SQF{Float64}(quadratic_terms, SAT{Float64}[], 0.0),
+    )
+
+    MOI.optimize!(model)
+
+    return model
+end
+
+function _measure(f::Function)
+    GC.gc()
+
+    return @timed f()
+end
+
+function _print_result(label::AbstractString, stats)
+    println(
+        label,
+        ": time = ",
+        round(stats.time; digits = 6),
+        " s, allocated = ",
+        round(stats.bytes / 1024^2; digits = 3),
+        " MiB, gc = ",
+        round(stats.gctime; digits = 6),
+        " s",
+    )
+
+    return nothing
+end
+
+function main()
+    n = parse(Int, get(ENV, "TOQUBO_TSP_BACKEND_N", string(DEFAULT_N)))
+    allocation_budget = parse(
+        Int,
+        get(
+            ENV,
+            "TOQUBO_TSP_BACKEND_ALLOC_BUDGET_BYTES",
+            string(DEFAULT_BACKEND_ALLOCATION_BUDGET_BYTES),
+        ),
+    )
+    run_full_metadata = _env_bool("TOQUBO_TSP_BACKEND_FULL_METADATA")
+
+    model = build_tsp_style_model(n)
+
+    QUBOTools.backend(model)
+    default_stats = _measure() do
+        QUBOTools.backend(model)
+    end
+
+    println("TSP-style backend extraction benchmark")
+    println("n = ", n)
+    println("allocation budget = ", round(allocation_budget / 1024^2; digits = 3), " MiB")
+    _print_result("default backend extraction", default_stats)
+
+    if default_stats.bytes > allocation_budget
+        error(
+            "default backend extraction allocated $(default_stats.bytes) bytes, above " *
+            "the budget of $(allocation_budget) bytes",
+        )
+    end
+
+    if run_full_metadata
+        full_stats = _measure() do
+            QUBOTools.backend(model; full_metadata = true)
+        end
+
+        _print_result("full metadata extraction", full_stats)
+    else
+        println(
+            "full metadata extraction skipped; set " *
+            "TOQUBO_TSP_BACKEND_FULL_METADATA=true to measure it",
+        )
+    end
+
+    return nothing
+end
+
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    TSPBackendExtractionBenchmark.main()
+end

--- a/docs/src/manual/3-results.md
+++ b/docs/src/manual/3-results.md
@@ -213,14 +213,18 @@ zeta = MOI.get(model, Attributes.SlackVariableEncodingFunction(), constraint_ref
 ToQUBO records JSON-compatible reformulation metadata for downstream tools that
 need to interpret full QUBO states. The metadata uses string-keyed dictionaries,
 arrays, primitive values, and finite numeric values. It is available directly
-from the optimizer and is also attached under
-`metadata["toqubo"]["reformulation"]` on the `QUBOTools` model returned by
-`QUBOTools.backend`.
+from the optimizer. `QUBOTools.backend` does not attach the full metadata payload
+by default, so public QUBO extraction can avoid materializing large
+JSON-compatible term dictionaries. Opt in with `full_metadata = true` when the
+returned `QUBOTools` model needs embedded metadata under
+`metadata["toqubo"]["reformulation"]`.
 
 ```julia
 using ToQUBO: QUBOTools
 
-qubo_model = QUBOTools.backend(model)
+metadata = ToQUBO.reformulation_metadata(JuMP.unsafe_backend(model))
+
+qubo_model = QUBOTools.backend(model; full_metadata = true)
 metadata = ToQUBO.reformulation_metadata(qubo_model)
 
 original = ToQUBO.original_variables(metadata)
@@ -239,6 +243,15 @@ constraint, variable-encoding, and slack-variable penalty coefficients.
 corresponding metadata records. This is enough to project a full QUBO state back
 to original variables. Exact auxiliary consistency checks and repair remain
 encoding-specific and are not guaranteed by this metadata contract.
+
+Full reformulation metadata is intentionally generated on request. Dense models
+can create one metadata record per source-to-target expansion term and per
+constraint-encoding term, so the JSON-compatible payload may allocate gigabytes
+on large TSP-style formulations. Use the default `QUBOTools.backend(model)` path
+when you only need the compiled QUBO, and use
+`QUBOTools.backend(model; full_metadata = true)` or
+`ToQUBO.reformulation_metadata(JuMP.unsafe_backend(model))` when you need
+projection and interpretation metadata.
 
 ```@docs
 ToQUBO.reformulation_metadata

--- a/ext/ToQUBOJuMPExt.jl
+++ b/ext/ToQUBOJuMPExt.jl
@@ -6,8 +6,8 @@ import ToQUBO
 
 # Intentional extension glue: ToQUBO owns the compiler result, while
 # QUBOTools owns the backend/export surface used to inspect it.
-function QUBOTools.backend(model::JuMP.Model)
-    return QUBOTools.backend(JuMP.unsafe_backend(model))
+function QUBOTools.backend(model::JuMP.Model; kwargs...)
+    return QUBOTools.backend(JuMP.unsafe_backend(model); kwargs...)
 end
 
 function ToQUBO.violations(model::JuMP.Model; kwargs...)

--- a/src/reformulation.jl
+++ b/src/reformulation.jl
@@ -8,7 +8,9 @@ const _REFORMULATION_SCHEMA_VERSION = 1
 Return JSON-compatible ToQUBO reformulation metadata. For a live
 `ToQUBO.Optimizer`, the metadata is generated from the compiled virtual model.
 For a `QUBOTools.AbstractModel` or a metadata dictionary, the metadata is read
-from `metadata["toqubo"]["reformulation"]`.
+from `metadata["toqubo"]["reformulation"]`. `QUBOTools.backend` skips this full
+metadata payload by default; call `QUBOTools.backend(model; full_metadata = true)`
+when a returned QUBOTools model needs embedded reformulation metadata.
 
 The `applied_penalties` section is a convenience view. Its entries duplicate
 the applied penalty coefficients also attached to the corresponding variable,

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -157,10 +157,12 @@ function Base.show(io::IO, model::Optimizer)
     )
 end
 
-function QUBOTools.backend(model::Optimizer{T}) where {T}
+function QUBOTools.backend(model::Optimizer{T}; full_metadata::Bool = false) where {T}
     qubo_model = QUBOTools.Model{T}(model.target_model)
 
-    _attach_reformulation_metadata!(qubo_model, model)
+    if full_metadata
+        _attach_reformulation_metadata!(qubo_model, model)
+    end
 
     return qubo_model
 end

--- a/test/unit/reformulation.jl
+++ b/test/unit/reformulation.jl
@@ -121,6 +121,9 @@ function test_reformulation_metadata()
         @test dict_projected[y] == 1.0
 
         backend = QUBOTools.backend(model)
+        @test_throws ErrorException ToQUBO.reformulation_metadata(backend)
+
+        backend = QUBOTools.backend(model; full_metadata = true)
         backend_metadata = QUBOTools.metadata(backend)
         backend_reformulation = ToQUBO.reformulation_metadata(backend)
 

--- a/test/unit/wrapper/wrapper.jl
+++ b/test/unit/wrapper/wrapper.jl
@@ -86,7 +86,11 @@ function test_wrapper_optimizer()
 
                 backend = QUBOTools.backend(model)
                 @test backend isa QUBOTools.Model
-                @test haskey(QUBOTools.metadata(backend), "toqubo")
+                @test !haskey(QUBOTools.metadata(backend), "toqubo")
+
+                backend_with_metadata = QUBOTools.backend(model; full_metadata = true)
+                @test backend_with_metadata isa QUBOTools.Model
+                @test haskey(QUBOTools.metadata(backend_with_metadata), "toqubo")
 
                 n, L, Q, α, β = QUBOTools.qubo(model, :dense)
                 n′, L′, Q′, α′, β′ = ToQUBO.qubo(model, :dense)


### PR DESCRIPTION
## Summary

- Makes `QUBOTools.backend(::ToQUBO.Optimizer)` skip full reformulation metadata by default.
- Adds `full_metadata = true` for callers that need embedded `metadata["toqubo"]["reformulation"]`, and forwards the keyword through the JuMP extension.
- Documents the opt-in metadata path and adds a TSP-style backend extraction benchmark with a default allocation budget.

Closes #164.

## Tests

- `git diff --check` passed.
- Focused wrapper and reformulation tests:
  `julia --project=. -e 'push!(LOAD_PATH, joinpath(pwd(), "test")); using Test; using JuMP; import MathOptInterface as MOI; const MOIU = MOI.Utilities; const VI = MOI.VariableIndex; const CI{F,S} = MOI.ConstraintIndex{F,S}; using QUBODrivers; using LinearAlgebra; using TOML; using ToQUBO; using ToQUBO: Attributes, Encoding; import QUBOTools; import PseudoBooleanOptimization as PBO; MOIU.map_indices(::Function, arch::QUBOTools.AbstractArchitecture) = arch; MOIU.map_indices(::Function, quad::PBO.QuadratizationMethod) = quad; include("test/unit/wrapper/wrapper.jl"); include("test/unit/reformulation.jl"); test_wrapper_optimizer(); test_reformulation_metadata()'`
  passed with 53 wrapper tests and 30 reformulation metadata tests.
- Full test suite:
  `julia --project=. -e 'push!(LOAD_PATH, joinpath(pwd(), "test")); include("test/runtests.jl")'`
  passed with 1,311 tests.
- TSP-style backend extraction benchmark:
  `julia --project=. benchmarks/tsp_backend_extraction.jl`
  passed at `n = 30`, allocating 12.247 MiB against the 256 MiB default budget.

## Branch Hygiene

- Base branch: `main`.
- Source branch point: `061f190fc5b80e6bb592db2f0de4d08a706c5257` (`origin/main` at branch creation).
- Stacked status: not stacked; branch is based directly on `origin/main`.
- Prerequisite PRs: none.
