### PR TITLE
Add fast path for already-QUBO models

### DIFF
--- a/src/compiler/compiler.jl
+++ b/src/compiler/compiler.jl
@@ -42,6 +42,8 @@ function compile!(model::Virtual.Model)
 end
 
 function compile!(model::Virtual.Model{T}, arch::AbstractArchitecture) where {T}
+    delete!(model.compiler_settings, :qubo_fast_path)
+
     if is_qubo(model.source_model)
         Compiler.copy!(model, arch)
 
@@ -95,20 +97,177 @@ function reset!(model::Virtual.Model, ::AbstractArchitecture = GenericArchitectu
     # Optimize-generated status
     MOI.set(model, Attributes.CompilationStatus(), nothing)
     MOI.set(model, Attributes.CompilationTime(), nothing)
+    delete!(model.compiler_settings, :qubo_fast_path)
     delete!(model.moi_settings, :raw_status_string)
 
     return nothing
 end
 
 function Compiler.copy!(model::Virtual.Model{T}, arch::AbstractArchitecture) where {T}
-    # Map Variables
-    for vi in MOI.get(model.source_model, MOI.ListOfVariableIndices())
-        Encoding.encode!(model, vi, Encoding.Mirror{T}())
+    reset!(model, arch)
+
+    variable_map = _copy_qubo_variables!(model)
+
+    MOI.set(
+        model.target_model,
+        MOI.ObjectiveSense(),
+        MOI.get(model.source_model, MOI.ObjectiveSense()),
+    )
+
+    _copy_qubo_objective!(model, variable_map)
+    _copy_qubo_hamiltonian!(model)
+    _output_qubo_objective!(model)
+
+    model.compiler_settings[:qubo_fast_path] = true
+
+    return nothing
+end
+
+function _copy_qubo_variables!(model::Virtual.Model{T}) where {T}
+    source_variables = MOI.get(model.source_model, MOI.ListOfVariableIndices())
+    variable_map = sizehint!(Dict{VI,VI}(), length(source_variables))
+
+    for x in source_variables
+        y, _ = MOI.add_constrained_variable(model.target_model, MOI.ZeroOne())
+        variable_map[x] = y
+
+        v = Virtual.Variable{T}(
+            Encoding.Mirror{T}(),
+            x,
+            VI[y],
+            PBO.PBF{VI,T}(y),
+            nothing,
+        )
+
+        model.source[x] = v
+        model.target[y] = v
+        push!(model.variables, v)
     end
 
-    sense!(model, arch)
-    objective!(model, arch)
-    build!(model, arch)
+    return variable_map
+end
+
+function _qubo_term(x::VI)
+    return PBO.Term{VI}(VI[x])
+end
+
+function _qubo_term(x::VI, y::VI)
+    if x.value <= y.value
+        return PBO.Term{VI}(VI[x, y])
+    else
+        return PBO.Term{VI}(VI[y, x])
+    end
+end
+
+function _add_qubo_affine_term!(f::PBO.PBF{VI,T}, variable_map, a::SAT{T}) where {T}
+    f[_qubo_term(variable_map[a.variable])] += a.coefficient
+
+    return nothing
+end
+
+function _add_qubo_quadratic_term!(f::PBO.PBF{VI,T}, variable_map, q::SQT{T}) where {T}
+    x = variable_map[q.variable_1]
+    y = variable_map[q.variable_2]
+    c = q.coefficient
+
+    if x == y
+        # MOI stores diagonal quadratic terms with doubled coefficients for
+        # pseudo-boolean variables because x^2 == x.
+        f[_qubo_term(x)] += c / 2
+    else
+        f[_qubo_term(x, y)] += c
+    end
+
+    return nothing
+end
+
+function _copy_qubo_function!(
+    f::PBO.PBF{VI,T},
+    variable_map,
+    vi::VI,
+) where {T}
+    f[_qubo_term(variable_map[vi])] += one(T)
+
+    return nothing
+end
+
+function _copy_qubo_function!(
+    f::PBO.PBF{VI,T},
+    variable_map,
+    obj::SAF{T},
+) where {T}
+    sizehint!(f, length(obj.terms) + 1)
+
+    for a in obj.terms
+        _add_qubo_affine_term!(f, variable_map, a)
+    end
+
+    f[nothing] += obj.constant
+
+    return nothing
+end
+
+function _copy_qubo_function!(
+    f::PBO.PBF{VI,T},
+    variable_map,
+    obj::SQF{T},
+) where {T}
+    sizehint!(f, length(obj.quadratic_terms) + length(obj.affine_terms) + 1)
+
+    for q in obj.quadratic_terms
+        _add_qubo_quadratic_term!(f, variable_map, q)
+    end
+
+    for a in obj.affine_terms
+        _add_qubo_affine_term!(f, variable_map, a)
+    end
+
+    f[nothing] += obj.constant
+
+    return nothing
+end
+
+function _copy_qubo_objective!(model::Virtual.Model{T}, variable_map) where {T}
+    F = MOI.get(model.source_model, MOI.ObjectiveFunctionType())
+    f = MOI.get(model.source_model, MOI.ObjectiveFunction{F}())
+
+    _copy_qubo_function!(model.f, variable_map, f)
+
+    return nothing
+end
+
+function _copy_qubo_hamiltonian!(model::Virtual.Model)
+    Base.copy!(model.H, model.f)
+
+    return nothing
+end
+
+function _output_qubo_objective!(model::Virtual.Model{T}) where {T}
+    Q = SQT{T}[]
+    a = SAT{T}[]
+    b = zero(T)
+
+    for (ω, c) in model.H
+        if isempty(ω)
+            b += c
+        elseif length(ω) == 1
+            x, = ω
+
+            push!(a, SAT{T}(c, x))
+        elseif length(ω) == 2
+            x, y = ω
+
+            push!(Q, SQT{T}(c, x, y))
+        else
+            compilation_error!(
+                model,
+                "Fatal: QUBO fast path produced a higher-order term";
+                status="Failure in QUBO fast path",
+            )
+        end
+    end
+
+    MOI.set(model.target_model, MOI.ObjectiveFunction{SQF{T}}(), SQF{T}(Q, a, b))
 
     return nothing
 end

--- a/test/unit/compiler/compiler.jl
+++ b/test/unit/compiler/compiler.jl
@@ -1,4 +1,5 @@
 include("constraints.jl")
+include("copy.jl")
 include("error.jl")
 include("analysis.jl")
 include("variables.jl")
@@ -7,6 +8,7 @@ include("penalties.jl")
 function test_compiler()
     @testset "□ Compiler" verbose = true begin
         test_compiler_constraints()
+        test_compiler_copy()
         test_compiler_error()
         test_compiler_analysis()
         test_compiler_variables()

--- a/test/unit/compiler/copy.jl
+++ b/test/unit/compiler/copy.jl
@@ -1,0 +1,231 @@
+function _target_objective_pbf(model::ToQUBO.Optimizer{T}) where {T}
+    obj = MOI.get(model.target_model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{T}}())
+    f = PBO.PBF{VI,T}()
+
+    for q in obj.quadratic_terms
+        if q.variable_1 == q.variable_2
+            f[q.variable_1] += q.coefficient / 2
+        else
+            f[VI[q.variable_1, q.variable_2]] += q.coefficient
+        end
+    end
+
+    for a in obj.affine_terms
+        f[a.variable] += a.coefficient
+    end
+
+    f[nothing] += obj.constant
+
+    return f
+end
+
+function _compiled_uses_qubo_fast_path(model::ToQUBO.Optimizer)
+    return get(model.compiler_settings, :qubo_fast_path, false) === true
+end
+
+function _set_objective!(model, sense, f)
+    MOI.set(model, MOI.ObjectiveSense(), sense)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+
+    return nothing
+end
+
+function test_compiler_copy()
+    @testset "→ Copy" begin
+        @testset "already-QUBO quadratic objective uses direct copy" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                x, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+
+                obj = MOI.ScalarQuadraticFunction{Float64}(
+                    [
+                        MOI.ScalarQuadraticTerm(6.0, x, x),
+                        MOI.ScalarQuadraticTerm(3.0, x, y),
+                        MOI.ScalarQuadraticTerm(5.0, y, x),
+                    ],
+                    [MOI.ScalarAffineTerm(2.0, y)],
+                    7.0,
+                )
+                _set_objective!(model, MOI.MIN_SENSE, obj)
+
+                MOI.optimize!(model)
+
+                x_target = only(MOI.get(model, Attributes.VariableTargetVariables(), x))
+                y_target = only(MOI.get(model, Attributes.VariableTargetVariables(), y))
+                expected = PBO.PBF{VI,Float64}(
+                    7.0,
+                    x_target => 3.0,
+                    y_target => 2.0,
+                    VI[x_target, y_target] => 8.0,
+                )
+
+                @test _compiled_uses_qubo_fast_path(model)
+                @test MOI.get(model.target_model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
+                @test MOI.get(model.target_model, MOI.NumberOfVariables()) == 2
+                @test MOI.get(model.target_model, MOI.NumberOfConstraints{VI,MOI.ZeroOne}()) == 2
+                @test isempty(model.g)
+                @test isempty(model.h)
+                @test isempty(model.s)
+                @test MOI.get(model, Attributes.CompiledObjectiveFunction()) == expected
+                @test MOI.get(model, Attributes.CompiledHamiltonian()) == expected
+                @test _target_objective_pbf(model) == expected
+            end
+        end
+
+        @testset "affine and variable objectives are copied directly" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                x, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+
+                obj = MOI.ScalarAffineFunction{Float64}(
+                    [
+                        MOI.ScalarAffineTerm(2.0, x),
+                        MOI.ScalarAffineTerm(-1.0, y),
+                    ],
+                    4.0,
+                )
+                _set_objective!(model, MOI.MAX_SENSE, obj)
+
+                MOI.optimize!(model)
+
+                x_target = only(MOI.get(model, Attributes.VariableTargetVariables(), x))
+                y_target = only(MOI.get(model, Attributes.VariableTargetVariables(), y))
+                expected = PBO.PBF{VI,Float64}(
+                    4.0,
+                    x_target => 2.0,
+                    y_target => -1.0,
+                )
+
+                @test _compiled_uses_qubo_fast_path(model)
+                @test MOI.get(model.target_model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
+                @test MOI.get(model, Attributes.CompiledObjectiveFunction()) == expected
+                @test _target_objective_pbf(model) == expected
+            end
+
+            let model = ToQUBO.Optimizer{Float64}()
+                x, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+
+                MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+                MOI.set(model, MOI.ObjectiveFunction{VI}(), x)
+
+                MOI.optimize!(model)
+
+                x_target = only(MOI.get(model, Attributes.VariableTargetVariables(), x))
+                y_target = only(MOI.get(model, Attributes.VariableTargetVariables(), y))
+                expected = PBO.PBF{VI,Float64}(x_target => 1.0)
+
+                @test _compiled_uses_qubo_fast_path(model)
+                @test MOI.get(model, Attributes.CompiledObjectiveFunction()) == expected
+                @test MOI.get(model, Attributes.VariableTargetVariables(), x) == VI[x_target]
+                @test MOI.get(model, Attributes.VariableTargetVariables(), y) == VI[y_target]
+            end
+        end
+
+        @testset "metadata and projection stay coherent for pass-through QUBO" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                x, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+
+                obj = MOI.ScalarAffineFunction{Float64}(
+                    [MOI.ScalarAffineTerm(1.0, x)],
+                    0.0,
+                )
+                _set_objective!(model, MOI.MIN_SENSE, obj)
+
+                MOI.optimize!(model)
+
+                backend = QUBOTools.backend(model)
+                @test backend isa QUBOTools.Model
+                @test !haskey(QUBOTools.metadata(backend), "toqubo")
+
+                full_backend = QUBOTools.backend(model; full_metadata = true)
+                metadata = ToQUBO.reformulation_metadata(full_backend)
+
+                @test metadata["source"]["variable_order"] == [x.value, y.value]
+                @test metadata["target"]["num_variables"] == 2
+                @test isempty(metadata["auxiliary_variables"])
+                @test all(entry["role"] == "source" for entry in metadata["target_variables"])
+                @test ToQUBO.original_variables(full_backend) == [x.value, y.value]
+
+                state = [1, 0]
+                live_projection = ToQUBO.project_original_state(model, state)
+                backend_projection = ToQUBO.project_original_state(full_backend, state)
+
+                @test live_projection[x] == 1.0
+                @test live_projection[y] == 0.0
+                @test backend_projection[x.value] == 1.0
+                @test backend_projection[y.value] == 0.0
+            end
+        end
+
+        @testset "NPP-style quadratic fixture selects fast path" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                n = 6
+                weights = collect(1.0:n)
+                total = sum(weights)
+                x = VI[]
+
+                for _ = 1:n
+                    vi, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                    push!(x, vi)
+                end
+
+                quadratic_terms = MOI.ScalarQuadraticTerm{Float64}[]
+                affine_terms = MOI.ScalarAffineTerm{Float64}[]
+
+                for i = 1:n
+                    push!(quadratic_terms, MOI.ScalarQuadraticTerm(8 * weights[i]^2, x[i], x[i]))
+                    push!(affine_terms, MOI.ScalarAffineTerm(-4 * total * weights[i], x[i]))
+
+                    for j = (i + 1):n
+                        push!(
+                            quadratic_terms,
+                            MOI.ScalarQuadraticTerm(8 * weights[i] * weights[j], x[i], x[j]),
+                        )
+                    end
+                end
+
+                obj = MOI.ScalarQuadraticFunction{Float64}(
+                    quadratic_terms,
+                    affine_terms,
+                    total^2,
+                )
+                _set_objective!(model, MOI.MIN_SENSE, obj)
+
+                MOI.optimize!(model)
+
+                @test _compiled_uses_qubo_fast_path(model)
+                @test MOI.get(model.target_model, MOI.NumberOfVariables()) == n
+                @test isempty(model.slack)
+                @test isempty(ToQUBO.auxiliary_variables(model))
+                @test QUBOTools.backend(model) isa QUBOTools.Model
+            end
+        end
+
+        @testset "constrained models use normal reformulation path" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                x, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+
+                constraint = MOI.ScalarAffineFunction{Float64}(
+                    [
+                        MOI.ScalarAffineTerm(1.0, x),
+                        MOI.ScalarAffineTerm(1.0, y),
+                    ],
+                    0.0,
+                )
+                MOI.add_constraint(model, constraint, MOI.LessThan(1.0))
+                _set_objective!(model, MOI.MIN_SENSE, constraint)
+
+                MOI.optimize!(model)
+
+                @test !ToQUBO.Compiler.is_qubo(model.source_model)
+                @test !_compiled_uses_qubo_fast_path(model)
+                @test !isempty(model.g)
+            end
+        end
+    end
+
+    return nothing
+end

--- a/test/unit/compiler/copy.jl
+++ b/test/unit/compiler/copy.jl
@@ -225,6 +225,46 @@ function test_compiler_copy()
                 @test !isempty(model.g)
             end
         end
+
+        @testset "non-binary domain models use normal reformulation path" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                x, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                y = MOI.add_variable(model)
+                MOI.add_constraint(model, y, MOI.Integer())
+                MOI.add_constraint(model, y, MOI.Interval(0.0, 3.0))
+
+                obj = MOI.ScalarQuadraticFunction{Float64}(
+                    [MOI.ScalarQuadraticTerm(2.0, x, y)],
+                    [
+                        MOI.ScalarAffineTerm(1.0, x),
+                        MOI.ScalarAffineTerm(3.0, y),
+                    ],
+                    4.0,
+                )
+                _set_objective!(model, MOI.MIN_SENSE, obj)
+
+                MOI.optimize!(model)
+
+                x_target = only(MOI.get(model, Attributes.VariableTargetVariables(), x))
+                y_targets = MOI.get(model, Attributes.VariableTargetVariables(), y)
+                state = zeros(Int, MOI.get(model.target_model, MOI.NumberOfVariables()))
+                state[x_target.value] = 1
+
+                for yi in y_targets
+                    state[yi.value] = 1
+                end
+
+                projected = ToQUBO.project_original_state(model, state)
+
+                @test !ToQUBO.Compiler.is_qubo(model.source_model)
+                @test !_compiled_uses_qubo_fast_path(model)
+                @test MOI.get(model.target_model, MOI.NumberOfVariables()) == 3
+                @test length(y_targets) == 2
+                @test projected[x] == 1.0
+                @test projected[y] == 3.0
+                @test QUBOTools.backend(model) isa QUBOTools.Model
+            end
+        end
     end
 
     return nothing


### PR DESCRIPTION
Summary

- Added a direct `Compiler.copy!` path for source models that already satisfy `is_qubo(source_model)`.
- Copies binary variables, objective sense, and `VariableIndex`/affine/quadratic objectives directly into the target QUBO model.
- Preserves mirror-style virtual metadata, compiled objective, compiled Hamiltonian, backend metadata, and solution projection behavior without running constraint, penalty, quadratization, or generic build machinery.
- Added compiler tests for quadratic, affine, and single-variable objectives, min/max sense, metadata/projection, an NPP-style fixture, and constrained-model fallback.

Tests

- `julia --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`
  - Passed: 1408/1408 tests.
- Local warmed NPP-style timing probe, 1000 binary variables, same machine:
  - `origin/main` compilation time: `0.697745332s`
  - this branch compilation time: `0.305040407s`
  - this branch marker: `fast_path=true`
  - target variables: `1000`

Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `271e1a0`
- Stacked status: not stacked; branch was created directly from current `origin/main`
- Prerequisite PRs: none

Closes #168
