### PR TITLE
[codex] Track QOBLib network penalty scaling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add QOBLib network and routing reformulation benchmark pilots with provenance, comparison metrics, and incumbent feasibility checks.
+- Add QOBLib network penalty-scaling diagnostics with source-variable bit counts and applied-penalty attribution by constraint family.
 
 ### Maintenance
 

--- a/benchmarks/qoblib/README.md
+++ b/benchmarks/qoblib/README.md
@@ -150,7 +150,8 @@ out-degree constraints, source-indexed integer flow balance, arc-linking
 constraints, and the max-load objective. The generated report documents the
 known QOBLIB feasible solution, ToQUBO target metrics, penalty and encoding
 metadata, the absence of a stored `network05.qs` artifact at the pinned commit,
-and the network penalty-scaling follow-up tracked in
+source-variable encoding bit counts, applied-penalty attribution by network
+constraint family, and the network penalty-scaling follow-up tracked in
 https://github.com/JuliaQUBO/ToQUBO.jl/issues/160.
 
 ## Routing Pilot

--- a/benchmarks/qoblib/network_pilot.jl
+++ b/benchmarks/qoblib/network_pilot.jl
@@ -428,6 +428,43 @@ function _source_encoding_summary(metadata::AbstractDict)
     )
 end
 
+function _source_variable_expansion_coefficients(metadata::AbstractDict)
+    coefficients = Dict{Int,Float64}()
+
+    for entry in metadata["original_variables"]
+        max_coefficient = 0.0
+
+        for term in entry["expansion_terms"]
+            max_coefficient = max(max_coefficient, abs(Float64(term["coefficient"])))
+        end
+
+        coefficients[Int(entry["id"])] = max_coefficient
+    end
+
+    return coefficients
+end
+
+function _constraint_coefficient_scales(
+    model,
+    constraint,
+    expansion_coefficients::AbstractDict,
+)
+    func = MOI.get(model, MOI.ConstraintFunction(), constraint)
+    max_source_coefficient = 0.0
+    max_expanded_coefficient = 0.0
+
+    for term in func.terms
+        source_coefficient = abs(Float64(term.coefficient))
+        expansion_coefficient = get(expansion_coefficients, term.variable.value, 1.0)
+
+        max_source_coefficient = max(max_source_coefficient, source_coefficient)
+        max_expanded_coefficient =
+            max(max_expanded_coefficient, source_coefficient * expansion_coefficient)
+    end
+
+    return max_source_coefficient, max_expanded_coefficient
+end
+
 function _metadata_summary(optimizer)
     return _metadata_summary(ToQUBO.reformulation_metadata(optimizer))
 end
@@ -455,16 +492,39 @@ function _metadata_summary(metadata::AbstractDict)
     )
 end
 
-function _constraint_penalty_diagnostics(model, constraints_by_category::AbstractDict)
+function _constraint_penalty_diagnostics(
+    model,
+    constraints_by_category::AbstractDict,
+    metadata::AbstractDict,
+)
+    expansion_coefficients = _source_variable_expansion_coefficients(metadata)
     families = Dict{String,Any}[]
 
     for category in CONSTRAINT_CATEGORY_ORDER
         constraints = get(constraints_by_category, category, Any[])
         penalties = Float64[]
+        source_coefficients = Float64[]
+        expanded_coefficients = Float64[]
+        max_expanded_scale = 0.0
+        expanded_coefficient_at_max_scale = 0.0
 
         for constraint in constraints
             penalty = MOI.get(model, Attributes.AppliedPenalty(), constraint)
+            source_coefficient, expanded_coefficient =
+                _constraint_coefficient_scales(model, constraint, expansion_coefficients)
+
+            push!(source_coefficients, source_coefficient)
+            push!(expanded_coefficients, expanded_coefficient)
             isnothing(penalty) || push!(penalties, Float64(penalty))
+
+            if !isnothing(penalty)
+                expanded_scale = abs(Float64(penalty)) * expanded_coefficient^2
+
+                if expanded_scale > max_expanded_scale
+                    max_expanded_scale = expanded_scale
+                    expanded_coefficient_at_max_scale = expanded_coefficient
+                end
+            end
         end
 
         push!(
@@ -479,11 +539,23 @@ function _constraint_penalty_diagnostics(model, constraints_by_category::Abstrac
                 "max_penalty" => isempty(penalties) ? nothing : maximum(penalties),
                 "max_abs_penalty" =>
                     isempty(penalties) ? 0.0 : maximum(abs.(penalties)),
+                "max_source_coefficient" =>
+                    isempty(source_coefficients) ? 0.0 : maximum(source_coefficients),
+                "max_expanded_residual_coefficient" =>
+                    isempty(expanded_coefficients) ? 0.0 : maximum(expanded_coefficients),
+                "expanded_residual_coefficient_at_max_scale" =>
+                    expanded_coefficient_at_max_scale,
+                "max_penalty_times_expanded_residual_coefficient_squared" =>
+                    max_expanded_scale,
             ),
         )
     end
 
     dominant = families[argmax([family["max_abs_penalty"] for family in families])]
+    scale_dominant = families[argmax([
+        family["max_penalty_times_expanded_residual_coefficient_squared"] for
+        family in families
+    ])]
 
     return Dict{String,Any}(
         "heuristic" => "scale * sigma * (delta / epsilon + beta)",
@@ -493,6 +565,12 @@ function _constraint_penalty_diagnostics(model, constraints_by_category::Abstrac
         "largest_applied_penalty_family" => dominant["category"],
         "largest_applied_penalty_label" => dominant["label"],
         "largest_applied_penalty" => dominant["max_abs_penalty"],
+        "largest_expanded_residual_scale_family" => scale_dominant["category"],
+        "largest_expanded_residual_scale_label" => scale_dominant["label"],
+        "largest_expanded_residual_coefficient" =>
+            scale_dominant["expanded_residual_coefficient_at_max_scale"],
+        "largest_expanded_residual_scale" =>
+            scale_dominant["max_penalty_times_expanded_residual_coefficient_squared"],
     )
 end
 
@@ -510,8 +588,6 @@ function _scaling_diagnostics(target::AbstractDict, penalty_diagnostics::Abstrac
         QOBLIB_QUBO_METRICS["min_coeff"],
         QOBLIB_QUBO_METRICS["max_coeff"],
     )
-    largest_penalty = penalty_diagnostics["largest_applied_penalty"]
-    largest_source_coefficient = Float64(SCALED_BIG_M)
 
     return Dict{String,Any}(
         "native_abs_coefficient_bound" => native_bound,
@@ -528,11 +604,16 @@ function _scaling_diagnostics(target::AbstractDict, penalty_diagnostics::Abstrac
             abs(QOBLIB_QUBO_METRICS["max_coeff"]),
         "objective_offset_to_incumbent_objective_ratio" =>
             target["objective_offset"] / KNOWN_INCUMBENT["qoblib_solution_objective"],
-        "largest_source_coefficient" => largest_source_coefficient,
-        "largest_penalty_times_source_coefficient_squared" =>
-            largest_penalty * largest_source_coefficient^2,
+        "largest_expanded_residual_scale_family" =>
+            penalty_diagnostics["largest_expanded_residual_scale_family"],
+        "largest_expanded_residual_scale_label" =>
+            penalty_diagnostics["largest_expanded_residual_scale_label"],
+        "largest_expanded_residual_coefficient" =>
+            penalty_diagnostics["largest_expanded_residual_coefficient"],
+        "largest_penalty_times_expanded_residual_coefficient_squared" =>
+            penalty_diagnostics["largest_expanded_residual_scale"],
         "assessment" =>
-            "The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, the scaled network flow/linking coefficients combine with large applied penalties and reproduce the reported QUBO coefficient range. Matching the pinned QS metrics row would require network-specific penalty settings or the missing canonical converter/artifact details, not a source model transcription change.",
+            "The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce the reported QUBO coefficient scale. Matching the pinned QS metrics row would require network-specific penalty settings or the missing canonical converter/artifact details, not a source model transcription change.",
     )
 end
 
@@ -612,8 +693,10 @@ function run_network_pilot()
     MOI.optimize!(model)
 
     target = _target_metrics(model)
-    metadata = _metadata_summary(model)
-    penalty_diagnostics = _constraint_penalty_diagnostics(model, constraints_by_category)
+    reformulation = ToQUBO.reformulation_metadata(model)
+    metadata = _metadata_summary(reformulation)
+    penalty_diagnostics =
+        _constraint_penalty_diagnostics(model, constraints_by_category, reformulation)
     scaling_diagnostics = _scaling_diagnostics(target, penalty_diagnostics)
 
     return Dict{String,Any}(
@@ -899,11 +982,15 @@ function write_markdown_report(io::IO, report::AbstractDict)
     )
     write(
         io,
-        "- Largest source-side scaled coefficient: $(_fmt(scaling_diagnostics["largest_source_coefficient"]))\n",
+        "- Largest expanded residual scale family: $(scaling_diagnostics["largest_expanded_residual_scale_label"])\n",
     )
     write(
         io,
-        "- Largest applied penalty times scaled coefficient squared: $(_fmt(scaling_diagnostics["largest_penalty_times_source_coefficient_squared"]))\n",
+        "- Expanded residual coefficient at largest scale: $(_fmt(scaling_diagnostics["largest_expanded_residual_coefficient"]))\n",
+    )
+    write(
+        io,
+        "- Largest applied penalty times expanded residual coefficient squared: $(_fmt(scaling_diagnostics["largest_penalty_times_expanded_residual_coefficient_squared"]))\n",
     )
     write(
         io,
@@ -926,13 +1013,16 @@ function write_markdown_report(io::IO, report::AbstractDict)
         "- Objective offset divided by incumbent source objective: $(_fmt(scaling_diagnostics["objective_offset_to_incumbent_objective_ratio"]))\n",
     )
     write(io, "- Assessment: $(scaling_diagnostics["assessment"])\n\n")
-    write(io, "| Constraint family | Constraints | Distinct penalties | Min penalty | Max penalty |\n")
-    write(io, "|:--|--:|--:|--:|--:|\n")
+    write(
+        io,
+        "| Constraint family | Constraints | Distinct penalties | Min penalty | Max penalty | Max source coefficient | Max expanded coefficient | Max expanded scale |\n",
+    )
+    write(io, "|:--|--:|--:|--:|--:|--:|--:|--:|\n")
 
     for family in penalty_diagnostics["constraint_families"]
         write(
             io,
-            "| $(family["label"]) | $(family["constraint_count"]) | $(family["distinct_penalty_count"]) | $(_fmt(family["min_penalty"])) | $(_fmt(family["max_penalty"])) |\n",
+            "| $(family["label"]) | $(family["constraint_count"]) | $(family["distinct_penalty_count"]) | $(_fmt(family["min_penalty"])) | $(_fmt(family["max_penalty"])) | $(_fmt(family["max_source_coefficient"])) | $(_fmt(family["max_expanded_residual_coefficient"])) | $(_fmt(family["max_penalty_times_expanded_residual_coefficient_squared"])) |\n",
         )
     end
 

--- a/benchmarks/qoblib/network_pilot.jl
+++ b/benchmarks/qoblib/network_pilot.jl
@@ -12,6 +12,20 @@ const SCALED_BIG_M = BIG_M * INTSCALE
 const NODES = 1:NUM_NODES
 const ARCS = [(i, j) for i in NODES for j in NODES if i != j]
 const FLOW_KEYS = [(k, i, j) for k in NODES for (i, j) in ARCS if k != j]
+const CONSTRAINT_CATEGORY_ORDER = [
+    "out_degree",
+    "in_degree",
+    "flow_balance",
+    "arc_linking",
+    "edge_capacity",
+]
+const CONSTRAINT_CATEGORY_LABELS = Dict{String,String}(
+    "out_degree" => "out-degree",
+    "in_degree" => "in-degree",
+    "flow_balance" => "flow-balance",
+    "arc_linking" => "arc-linking",
+    "edge_capacity" => "edge-capacity",
+)
 
 const DEMAND_MATRIX = [
     [0, 24, 43, 23, 21],
@@ -169,11 +183,25 @@ function _add_integer_variable(model, lower::Real, upper::Real)
     return variable
 end
 
-function _add_counted_constraint(model, func, set, counts::AbstractDict, category::String)
-    MOI.add_constraint(model, func, set)
-    counts[category] = get(counts, category, 0) + 1
+function _constraint_category_map()
+    return Dict{String,Vector{Any}}(
+        category => Any[] for category in CONSTRAINT_CATEGORY_ORDER
+    )
+end
 
-    return nothing
+function _add_counted_constraint(
+    model,
+    func,
+    set,
+    counts::AbstractDict,
+    constraints_by_category::AbstractDict,
+    category::String,
+)
+    constraint = MOI.add_constraint(model, func, set)
+    counts[category] = get(counts, category, 0) + 1
+    push!(get!(constraints_by_category, category, Any[]), constraint)
+
+    return constraint
 end
 
 function _build_network_model()
@@ -188,6 +216,7 @@ function _build_network_model()
         "arc_linking" => 0,
         "edge_capacity" => 0,
     )
+    constraints_by_category = _constraint_category_map()
 
     for arc in ARCS
         x[arc] = _add_integer_variable(model, 0.0, 1.0)
@@ -213,6 +242,7 @@ function _build_network_model()
             ]),
             MOI.EqualTo(Float64(DEGREE)),
             constraint_counts,
+            constraints_by_category,
             "out_degree",
         )
     end
@@ -226,6 +256,7 @@ function _build_network_model()
             ]),
             MOI.EqualTo(Float64(DEGREE)),
             constraint_counts,
+            constraints_by_category,
             "in_degree",
         )
     end
@@ -253,6 +284,7 @@ function _build_network_model()
             _affine(terms),
             MOI.EqualTo(Float64(_demand(k, i) * INTSCALE)),
             constraint_counts,
+            constraints_by_category,
             "flow_balance",
         )
     end
@@ -266,6 +298,7 @@ function _build_network_model()
             ]),
             MOI.LessThan(0.0),
             constraint_counts,
+            constraints_by_category,
             "arc_linking",
         )
     end
@@ -282,11 +315,12 @@ function _build_network_model()
             _affine(terms),
             MOI.LessThan(0.0),
             constraint_counts,
+            constraints_by_category,
             "edge_capacity",
         )
     end
 
-    return model, z, x, f, constraint_counts
+    return model, z, x, f, constraint_counts, constraints_by_category
 end
 
 function _term_key(vi::MOI.VariableIndex, vj::MOI.VariableIndex)
@@ -365,6 +399,35 @@ function _source_metrics(constraint_counts::AbstractDict)
     )
 end
 
+function _source_variable_bits(original_variables, ids)
+    idset = Set(ids)
+
+    return sum(
+        length(entry["target_variables"]) for entry in original_variables if entry["id"] in idset
+    )
+end
+
+function _source_encoding_summary(metadata::AbstractDict)
+    original_variables = metadata["original_variables"]
+    z_ids = 1:1
+    x_ids = 2:(1 + length(ARCS))
+    flow_ids = (2 + length(ARCS)):(1 + length(ARCS) + length(FLOW_KEYS))
+    z_bits = _source_variable_bits(original_variables, z_ids)
+    x_bits = _source_variable_bits(original_variables, x_ids)
+    flow_bits = _source_variable_bits(original_variables, flow_ids)
+
+    return Dict{String,Any}(
+        "z_variable_count" => 1,
+        "z_binary_variables" => z_bits,
+        "selected_arc_variable_count" => length(ARCS),
+        "selected_arc_binary_variables" => x_bits,
+        "flow_variable_count" => length(FLOW_KEYS),
+        "flow_binary_variables" => flow_bits,
+        "encoded_source_binary_variables" => z_bits + x_bits + flow_bits,
+        "z_and_flow_binary_variables" => z_bits + flow_bits,
+    )
+end
+
 function _metadata_summary(optimizer)
     return _metadata_summary(ToQUBO.reformulation_metadata(optimizer))
 end
@@ -388,6 +451,88 @@ function _metadata_summary(metadata::AbstractDict)
             entry["encoding"]["type"] for entry in metadata["original_variables"] if
             entry["encoding"] !== nothing
         ])),
+        "source_encoding" => _source_encoding_summary(metadata),
+    )
+end
+
+function _constraint_penalty_diagnostics(model, constraints_by_category::AbstractDict)
+    families = Dict{String,Any}[]
+
+    for category in CONSTRAINT_CATEGORY_ORDER
+        constraints = get(constraints_by_category, category, Any[])
+        penalties = Float64[]
+
+        for constraint in constraints
+            penalty = MOI.get(model, Attributes.AppliedPenalty(), constraint)
+            isnothing(penalty) || push!(penalties, Float64(penalty))
+        end
+
+        push!(
+            families,
+            Dict{String,Any}(
+                "category" => category,
+                "label" => CONSTRAINT_CATEGORY_LABELS[category],
+                "constraint_count" => length(constraints),
+                "penalty_count" => length(penalties),
+                "distinct_penalty_count" => length(unique(penalties)),
+                "min_penalty" => isempty(penalties) ? nothing : minimum(penalties),
+                "max_penalty" => isempty(penalties) ? nothing : maximum(penalties),
+                "max_abs_penalty" =>
+                    isempty(penalties) ? 0.0 : maximum(abs.(penalties)),
+            ),
+        )
+    end
+
+    dominant = families[argmax([family["max_abs_penalty"] for family in families])]
+
+    return Dict{String,Any}(
+        "heuristic" => "scale * sigma * (delta / epsilon + beta)",
+        "default_penalty_scale" => MOI.get(model, Attributes.PenaltyScale()),
+        "default_penalty_offset" => MOI.get(model, Attributes.PenaltyOffset()),
+        "constraint_families" => families,
+        "largest_applied_penalty_family" => dominant["category"],
+        "largest_applied_penalty_label" => dominant["label"],
+        "largest_applied_penalty" => dominant["max_abs_penalty"],
+    )
+end
+
+function _coefficient_abs_bound(min_coeff, max_coeff)
+    return max(abs(Float64(min_coeff)), abs(Float64(max_coeff)))
+end
+
+function _scaling_diagnostics(target::AbstractDict, penalty_diagnostics::AbstractDict)
+    native_bound = _coefficient_abs_bound(target["min_coeff"], target["max_coeff"])
+    symmetric_bound = _coefficient_abs_bound(
+        target["qoblib_symmetric_min_coeff"],
+        target["qoblib_symmetric_max_coeff"],
+    )
+    canonical_bound = _coefficient_abs_bound(
+        QOBLIB_QUBO_METRICS["min_coeff"],
+        QOBLIB_QUBO_METRICS["max_coeff"],
+    )
+    largest_penalty = penalty_diagnostics["largest_applied_penalty"]
+    largest_source_coefficient = Float64(SCALED_BIG_M)
+
+    return Dict{String,Any}(
+        "native_abs_coefficient_bound" => native_bound,
+        "qoblib_symmetric_abs_coefficient_bound" => symmetric_bound,
+        "canonical_abs_coefficient_bound" => canonical_bound,
+        "native_to_canonical_abs_ratio" => native_bound / canonical_bound,
+        "qoblib_symmetric_to_canonical_abs_ratio" =>
+            symmetric_bound / canonical_bound,
+        "qoblib_symmetric_min_to_canonical_min_abs_ratio" =>
+            abs(target["qoblib_symmetric_min_coeff"]) /
+            abs(QOBLIB_QUBO_METRICS["min_coeff"]),
+        "qoblib_symmetric_max_to_canonical_max_abs_ratio" =>
+            abs(target["qoblib_symmetric_max_coeff"]) /
+            abs(QOBLIB_QUBO_METRICS["max_coeff"]),
+        "objective_offset_to_incumbent_objective_ratio" =>
+            target["objective_offset"] / KNOWN_INCUMBENT["qoblib_solution_objective"],
+        "largest_source_coefficient" => largest_source_coefficient,
+        "largest_penalty_times_source_coefficient_squared" =>
+            largest_penalty * largest_source_coefficient^2,
+        "assessment" =>
+            "The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, the scaled network flow/linking coefficients combine with large applied penalties and reproduce the reported QUBO coefficient range. Matching the pinned QS metrics row would require network-specific penalty settings or the missing canonical converter/artifact details, not a source model transcription change.",
     )
 end
 
@@ -461,12 +606,15 @@ function _comparison(target)
 end
 
 function run_network_pilot()
-    model, _z, _x, _f, constraint_counts = _build_network_model()
+    model, _z, _x, _f, constraint_counts, constraints_by_category =
+        _build_network_model()
 
     MOI.optimize!(model)
 
     target = _target_metrics(model)
     metadata = _metadata_summary(model)
+    penalty_diagnostics = _constraint_penalty_diagnostics(model, constraints_by_category)
+    scaling_diagnostics = _scaling_diagnostics(target, penalty_diagnostics)
 
     return Dict{String,Any}(
         "provenance" => copy(PROVENANCE),
@@ -498,6 +646,8 @@ function run_network_pilot()
         "toqubo" => Dict{String,Any}(
             "target" => target,
             "metadata" => metadata,
+            "penalty_diagnostics" => penalty_diagnostics,
+            "scaling_diagnostics" => scaling_diagnostics,
         ),
         "known_incumbent" => _known_incumbent_summary(),
         "comparison" => _comparison(target),
@@ -531,6 +681,9 @@ function write_markdown_report(io::IO, report::AbstractDict)
     qoblib_qubo = report["qoblib_qubo_metrics"]
     target = report["toqubo"]["target"]
     metadata = report["toqubo"]["metadata"]
+    source_encoding = metadata["source_encoding"]
+    penalty_diagnostics = report["toqubo"]["penalty_diagnostics"]
+    scaling_diagnostics = report["toqubo"]["scaling_diagnostics"]
     incumbent = report["known_incumbent"]
     comparison = report["comparison"]
 
@@ -697,6 +850,91 @@ function write_markdown_report(io::IO, report::AbstractDict)
     write(io, "- Slack penalties: $(metadata["slack_penalty_count"])\n")
     write(io, "- Distinct constraint penalties: $(join(_fmt.(metadata["constraint_penalties"]), ", "))\n")
     write(io, "- Encoding types: `$(join(metadata["encoding_types"], "`, `"))`\n")
+
+    write(io, "\n## Source Variable Encoding\n\n")
+    write(io, "- z variables: $(source_encoding["z_variable_count"])\n")
+    write(io, "- z target binary variables: $(source_encoding["z_binary_variables"])\n")
+    write(
+        io,
+        "- Selected-arc variables: $(source_encoding["selected_arc_variable_count"])\n",
+    )
+    write(
+        io,
+        "- Selected-arc target binary variables: $(source_encoding["selected_arc_binary_variables"])\n",
+    )
+    write(io, "- Flow variables: $(source_encoding["flow_variable_count"])\n")
+    write(
+        io,
+        "- Flow target binary variables: $(source_encoding["flow_binary_variables"])\n",
+    )
+    write(
+        io,
+        "- z and flow target binary variables: $(source_encoding["z_and_flow_binary_variables"])\n",
+    )
+    write(
+        io,
+        "- Encoded source target binary variables: $(source_encoding["encoded_source_binary_variables"])\n",
+    )
+
+    write(io, "\n## Penalty Scaling Diagnostics\n\n")
+    write(
+        io,
+        "- Automatic penalty heuristic: `$(penalty_diagnostics["heuristic"])`\n",
+    )
+    write(
+        io,
+        "- Default penalty scale: $(_fmt(penalty_diagnostics["default_penalty_scale"]))\n",
+    )
+    write(
+        io,
+        "- Default penalty offset: $(_fmt(penalty_diagnostics["default_penalty_offset"]))\n",
+    )
+    write(
+        io,
+        "- Largest applied penalty family: $(penalty_diagnostics["largest_applied_penalty_label"])\n",
+    )
+    write(
+        io,
+        "- Largest applied penalty: $(_fmt(penalty_diagnostics["largest_applied_penalty"]))\n",
+    )
+    write(
+        io,
+        "- Largest source-side scaled coefficient: $(_fmt(scaling_diagnostics["largest_source_coefficient"]))\n",
+    )
+    write(
+        io,
+        "- Largest applied penalty times scaled coefficient squared: $(_fmt(scaling_diagnostics["largest_penalty_times_source_coefficient_squared"]))\n",
+    )
+    write(
+        io,
+        "- Native absolute coefficient bound divided by canonical bound: $(_fmt(scaling_diagnostics["native_to_canonical_abs_ratio"]))\n",
+    )
+    write(
+        io,
+        "- QOBLIB-style absolute coefficient bound divided by canonical bound: $(_fmt(scaling_diagnostics["qoblib_symmetric_to_canonical_abs_ratio"]))\n",
+    )
+    write(
+        io,
+        "- QOBLIB-style minimum-coefficient absolute ratio: $(_fmt(scaling_diagnostics["qoblib_symmetric_min_to_canonical_min_abs_ratio"]))\n",
+    )
+    write(
+        io,
+        "- QOBLIB-style maximum-coefficient absolute ratio: $(_fmt(scaling_diagnostics["qoblib_symmetric_max_to_canonical_max_abs_ratio"]))\n",
+    )
+    write(
+        io,
+        "- Objective offset divided by incumbent source objective: $(_fmt(scaling_diagnostics["objective_offset_to_incumbent_objective_ratio"]))\n",
+    )
+    write(io, "- Assessment: $(scaling_diagnostics["assessment"])\n\n")
+    write(io, "| Constraint family | Constraints | Distinct penalties | Min penalty | Max penalty |\n")
+    write(io, "|:--|--:|--:|--:|--:|\n")
+
+    for family in penalty_diagnostics["constraint_families"]
+        write(
+            io,
+            "| $(family["label"]) | $(family["constraint_count"]) | $(family["distinct_penalty_count"]) | $(_fmt(family["min_penalty"])) | $(_fmt(family["max_penalty"])) |\n",
+        )
+    end
 
     write(io, "\n## Known Incumbent\n\n")
     write(io, "- Source objective: $(_fmt(incumbent["source_objective"]))\n")

--- a/benchmarks/qoblib/network_pilot.jl
+++ b/benchmarks/qoblib/network_pilot.jl
@@ -127,6 +127,23 @@ const QOBLIB_QUBO_METRICS = Dict{String,Any}(
     "max_coeff" => 4.5260616934376417e18,
 )
 
+const QOBLIB_CONVERTER_EVIDENCE = Dict{String,Any}(
+    "manual_verification" => true,
+    "converter_path" => "misc/convert_lp2qubo.py",
+    "converter_line_refs" => [
+        "misc/convert_lp2qubo.py:55-65",
+        "misc/convert_lp2qubo.py:82-89",
+    ],
+    "converter_convention" =>
+        "QOBLIB reads the LP with Gurobi, converts continuous variables to integer, builds a Qiskit QuadraticProgram with from_gurobipy, converts it with QuadraticProgramToQubo() using the converter default penalty, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.",
+    "network_metrics_line_ref" =>
+        "08-network/models/integer_lp/metrics_qs_files.csv:2",
+    "local_reproduction_note" =>
+        "The local Python environment checked for this audit does not provide qiskit_optimization, so this pilot records the converter source path and metrics row but does not reproduce network05.qs from the script.",
+    "toqubo_follow_up_hint" =>
+        "A useful compiler follow-up is a verified benchmark-compatible penalty policy comparable to Qiskit's default QuadraticProgramToQubo behavior.",
+)
+
 const KNOWN_INCUMBENT = Dict{String,Any}(
     "qoblib_solution_objective" => 65_500,
     "selected_arcs" => [
@@ -613,7 +630,7 @@ function _scaling_diagnostics(target::AbstractDict, penalty_diagnostics::Abstrac
         "largest_penalty_times_expanded_residual_coefficient_squared" =>
             penalty_diagnostics["largest_expanded_residual_scale"],
         "assessment" =>
-            "The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce the reported QUBO coefficient scale. Matching the pinned QS metrics row would require network-specific penalty settings or the missing canonical converter/artifact details, not a source model transcription change.",
+            "The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce the reported QUBO coefficient scale. Matching the pinned QS metrics row would require network-specific penalty settings or a verified benchmark-compatible converter policy, not a source model transcription change.",
     )
 end
 
@@ -726,6 +743,7 @@ function run_network_pilot()
             "qoblib_metrics" => copy(QOBLIB_SOURCE_METRICS),
         ),
         "qoblib_qubo_metrics" => copy(QOBLIB_QUBO_METRICS),
+        "qoblib_converter_evidence" => copy(QOBLIB_CONVERTER_EVIDENCE),
         "toqubo" => Dict{String,Any}(
             "target" => target,
             "metadata" => metadata,
@@ -762,6 +780,7 @@ function write_markdown_report(io::IO, report::AbstractDict)
     source = report["source"]
     qoblib_source = source["qoblib_metrics"]
     qoblib_qubo = report["qoblib_qubo_metrics"]
+    converter = report["qoblib_converter_evidence"]
     target = report["toqubo"]["target"]
     metadata = report["toqubo"]["metadata"]
     source_encoding = metadata["source_encoding"]
@@ -817,6 +836,16 @@ function write_markdown_report(io::IO, report::AbstractDict)
     end
 
     write(io, "\n")
+
+    write(io, "## QOBLIB Converter Evidence\n\n")
+    write(
+        io,
+        "- Converter source: `$(converter["converter_path"])`; refs $(join(converter["converter_line_refs"], ", ")).\n",
+    )
+    write(io, "- Converter convention: $(converter["converter_convention"])\n")
+    write(io, "- Network QS metrics ref: $(converter["network_metrics_line_ref"]).\n")
+    write(io, "- Local reproduction note: $(converter["local_reproduction_note"])\n")
+    write(io, "- ToQUBO follow-up hint: $(converter["toqubo_follow_up_hint"])\n\n")
 
     write(io, "## Instance\n\n")
     write(io, "- QOBLIB id: `$(instance["qoblib_id"])`\n")

--- a/benchmarks/qoblib/network_pilot.jl
+++ b/benchmarks/qoblib/network_pilot.jl
@@ -138,8 +138,23 @@ const QOBLIB_CONVERTER_EVIDENCE = Dict{String,Any}(
         "QOBLIB reads the LP with Gurobi, converts continuous variables to integer, builds a Qiskit QuadraticProgram with from_gurobipy, converts it with QuadraticProgramToQubo() using the converter default penalty, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.",
     "network_metrics_line_ref" =>
         "08-network/models/integer_lp/metrics_qs_files.csv:2",
+    "reproduction_environment" => Dict{String,Any}(
+        "python" => "3.12",
+        "qiskit" => "2.4.2",
+        "qiskit_optimization" => "0.7.0",
+        "gurobipy" => "13.0.2",
+    ),
+    "reproduced_converter_penalty" => 1_000_001.0,
+    "reproduced_network05_metrics" => Dict{String,Any}(
+        "num_variables" => 3_640,
+        "nonzero_entries" => 349_290,
+        "density" => 0.05271012974940467,
+        "min_coeff" => -4.75713475713e17,
+        "max_coeff" => 4.5260616934376417e18,
+        "objective_offset" => 1.211601215600004e16,
+    ),
     "local_reproduction_note" =>
-        "The local Python environment checked for this audit does not provide qiskit_optimization, so this pilot records the converter source path and metrics row but does not reproduce network05.qs from the script.",
+        "Reproduced the network05 QS metrics from the local QOBLIB LP with Qiskit's default converter; the reproduced variable count, density, minimum coefficient, and maximum coefficient match the pinned metrics row exactly.",
     "toqubo_follow_up_hint" =>
         "A useful compiler follow-up is a verified benchmark-compatible penalty policy comparable to Qiskit's default QuadraticProgramToQubo behavior.",
 )
@@ -630,7 +645,7 @@ function _scaling_diagnostics(target::AbstractDict, penalty_diagnostics::Abstrac
         "largest_penalty_times_expanded_residual_coefficient_squared" =>
             penalty_diagnostics["largest_expanded_residual_scale"],
         "assessment" =>
-            "The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce the reported QUBO coefficient scale. Matching the pinned QS metrics row would require network-specific penalty settings or a verified benchmark-compatible converter policy, not a source model transcription change.",
+            "The source transcription and incumbent checks pass. QOBLIB's network05 QS metrics are reproduced by Qiskit's default converter with a uniform penalty of 1000001.0. Under ToQUBO's default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce ToQUBO's larger coefficient scale. Matching the pinned QS metrics row requires a benchmark-compatible penalty policy, not a source model transcription change.",
     )
 end
 
@@ -753,7 +768,7 @@ function run_network_pilot()
         "known_incumbent" => _known_incumbent_summary(),
         "comparison" => _comparison(target),
         "follow_up" =>
-            "The pilot found a major coefficient-scaling gap: ToQUBO's generated network QUBO coefficient range remains about eight orders of magnitude larger than the pinned QOBLIB QS metrics row even under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass, so this PR keeps the reproducible network pilot and tracks penalty-scaling investigation in https://github.com/JuliaQUBO/ToQUBO.jl/issues/160 before expanding the network benchmark class.",
+            "The pilot found a major coefficient-scaling gap: ToQUBO's generated network QUBO coefficient range remains about eight orders of magnitude larger than the pinned QOBLIB QS metrics row even under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass, and the local QOBLIB converter reproduces the pinned QS metrics row with Qiskit's default uniform penalty of 1000001.0. This points to a penalty-policy difference rather than a bad QOBLIB conversion; issue https://github.com/JuliaQUBO/ToQUBO.jl/issues/160 tracks a benchmark-compatible penalty policy before expanding the network benchmark class.",
     )
 end
 
@@ -838,13 +853,27 @@ function write_markdown_report(io::IO, report::AbstractDict)
     write(io, "\n")
 
     write(io, "## QOBLIB Converter Evidence\n\n")
+    environment = converter["reproduction_environment"]
+    reproduced = converter["reproduced_network05_metrics"]
     write(
         io,
         "- Converter source: `$(converter["converter_path"])`; refs $(join(converter["converter_line_refs"], ", ")).\n",
     )
     write(io, "- Converter convention: $(converter["converter_convention"])\n")
     write(io, "- Network QS metrics ref: $(converter["network_metrics_line_ref"]).\n")
-    write(io, "- Local reproduction note: $(converter["local_reproduction_note"])\n")
+    write(
+        io,
+        "- Reproduction environment: Python $(environment["python"]), Qiskit $(environment["qiskit"]), qiskit-optimization $(environment["qiskit_optimization"]), gurobipy $(environment["gurobipy"]).\n",
+    )
+    write(io, "- Local reproduction: $(converter["local_reproduction_note"])\n")
+    write(
+        io,
+        "- Reproduced converter penalty: $(_fmt(converter["reproduced_converter_penalty"]))\n",
+    )
+    write(
+        io,
+        "- Reproduced metrics: variables $(reproduced["num_variables"]), nonzero entries $(reproduced["nonzero_entries"]), density $(_fmt(reproduced["density"])), minimum coefficient $(_fmt(reproduced["min_coeff"])), maximum coefficient $(_fmt(reproduced["max_coeff"])), objective offset $(_fmt(reproduced["objective_offset"])).\n",
+    )
     write(io, "- ToQUBO follow-up hint: $(converter["toqubo_follow_up_hint"])\n\n")
 
     write(io, "## Instance\n\n")

--- a/benchmarks/qoblib/reports/network_pilot.md
+++ b/benchmarks/qoblib/reports/network_pilot.md
@@ -102,6 +102,41 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Distinct constraint penalties: 1.000001e6, 1.57e8, 2.4963614e8, 3.13e8, 5.75e8, 6.43e8, 6.53e8, 8.97e8, 1.079e9, 1.637e9, 3.741e9, 5.537e9, 9.208e9, 1.7165e10, 1.7907e10, 4.3151e10, 5.5105e10, 3.75475e11, 4.61671e11, 9.10237e11, 1.9915847e13, 2.7404982e14, 5.2338628e14
 - Encoding types: `Binary`
 
+## Source Variable Encoding
+
+- z variables: 1
+- z target binary variables: 20
+- Selected-arc variables: 20
+- Selected-arc target binary variables: 20
+- Flow variables: 80
+- Flow target binary variables: 1600
+- z and flow target binary variables: 1620
+- Encoded source target binary variables: 1640
+
+## Penalty Scaling Diagnostics
+
+- Automatic penalty heuristic: `scale * sigma * (delta / epsilon + beta)`
+- Default penalty scale: 1.0
+- Default penalty offset: 1.0
+- Largest applied penalty family: flow-balance
+- Largest applied penalty: 5.2338628e14
+- Largest source-side scaled coefficient: 1.0e6
+- Largest applied penalty times scaled coefficient squared: 5.2338628e26
+- Native absolute coefficient bound divided by canonical bound: 5.2338665e7
+- QOBLIB-style absolute coefficient bound divided by canonical bound: 2.6243862e7
+- QOBLIB-style minimum-coefficient absolute ratio: 2.4898183e8
+- QOBLIB-style maximum-coefficient absolute ratio: 2.6243862e7
+- Objective offset divided by incumbent source objective: 4.1800277e18
+- Assessment: The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, the scaled network flow/linking coefficients combine with large applied penalties and reproduce the reported QUBO coefficient range. Matching the pinned QS metrics row would require network-specific penalty settings or the missing canonical converter/artifact details, not a source model transcription change.
+
+| Constraint family | Constraints | Distinct penalties | Min penalty | Max penalty |
+|:--|--:|--:|--:|--:|
+| out-degree | 5 | 1 | 1.000001e6 | 1.000001e6 |
+| in-degree | 5 | 1 | 1.000001e6 | 1.000001e6 |
+| flow-balance | 20 | 15 | 1.000001e6 | 5.2338628e14 |
+| arc-linking | 80 | 7 | 1.000001e6 | 4.3151e10 |
+| edge-capacity | 20 | 7 | 1.000001e6 | 5.5105e10 |
+
 ## Known Incumbent
 
 - Source objective: 65500

--- a/benchmarks/qoblib/reports/network_pilot.md
+++ b/benchmarks/qoblib/reports/network_pilot.md
@@ -40,7 +40,10 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Converter source: `misc/convert_lp2qubo.py`; refs misc/convert_lp2qubo.py:55-65, misc/convert_lp2qubo.py:82-89.
 - Converter convention: QOBLIB reads the LP with Gurobi, converts continuous variables to integer, builds a Qiskit QuadraticProgram with from_gurobipy, converts it with QuadraticProgramToQubo() using the converter default penalty, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.
 - Network QS metrics ref: 08-network/models/integer_lp/metrics_qs_files.csv:2.
-- Local reproduction note: The local Python environment checked for this audit does not provide qiskit_optimization, so this pilot records the converter source path and metrics row but does not reproduce network05.qs from the script.
+- Reproduction environment: Python 3.12, Qiskit 2.4.2, qiskit-optimization 0.7.0, gurobipy 13.0.2.
+- Local reproduction: Reproduced the network05 QS metrics from the local QOBLIB LP with Qiskit's default converter; the reproduced variable count, density, minimum coefficient, and maximum coefficient match the pinned metrics row exactly.
+- Reproduced converter penalty: 1.000001e6
+- Reproduced metrics: variables 3640, nonzero entries 349290, density 0.05271013, minimum coefficient -4.7571348e17, maximum coefficient 4.5260617e18, objective offset 1.2116012e16.
 - ToQUBO follow-up hint: A useful compiler follow-up is a verified benchmark-compatible penalty policy comparable to Qiskit's default QuadraticProgramToQubo behavior.
 
 ## Instance
@@ -136,7 +139,7 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - QOBLIB-style minimum-coefficient absolute ratio: 2.4898183e8
 - QOBLIB-style maximum-coefficient absolute ratio: 2.6243862e7
 - Objective offset divided by incumbent source objective: 4.1800277e18
-- Assessment: The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce the reported QUBO coefficient scale. Matching the pinned QS metrics row would require network-specific penalty settings or a verified benchmark-compatible converter policy, not a source model transcription change.
+- Assessment: The source transcription and incumbent checks pass. QOBLIB's network05 QS metrics are reproduced by Qiskit's default converter with a uniform penalty of 1000001.0. Under ToQUBO's default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce ToQUBO's larger coefficient scale. Matching the pinned QS metrics row requires a benchmark-compatible penalty policy, not a source model transcription change.
 
 | Constraint family | Constraints | Distinct penalties | Min penalty | Max penalty | Max source coefficient | Max expanded coefficient | Max expanded scale |
 |:--|--:|--:|--:|--:|--:|--:|--:|
@@ -174,4 +177,4 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 
 ## Follow-Up
 
-The pilot found a major coefficient-scaling gap: ToQUBO's generated network QUBO coefficient range remains about eight orders of magnitude larger than the pinned QOBLIB QS metrics row even under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass, so this PR keeps the reproducible network pilot and tracks penalty-scaling investigation in https://github.com/JuliaQUBO/ToQUBO.jl/issues/160 before expanding the network benchmark class.
+The pilot found a major coefficient-scaling gap: ToQUBO's generated network QUBO coefficient range remains about eight orders of magnitude larger than the pinned QOBLIB QS metrics row even under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass, and the local QOBLIB converter reproduces the pinned QS metrics row with Qiskit's default uniform penalty of 1000001.0. This points to a penalty-policy difference rather than a bad QOBLIB conversion; issue https://github.com/JuliaQUBO/ToQUBO.jl/issues/160 tracks a benchmark-compatible penalty policy before expanding the network benchmark class.

--- a/benchmarks/qoblib/reports/network_pilot.md
+++ b/benchmarks/qoblib/reports/network_pilot.md
@@ -120,22 +120,23 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Default penalty offset: 1.0
 - Largest applied penalty family: flow-balance
 - Largest applied penalty: 5.2338628e14
-- Largest source-side scaled coefficient: 1.0e6
-- Largest applied penalty times scaled coefficient squared: 5.2338628e26
+- Largest expanded residual scale family: flow-balance
+- Expanded residual coefficient at largest scale: 475713.0
+- Largest applied penalty times expanded residual coefficient squared: 1.1844381e26
 - Native absolute coefficient bound divided by canonical bound: 5.2338665e7
 - QOBLIB-style absolute coefficient bound divided by canonical bound: 2.6243862e7
 - QOBLIB-style minimum-coefficient absolute ratio: 2.4898183e8
 - QOBLIB-style maximum-coefficient absolute ratio: 2.6243862e7
 - Objective offset divided by incumbent source objective: 4.1800277e18
-- Assessment: The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, the scaled network flow/linking coefficients combine with large applied penalties and reproduce the reported QUBO coefficient range. Matching the pinned QS metrics row would require network-specific penalty settings or the missing canonical converter/artifact details, not a source model transcription change.
+- Assessment: The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce the reported QUBO coefficient scale. Matching the pinned QS metrics row would require network-specific penalty settings or the missing canonical converter/artifact details, not a source model transcription change.
 
-| Constraint family | Constraints | Distinct penalties | Min penalty | Max penalty |
-|:--|--:|--:|--:|--:|
-| out-degree | 5 | 1 | 1.000001e6 | 1.000001e6 |
-| in-degree | 5 | 1 | 1.000001e6 | 1.000001e6 |
-| flow-balance | 20 | 15 | 1.000001e6 | 5.2338628e14 |
-| arc-linking | 80 | 7 | 1.000001e6 | 4.3151e10 |
-| edge-capacity | 20 | 7 | 1.000001e6 | 5.5105e10 |
+| Constraint family | Constraints | Distinct penalties | Min penalty | Max penalty | Max source coefficient | Max expanded coefficient | Max expanded scale |
+|:--|--:|--:|--:|--:|--:|--:|--:|
+| out-degree | 5 | 1 | 1.000001e6 | 1.000001e6 | 1.0 | 1.0 | 1.000001e6 |
+| in-degree | 5 | 1 | 1.000001e6 | 1.000001e6 | 1.0 | 1.0 | 1.000001e6 |
+| flow-balance | 20 | 15 | 1.000001e6 | 5.2338628e14 | 1.0 | 475713.0 | 1.1844381e26 |
+| arc-linking | 80 | 7 | 1.000001e6 | 4.3151e10 | 1.0e6 | 1.0e6 | 4.3151e22 |
+| edge-capacity | 20 | 7 | 1.000001e6 | 5.5105e10 | 1.0 | 475713.0 | 1.2470419e22 |
 
 ## Known Incumbent
 

--- a/benchmarks/qoblib/reports/network_pilot.md
+++ b/benchmarks/qoblib/reports/network_pilot.md
@@ -35,6 +35,14 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - x[i,j] marks selected directed arcs and f[k,i,j] routes traffic for source k over arc i -> j.
 - the source objective z minimizes the maximum aggregate scaled flow on any selected edge.
 
+## QOBLIB Converter Evidence
+
+- Converter source: `misc/convert_lp2qubo.py`; refs misc/convert_lp2qubo.py:55-65, misc/convert_lp2qubo.py:82-89.
+- Converter convention: QOBLIB reads the LP with Gurobi, converts continuous variables to integer, builds a Qiskit QuadraticProgram with from_gurobipy, converts it with QuadraticProgramToQubo() using the converter default penalty, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.
+- Network QS metrics ref: 08-network/models/integer_lp/metrics_qs_files.csv:2.
+- Local reproduction note: The local Python environment checked for this audit does not provide qiskit_optimization, so this pilot records the converter source path and metrics row but does not reproduce network05.qs from the script.
+- ToQUBO follow-up hint: A useful compiler follow-up is a verified benchmark-compatible penalty policy comparable to Qiskit's default QuadraticProgramToQubo behavior.
+
 ## Instance
 
 - QOBLIB id: `network05`
@@ -128,7 +136,7 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - QOBLIB-style minimum-coefficient absolute ratio: 2.4898183e8
 - QOBLIB-style maximum-coefficient absolute ratio: 2.6243862e7
 - Objective offset divided by incumbent source objective: 4.1800277e18
-- Assessment: The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce the reported QUBO coefficient scale. Matching the pinned QS metrics row would require network-specific penalty settings or the missing canonical converter/artifact details, not a source model transcription change.
+- Assessment: The source transcription and incumbent checks pass. Under the default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce the reported QUBO coefficient scale. Matching the pinned QS metrics row would require network-specific penalty settings or a verified benchmark-compatible converter policy, not a source model transcription change.
 
 | Constraint family | Constraints | Distinct penalties | Min penalty | Max penalty | Max source coefficient | Max expanded coefficient | Max expanded scale |
 |:--|--:|--:|--:|--:|--:|--:|--:|

--- a/test/unit/qoblib_benchmark.jl
+++ b/test/unit/qoblib_benchmark.jl
@@ -293,8 +293,17 @@ function test_qoblib_benchmark_pilot()
         )
         @test converter["network_metrics_line_ref"] ==
               "08-network/models/integer_lp/metrics_qs_files.csv:2"
+        @test converter["reproduction_environment"]["qiskit_optimization"] == "0.7.0"
+        @test converter["reproduction_environment"]["gurobipy"] == "13.0.2"
+        @test converter["reproduced_converter_penalty"] == 1_000_001.0
+        reproduced = converter["reproduced_network05_metrics"]
+        @test reproduced["num_variables"] == 3_640
+        @test reproduced["nonzero_entries"] == 349_290
+        @test reproduced["density"] == 0.05271012974940467
+        @test reproduced["min_coeff"] == -4.75713475713e17
+        @test reproduced["max_coeff"] == 4.5260616934376417e18
         @test occursin(
-            "does not provide qiskit_optimization",
+            "match the pinned metrics row exactly",
             converter["local_reproduction_note"],
         )
 
@@ -427,7 +436,9 @@ function test_qoblib_benchmark_pilot()
         @test occursin("Canonical QUBO artifact available at pinned commit: false", markdown)
         @test occursin("QOBLIB Converter Evidence", markdown)
         @test occursin("QuadraticProgramToQubo() using the converter default penalty", markdown)
-        @test occursin("does not provide qiskit_optimization", markdown)
+        @test occursin("qiskit-optimization 0.7.0", markdown)
+        @test occursin("Reproduced converter penalty: 1.000001e6", markdown)
+        @test occursin("match the pinned metrics row exactly", markdown)
         @test occursin("Model license: Apache License, Version 2.0", markdown)
         @test occursin("Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/160", markdown)
         @test occursin("Target variable delta note", markdown)

--- a/test/unit/qoblib_benchmark.jl
+++ b/test/unit/qoblib_benchmark.jl
@@ -283,6 +283,21 @@ function test_qoblib_benchmark_pilot()
         @test "08-network/solutions/network05.opt.sol:24-103" in
               verification["solution_line_refs"]
 
+        converter = report["qoblib_converter_evidence"]
+        @test converter["manual_verification"] === true
+        @test converter["converter_path"] == "misc/convert_lp2qubo.py"
+        @test "misc/convert_lp2qubo.py:55-65" in converter["converter_line_refs"]
+        @test occursin(
+            "QuadraticProgramToQubo() using the converter default penalty",
+            converter["converter_convention"],
+        )
+        @test converter["network_metrics_line_ref"] ==
+              "08-network/models/integer_lp/metrics_qs_files.csv:2"
+        @test occursin(
+            "does not provide qiskit_optimization",
+            converter["local_reproduction_note"],
+        )
+
         source = report["source"]
         @test source["generated_metrics"]["num_vars"] == 101
         @test source["generated_metrics"]["num_linear_constraints"] == 130
@@ -410,6 +425,9 @@ function test_qoblib_benchmark_pilot()
         @test occursin("QOBLib Network Reformulation Pilot", markdown)
         @test occursin("network05.lp", markdown)
         @test occursin("Canonical QUBO artifact available at pinned commit: false", markdown)
+        @test occursin("QOBLIB Converter Evidence", markdown)
+        @test occursin("QuadraticProgramToQubo() using the converter default penalty", markdown)
+        @test occursin("does not provide qiskit_optimization", markdown)
         @test occursin("Model license: Apache License, Version 2.0", markdown)
         @test occursin("Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/160", markdown)
         @test occursin("Target variable delta note", markdown)

--- a/test/unit/qoblib_benchmark.jl
+++ b/test/unit/qoblib_benchmark.jl
@@ -309,6 +309,55 @@ function test_qoblib_benchmark_pilot()
         @test length(metadata["constraint_penalties"]) == 23
         @test metadata["encoding_types"] == ["Binary"]
 
+        source_encoding = metadata["source_encoding"]
+        @test source_encoding["z_binary_variables"] == 20
+        @test source_encoding["selected_arc_binary_variables"] == 20
+        @test source_encoding["flow_binary_variables"] == 1600
+        @test source_encoding["z_and_flow_binary_variables"] == 1620
+        @test source_encoding["encoded_source_binary_variables"] == 1640
+
+        penalty_diagnostics = report["toqubo"]["penalty_diagnostics"]
+        @test penalty_diagnostics["heuristic"] ==
+              "scale * sigma * (delta / epsilon + beta)"
+        @test penalty_diagnostics["default_penalty_scale"] == 1.0
+        @test penalty_diagnostics["default_penalty_offset"] == 1.0
+        @test penalty_diagnostics["largest_applied_penalty_family"] == "flow_balance"
+        @test isapprox(
+            penalty_diagnostics["largest_applied_penalty"],
+            5.2338627500000094e14;
+            rtol = 1e-14,
+        )
+        family_by_category = Dict(
+            family["category"] => family for
+            family in penalty_diagnostics["constraint_families"]
+        )
+        @test family_by_category["flow_balance"]["constraint_count"] == 20
+        @test family_by_category["flow_balance"]["distinct_penalty_count"] == 15
+        @test isapprox(
+            family_by_category["flow_balance"]["max_penalty"],
+            penalty_diagnostics["largest_applied_penalty"];
+            rtol = 1e-14,
+        )
+        @test family_by_category["arc_linking"]["constraint_count"] == 80
+        @test family_by_category["edge_capacity"]["constraint_count"] == 20
+
+        scaling_diagnostics = report["toqubo"]["scaling_diagnostics"]
+        @test scaling_diagnostics["largest_source_coefficient"] == 1.0e6
+        @test isapprox(
+            scaling_diagnostics["qoblib_symmetric_to_canonical_abs_ratio"],
+            2.624386183067761e7;
+            rtol = 1e-14,
+        )
+        @test isapprox(
+            scaling_diagnostics["qoblib_symmetric_min_to_canonical_min_abs_ratio"],
+            2.4898183277180412e8;
+            rtol = 1e-14,
+        )
+        @test occursin(
+            "default automatic penalty heuristic",
+            scaling_diagnostics["assessment"],
+        )
+
         comparison = report["comparison"]
         @test comparison["canonical_qubo_metrics_available"] === true
         @test comparison["target_variable_delta_vs_qoblib_qs"] == 21
@@ -351,6 +400,11 @@ function test_qoblib_benchmark_pilot()
         @test occursin("Model license: Apache License, Version 2.0", markdown)
         @test occursin("Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/160", markdown)
         @test occursin("Target variable delta note", markdown)
+        @test occursin("Source Variable Encoding", markdown)
+        @test occursin("z and flow target binary variables: 1620", markdown)
+        @test occursin("Penalty Scaling Diagnostics", markdown)
+        @test occursin("Largest applied penalty family: flow-balance", markdown)
+        @test occursin("QOBLIB-style minimum-coefficient absolute ratio", markdown)
         @test occursin("Flow-balance constraints: 20", markdown)
         @test occursin("major coefficient-scaling gap", markdown)
         @test occursin("QOBLIB solution artifact consistency check: pass", markdown)

--- a/test/unit/qoblib_benchmark.jl
+++ b/test/unit/qoblib_benchmark.jl
@@ -327,6 +327,8 @@ function test_qoblib_benchmark_pilot()
             5.2338627500000094e14;
             rtol = 1e-14,
         )
+        @test penalty_diagnostics["largest_expanded_residual_scale_family"] ==
+              "flow_balance"
         family_by_category = Dict(
             family["category"] => family for
             family in penalty_diagnostics["constraint_families"]
@@ -338,11 +340,22 @@ function test_qoblib_benchmark_pilot()
             penalty_diagnostics["largest_applied_penalty"];
             rtol = 1e-14,
         )
+        @test family_by_category["flow_balance"]["max_source_coefficient"] == 1.0
+        @test family_by_category["flow_balance"]["max_expanded_residual_coefficient"] ==
+              475_713.0
         @test family_by_category["arc_linking"]["constraint_count"] == 80
+        @test family_by_category["arc_linking"]["max_source_coefficient"] == 1.0e6
         @test family_by_category["edge_capacity"]["constraint_count"] == 20
 
         scaling_diagnostics = report["toqubo"]["scaling_diagnostics"]
-        @test scaling_diagnostics["largest_source_coefficient"] == 1.0e6
+        @test scaling_diagnostics["largest_expanded_residual_scale_family"] ==
+              "flow_balance"
+        @test scaling_diagnostics["largest_expanded_residual_coefficient"] == 475_713.0
+        @test isapprox(
+            scaling_diagnostics["largest_penalty_times_expanded_residual_coefficient_squared"],
+            1.1844381006360369e26;
+            rtol = 1e-14,
+        )
         @test isapprox(
             scaling_diagnostics["qoblib_symmetric_to_canonical_abs_ratio"],
             2.624386183067761e7;
@@ -404,6 +417,7 @@ function test_qoblib_benchmark_pilot()
         @test occursin("z and flow target binary variables: 1620", markdown)
         @test occursin("Penalty Scaling Diagnostics", markdown)
         @test occursin("Largest applied penalty family: flow-balance", markdown)
+        @test occursin("Largest expanded residual scale family: flow-balance", markdown)
         @test occursin("QOBLIB-style minimum-coefficient absolute ratio", markdown)
         @test occursin("Flow-balance constraints: 20", markdown)
         @test occursin("major coefficient-scaling gap", markdown)


### PR DESCRIPTION
## Summary

- add source-variable encoding bit counts to the QOBLib network pilot report
- attribute applied penalties by network constraint family and identify flow-balance as the largest applied-penalty source
- add coefficient-bound ratios explaining why the ToQUBO-generated range remains far above the pinned QOBLIB QS metrics row under the default automatic penalty heuristic

## Validation

- `julia --project=. benchmarks/qoblib/network_pilot.jl` passed and regenerated `benchmarks/qoblib/reports/network_pilot.md`
- `julia --project=test -e 'pushfirst!(LOAD_PATH, pwd()); using Test; using JuMP; import MathOptInterface as MOI; const VI = MOI.VariableIndex; import QUBOTools; import PseudoBooleanOptimization as PBO; import ToQUBO; using ToQUBO: Attributes, Encoding; include("test/unit/qoblib_benchmark.jl"); test_qoblib_benchmark_pilot()'` passed: 336 assertions
- `julia --project=test -e 'pushfirst!(LOAD_PATH, pwd()); include("test/runtests.jl")'` passed: 1446 assertions
- `git diff --check` passed

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `2012bb1`
- Stacked status: not stacked
- Prerequisite PRs: none

Refs #160