### PR TITLE
Add objective-range penalty policy

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 - Add QOBLib network and routing reformulation benchmark pilots with provenance, comparison metrics, and incumbent feasibility checks.
 - Add QOBLib network penalty-scaling diagnostics with source-variable bit counts and applied-penalty attribution by constraint family.
+- Add objective-range automatic penalty inference, with legacy maxgap inference available as an explicit fallback policy and diagnostic metadata.
 
 ### Maintenance
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Add QOBLib network and routing reformulation benchmark pilots with provenance, comparison metrics, and incumbent feasibility checks.
 - Add QOBLib network penalty-scaling diagnostics with source-variable bit counts and applied-penalty attribution by constraint family.
 - Add objective-range automatic penalty inference, with legacy maxgap inference available as an explicit fallback policy and diagnostic metadata.
+- Record per-inferred penalty gaps, gap sources, selected policies, and final coefficients in penalty policy metadata.
 
 ### Maintenance
 

--- a/benchmarks/qoblib/network_pilot.jl
+++ b/benchmarks/qoblib/network_pilot.jl
@@ -57,7 +57,6 @@ const PROVENANCE = Dict{String,Any}(
     "canonical_qubo_artifact_available_at_commit" => false,
     "canonical_qubo_artifact_note" =>
         "The pinned QOBLIB tree contains the network05.qs metrics row but no stored network05.qs or network05.qs.xz artifact, so this pilot compares against the metrics table row.",
-    "penalty_scaling_follow_up" => "https://github.com/JuliaQUBO/ToQUBO.jl/issues/172",
 )
 
 const UPSTREAM_VERIFICATION = Dict{String,Any}(
@@ -836,7 +835,6 @@ function write_markdown_report(io::IO, report::AbstractDict)
     write(io, "- Canonical QUBO artifact note: $(provenance["canonical_qubo_artifact_note"])\n")
     write(io, "- Model license: $(provenance["qoblib_model_license"])\n")
     write(io, "- Data license: $(provenance["qoblib_data_license"])\n")
-    write(io, "- Penalty scaling follow-up: $(provenance["penalty_scaling_follow_up"])\n")
     write(io, "- Generated collection label: $(provenance["collection"])\n\n")
 
     write(io, "## Upstream Verification\n\n")

--- a/benchmarks/qoblib/network_pilot.jl
+++ b/benchmarks/qoblib/network_pilot.jl
@@ -57,7 +57,7 @@ const PROVENANCE = Dict{String,Any}(
     "canonical_qubo_artifact_available_at_commit" => false,
     "canonical_qubo_artifact_note" =>
         "The pinned QOBLIB tree contains the network05.qs metrics row but no stored network05.qs or network05.qs.xz artifact, so this pilot compares against the metrics table row.",
-    "penalty_scaling_follow_up" => "https://github.com/JuliaQUBO/ToQUBO.jl/issues/160",
+    "penalty_scaling_follow_up" => "https://github.com/JuliaQUBO/ToQUBO.jl/issues/172",
 )
 
 const UPSTREAM_VERIFICATION = Dict{String,Any}(
@@ -530,6 +530,7 @@ function _constraint_penalty_diagnostics(
     metadata::AbstractDict,
 )
     expansion_coefficients = _source_variable_expansion_coefficients(metadata)
+    penalty_policy = metadata["penalty_policy"]
     families = Dict{String,Any}[]
 
     for category in CONSTRAINT_CATEGORY_ORDER
@@ -590,7 +591,10 @@ function _constraint_penalty_diagnostics(
     ])]
 
     return Dict{String,Any}(
-        "heuristic" => "scale * sigma * (delta / epsilon + beta)",
+        "heuristic" => "objective-range exact penalty with legacy fallback",
+        "automatic_penalty_policy" => penalty_policy["policy"],
+        "objective_range" => penalty_policy["objective_bounds"]["range"],
+        "fallback_count" => penalty_policy["fallback_count"],
         "default_penalty_scale" => MOI.get(model, Attributes.PenaltyScale()),
         "default_penalty_offset" => MOI.get(model, Attributes.PenaltyOffset()),
         "constraint_families" => families,
@@ -645,7 +649,7 @@ function _scaling_diagnostics(target::AbstractDict, penalty_diagnostics::Abstrac
         "largest_penalty_times_expanded_residual_coefficient_squared" =>
             penalty_diagnostics["largest_expanded_residual_scale"],
         "assessment" =>
-            "The source transcription and incumbent checks pass. QOBLIB's network05 QS metrics are reproduced by Qiskit's default converter with a uniform penalty of 1000001.0. Under ToQUBO's default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce ToQUBO's larger coefficient scale. Matching the pinned QS metrics row requires a benchmark-compatible penalty policy, not a source model transcription change.",
+            "The source transcription and incumbent checks pass. QOBLIB's network05 QS metrics are reproduced by Qiskit's default converter with a uniform penalty of 1000001.0. ToQUBO's objective-range exact-penalty policy now infers the same uniform applied penalty for all network constraints. The remaining coefficient gap is driven by residual expansion and encoding differences, with arc-linking dominating after the 1000000 source coefficient is expanded into the QUBO.",
     )
 end
 
@@ -768,7 +772,7 @@ function run_network_pilot()
         "known_incumbent" => _known_incumbent_summary(),
         "comparison" => _comparison(target),
         "follow_up" =>
-            "The pilot found a major coefficient-scaling gap: ToQUBO's generated network QUBO coefficient range remains about eight orders of magnitude larger than the pinned QOBLIB QS metrics row even under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass, and the local QOBLIB converter reproduces the pinned QS metrics row with Qiskit's default uniform penalty of 1000001.0. This points to a penalty-policy difference rather than a bad QOBLIB conversion; issue https://github.com/JuliaQUBO/ToQUBO.jl/issues/160 tracks a benchmark-compatible penalty policy before expanding the network benchmark class.",
+            "The objective-range exact-penalty policy tightens ToQUBO's applied network penalties from many family-dependent values up to about 5.23e14 down to the Qiskit/QOBLib-compatible uniform value 1000001.0. The source transcription and incumbent feasibility checks pass, and the local QOBLIB converter reproduces the pinned QS metrics row. The remaining coefficient-range gap is no longer caused by oversized applied penalties; it should be interpreted alongside ToQUBO's variable/slack encodings, residual expansion coefficients, and the target-variable delta before expanding the network benchmark class.",
     )
 end
 
@@ -1021,6 +1025,18 @@ function write_markdown_report(io::IO, report::AbstractDict)
     write(
         io,
         "- Automatic penalty heuristic: `$(penalty_diagnostics["heuristic"])`\n",
+    )
+    write(
+        io,
+        "- Automatic penalty policy: `$(penalty_diagnostics["automatic_penalty_policy"])`\n",
+    )
+    write(
+        io,
+        "- Objective range used for automatic penalties: $(_fmt(penalty_diagnostics["objective_range"]))\n",
+    )
+    write(
+        io,
+        "- Penalty policy fallback count: $(penalty_diagnostics["fallback_count"])\n",
     )
     write(
         io,

--- a/benchmarks/qoblib/reports/network_pilot.md
+++ b/benchmarks/qoblib/reports/network_pilot.md
@@ -19,7 +19,6 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Canonical QUBO artifact note: The pinned QOBLIB tree contains the network05.qs metrics row but no stored network05.qs or network05.qs.xz artifact, so this pilot compares against the metrics table row.
 - Model license: Apache License, Version 2.0
 - Data license: Creative Commons Attribution 4.0 International
-- Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/172
 - Generated collection label: ToQUBO-generated reformulation benchmark
 
 ## Upstream Verification

--- a/benchmarks/qoblib/reports/network_pilot.md
+++ b/benchmarks/qoblib/reports/network_pilot.md
@@ -19,7 +19,7 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Canonical QUBO artifact note: The pinned QOBLIB tree contains the network05.qs metrics row but no stored network05.qs or network05.qs.xz artifact, so this pilot compares against the metrics table row.
 - Model license: Apache License, Version 2.0
 - Data license: Creative Commons Attribution 4.0 International
-- Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/160
+- Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/172
 - Generated collection label: ToQUBO-generated reformulation benchmark
 
 ## Upstream Verification
@@ -82,11 +82,11 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 |:--|--:|--:|--:|
 | variables | 101 | 3640 | 3661 |
 | density | 0.033511043 | 0.05271013 | 0.052253736 |
-| minimum coefficient | -1.0e6 | -4.7571348e17 | -2.3688803e26 |
-| maximum coefficient | 1.0 | 4.5260617e18 | 2.3688762e26 |
-| QOBLIB-style minimum coefficient | n/a | -4.7571348e17 | -1.1844401e26 |
-| QOBLIB-style maximum coefficient | n/a | 4.5260617e18 | 1.1878134e26 |
-| objective offset | n/a | n/a | 2.7379181e23 |
+| minimum coefficient | -1.0e6 | -4.7571348e17 | -1.4184263e24 |
+| maximum coefficient | 1.0 | 4.5260617e18 | 1.8214698e24 |
+| QOBLIB-style minimum coefficient | n/a | -4.7571348e17 | -7.0921315e23 |
+| QOBLIB-style maximum coefficient | n/a | 4.5260617e18 | 1.8214698e24 |
+| objective offset | n/a | n/a | 6.113365e20 |
 | QUBO terms | n/a | n/a | 350272 |
 | quadratic terms | n/a | n/a | 346611 |
 
@@ -110,7 +110,7 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Constraint penalties: 130
 - Variable penalties: 0
 - Slack penalties: 0
-- Distinct constraint penalties: 1.000001e6, 1.57e8, 2.4963614e8, 3.13e8, 5.75e8, 6.43e8, 6.53e8, 8.97e8, 1.079e9, 1.637e9, 3.741e9, 5.537e9, 9.208e9, 1.7165e10, 1.7907e10, 4.3151e10, 5.5105e10, 3.75475e11, 4.61671e11, 9.10237e11, 1.9915847e13, 2.7404982e14, 5.2338628e14
+- Distinct constraint penalties: 1.000001e6
 - Encoding types: `Binary`
 
 ## Source Variable Encoding
@@ -126,28 +126,31 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 
 ## Penalty Scaling Diagnostics
 
-- Automatic penalty heuristic: `scale * sigma * (delta / epsilon + beta)`
+- Automatic penalty heuristic: `objective-range exact penalty with legacy fallback`
+- Automatic penalty policy: `ObjectiveRangePenalty`
+- Objective range used for automatic penalties: 1.0e6
+- Penalty policy fallback count: 0
 - Default penalty scale: 1.0
 - Default penalty offset: 1.0
-- Largest applied penalty family: flow-balance
-- Largest applied penalty: 5.2338628e14
-- Largest expanded residual scale family: flow-balance
-- Expanded residual coefficient at largest scale: 475713.0
-- Largest applied penalty times expanded residual coefficient squared: 1.1844381e26
-- Native absolute coefficient bound divided by canonical bound: 5.2338665e7
-- QOBLIB-style absolute coefficient bound divided by canonical bound: 2.6243862e7
-- QOBLIB-style minimum-coefficient absolute ratio: 2.4898183e8
-- QOBLIB-style maximum-coefficient absolute ratio: 2.6243862e7
-- Objective offset divided by incumbent source objective: 4.1800277e18
-- Assessment: The source transcription and incumbent checks pass. QOBLIB's network05 QS metrics are reproduced by Qiskit's default converter with a uniform penalty of 1000001.0. Under ToQUBO's default automatic penalty heuristic, flow-balance constraints dominate after integer flow-variable expansion; the largest applied penalty and expanded residual coefficient from that family reproduce ToQUBO's larger coefficient scale. Matching the pinned QS metrics row requires a benchmark-compatible penalty policy, not a source model transcription change.
+- Largest applied penalty family: out-degree
+- Largest applied penalty: 1.000001e6
+- Largest expanded residual scale family: arc-linking
+- Expanded residual coefficient at largest scale: 1.0e6
+- Largest applied penalty times expanded residual coefficient squared: 1.000001e18
+- Native absolute coefficient bound divided by canonical bound: 402440.34
+- QOBLIB-style absolute coefficient bound divided by canonical bound: 402440.34
+- QOBLIB-style minimum-coefficient absolute ratio: 1.490841e6
+- QOBLIB-style maximum-coefficient absolute ratio: 402440.34
+- Objective offset divided by incumbent source objective: 9.3333817e15
+- Assessment: The source transcription and incumbent checks pass. QOBLIB's network05 QS metrics are reproduced by Qiskit's default converter with a uniform penalty of 1000001.0. ToQUBO's objective-range exact-penalty policy now infers the same uniform applied penalty for all network constraints. The remaining coefficient gap is driven by residual expansion and encoding differences, with arc-linking dominating after the 1000000 source coefficient is expanded into the QUBO.
 
 | Constraint family | Constraints | Distinct penalties | Min penalty | Max penalty | Max source coefficient | Max expanded coefficient | Max expanded scale |
 |:--|--:|--:|--:|--:|--:|--:|--:|
 | out-degree | 5 | 1 | 1.000001e6 | 1.000001e6 | 1.0 | 1.0 | 1.000001e6 |
 | in-degree | 5 | 1 | 1.000001e6 | 1.000001e6 | 1.0 | 1.0 | 1.000001e6 |
-| flow-balance | 20 | 15 | 1.000001e6 | 5.2338628e14 | 1.0 | 475713.0 | 1.1844381e26 |
-| arc-linking | 80 | 7 | 1.000001e6 | 4.3151e10 | 1.0e6 | 1.0e6 | 4.3151e22 |
-| edge-capacity | 20 | 7 | 1.000001e6 | 5.5105e10 | 1.0 | 475713.0 | 1.2470419e22 |
+| flow-balance | 20 | 1 | 1.000001e6 | 1.000001e6 | 1.0 | 475713.0 | 2.2630308e17 |
+| arc-linking | 80 | 1 | 1.000001e6 | 1.000001e6 | 1.0e6 | 1.0e6 | 1.000001e18 |
+| edge-capacity | 20 | 1 | 1.000001e6 | 1.000001e6 | 1.0 | 475713.0 | 2.2630308e17 |
 
 ## Known Incumbent
 
@@ -170,11 +173,11 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Target variable delta vs QOBLIB QS metrics: 21
 - Target variable delta note: ToQUBO generates 21 more binary variables than the pinned QOBLIB QS metrics row. Reformulation metadata attributes 20 bits to the explicit bounded integer max-load variable z and reports one additional auxiliary variable under ToQUBO's current constraint encodings.
 - Target density delta vs QOBLIB QS metrics: -0.00045639349
-- Native min-coefficient delta vs QOBLIB QS metrics: -2.3688803e26
-- Native max-coefficient delta vs QOBLIB QS metrics: 2.3688762e26
-- QOBLIB-style min-coefficient delta vs QOBLIB QS metrics: -1.1844401e26
-- QOBLIB-style max-coefficient delta vs QOBLIB QS metrics: 1.1878133e26
+- Native min-coefficient delta vs QOBLIB QS metrics: -1.4184258e24
+- Native max-coefficient delta vs QOBLIB QS metrics: 1.8214653e24
+- QOBLIB-style min-coefficient delta vs QOBLIB QS metrics: -7.0921268e23
+- QOBLIB-style max-coefficient delta vs QOBLIB QS metrics: 1.8214653e24
 
 ## Follow-Up
 
-The pilot found a major coefficient-scaling gap: ToQUBO's generated network QUBO coefficient range remains about eight orders of magnitude larger than the pinned QOBLIB QS metrics row even under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass, and the local QOBLIB converter reproduces the pinned QS metrics row with Qiskit's default uniform penalty of 1000001.0. This points to a penalty-policy difference rather than a bad QOBLIB conversion; issue https://github.com/JuliaQUBO/ToQUBO.jl/issues/160 tracks a benchmark-compatible penalty policy before expanding the network benchmark class.
+The objective-range exact-penalty policy tightens ToQUBO's applied network penalties from many family-dependent values up to about 5.23e14 down to the Qiskit/QOBLib-compatible uniform value 1000001.0. The source transcription and incumbent feasibility checks pass, and the local QOBLIB converter reproduces the pinned QS metrics row. The remaining coefficient-range gap is no longer caused by oversized applied penalties; it should be interpreted alongside ToQUBO's variable/slack encodings, residual expansion coefficients, and the target-variable delta before expanding the network benchmark class.

--- a/benchmarks/qoblib/reports/routing_pilot.md
+++ b/benchmarks/qoblib/reports/routing_pilot.md
@@ -72,11 +72,11 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 |:--|--:|--:|--:|
 | variables | 441 | 4527 | 4351 |
 | density | 0.011558523 | 0.011716314 | 0.012450865 |
-| minimum coefficient | -331.0 | -1.2874612e10 | -1.4036904e13 |
-| maximum coefficient | 1.0 | 7.3976056e9 | 2.7938839e13 |
-| QOBLIB-style minimum coefficient | n/a | -1.2874612e10 | -1.4036904e13 |
-| QOBLIB-style maximum coefficient | n/a | 7.3976056e9 | 1.5646507e13 |
-| objective offset | n/a | n/a | 1.5412343e13 |
+| minimum coefficient | -331.0 | -1.2874612e10 | -1.2433534e10 |
+| maximum coefficient | 1.0 | 7.3976056e9 | 8.891019e9 |
+| QOBLIB-style minimum coefficient | n/a | -1.2874612e10 | -1.2433534e10 |
+| QOBLIB-style maximum coefficient | n/a | 7.3976056e9 | 8.0192823e9 |
+| objective offset | n/a | n/a | 3.5731794e11 |
 | QUBO terms | n/a | n/a | 117882 |
 | quadratic terms | n/a | n/a | 113531 |
 
@@ -101,7 +101,7 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Constraint penalties: 461
 - Variable penalties: 0
 - Slack penalties: 0
-- Distinct constraint penalties: 16697.376, 1.6479324e7, 2.6568944e8
+- Distinct constraint penalties: 16697.376
 - Encoding types: `Binary`
 
 ## Known Incumbent
@@ -129,11 +129,11 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Target variable delta note: ToQUBO generates fewer binary variables than the pinned QOBLIB QS metrics row. The current compiler also detects 22 explicit source constraints as always feasible, so the target-size delta should be interpreted alongside the redundant-constraint count and encoding metadata.
 - Redundant source constraints detected: 22
 - Target density delta vs QOBLIB QS metrics: 0.0007345511
-- Native min-coefficient delta vs QOBLIB QS metrics: -1.402403e13
-- Native max-coefficient delta vs QOBLIB QS metrics: 2.7931441e13
-- QOBLIB-style min-coefficient delta vs QOBLIB QS metrics: -1.402403e13
-- QOBLIB-style max-coefficient delta vs QOBLIB QS metrics: 1.5639109e13
+- Native min-coefficient delta vs QOBLIB QS metrics: 4.4107789e8
+- Native max-coefficient delta vs QOBLIB QS metrics: 1.4934133e9
+- QOBLIB-style min-coefficient delta vs QOBLIB QS metrics: 4.4107789e8
+- QOBLIB-style max-coefficient delta vs QOBLIB QS metrics: 6.2167672e8
 
 ## Follow-Up
 
-The pilot found a major coefficient-scaling gap: ToQUBO's generated routing QUBO coefficient range is about three orders of magnitude larger than the pinned QOBLIB QS metrics row even under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass, so this PR keeps the reproducible routing pilot and tracks penalty-scaling investigation in https://github.com/JuliaQUBO/ToQUBO.jl/issues/162 before expanding the routing benchmark class.
+The objective-range automatic penalty policy brings ToQUBO's generated routing QUBO coefficient range into the same order as the pinned QOBLIB QS metrics row under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass. Remaining routing differences should be interpreted alongside ToQUBO's variable and slack encodings, redundant-constraint handling, and target-variable delta; those benchmark-expansion questions remain tracked in https://github.com/JuliaQUBO/ToQUBO.jl/issues/162.

--- a/benchmarks/qoblib/routing_pilot.jl
+++ b/benchmarks/qoblib/routing_pilot.jl
@@ -586,7 +586,7 @@ function run_routing_pilot()
         "known_incumbent" => _known_incumbent_summary(),
         "comparison" => _comparison(target, metadata),
         "follow_up" =>
-            "The pilot found a major coefficient-scaling gap: ToQUBO's generated routing QUBO coefficient range is about three orders of magnitude larger than the pinned QOBLIB QS metrics row even under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass, so this PR keeps the reproducible routing pilot and tracks penalty-scaling investigation in https://github.com/JuliaQUBO/ToQUBO.jl/issues/162 before expanding the routing benchmark class.",
+            "The objective-range automatic penalty policy brings ToQUBO's generated routing QUBO coefficient range into the same order as the pinned QOBLIB QS metrics row under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass. Remaining routing differences should be interpreted alongside ToQUBO's variable and slack encodings, redundant-constraint handling, and target-variable delta; those benchmark-expansion questions remain tracked in https://github.com/JuliaQUBO/ToQUBO.jl/issues/162.",
     )
 end
 

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -54,9 +54,19 @@ where `s` is [`ToQUBO.Attributes.PenaltyScale`](@ref), `β` is
 [`ToQUBO.Attributes.PenaltyOffset`](@ref), `σ` is `1` for minimization models
 and `-1` for maximization models, `U - L` is the compiled pseudo-boolean
 objective range, and `ϵ` is the smallest positive value of the generated
-nonnegative penalty function. With `β > 0`, any infeasible assignment is
-penalized by more than the largest possible objective improvement available
-within the compiled objective range.
+nonnegative penalty function. With the default scale `s = 1` and `β > 0`, any
+infeasible assignment is penalized by more than the largest possible objective
+improvement available within the compiled objective range. With custom scales,
+the same sufficient exactness condition is `s * (U - L + β) > U - L`; smaller
+scales can make the penalty a tuning heuristic rather than a certified exact
+penalty.
+
+The objective range is computed from interval bounds on the compiled PBF over
+encoded target binary variables. For normal finite JuMP/MOI models this bound
+is finite after encoding, but it may overestimate the exact source-objective
+span when an encoding has redundant target states or feasibility relations such
+as one-hot sums. That overestimate keeps the penalty sufficient, but it is not
+always the tightest possible objective range.
 
 When the objective range or positive penalty gap cannot be certified, ToQUBO
 falls back for that coefficient to [`ToQUBO.Attributes.LegacyPenalty`](@ref):
@@ -66,9 +76,10 @@ falls back for that coefficient to [`ToQUBO.Attributes.LegacyPenalty`](@ref):
 ```
 
 where `δ` is the historical objective gap estimate from `PBO.maxgap`.
-The selected policy, objective bounds, and any fallback reasons are exposed
-through [`ToQUBO.Attributes.PenaltyPolicyMetadata`](@ref) and the
-`"penalty_policy"` field in reformulation metadata.
+The selected policy, objective bounds, inferred penalties with their `ϵ`
+sources, and any fallback reasons are exposed through
+[`ToQUBO.Attributes.PenaltyPolicyMetadata`](@ref) and the `"penalty_policy"`
+field in reformulation metadata.
 
 The precedence is:
 

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -39,19 +39,36 @@ ToQUBO.Attributes.StableQuadratization
 
 ## Variable & Constraint Encoding
 
-### Penalty Heuristic
+### Automatic Penalty Inference
 
 When a constraint, variable encoding, or slack-variable encoding needs a penalty
-coefficient and no explicit hint is set, ToQUBO uses the automatic heuristic
+coefficient and no explicit hint is set, ToQUBO infers one automatically. The
+default [`ToQUBO.Attributes.ObjectiveRangePenalty`](@ref) policy uses an
+objective-range exact-penalty bound:
+
+```math
+\rho = s \cdot \sigma \cdot \left(\frac{U - L + \beta}{\epsilon}\right)
+```
+
+where `s` is [`ToQUBO.Attributes.PenaltyScale`](@ref), `β` is
+[`ToQUBO.Attributes.PenaltyOffset`](@ref), `σ` is `1` for minimization models
+and `-1` for maximization models, `U - L` is the compiled pseudo-boolean
+objective range, and `ϵ` is the smallest positive value of the generated
+nonnegative penalty function. With `β > 0`, any infeasible assignment is
+penalized by more than the largest possible objective improvement available
+within the compiled objective range.
+
+When the objective range or positive penalty gap cannot be certified, ToQUBO
+falls back for that coefficient to [`ToQUBO.Attributes.LegacyPenalty`](@ref):
 
 ```math
 \rho = s \cdot \sigma \cdot \left(\frac{\delta}{\epsilon} + \beta\right)
 ```
 
-where `s` is [`ToQUBO.Attributes.PenaltyScale`](@ref), `β` is
-[`ToQUBO.Attributes.PenaltyOffset`](@ref), `σ` is `1` for minimization models
-and `-1` for maximization models, `δ` is the objective gap estimate, and `ϵ` is
-the smallest positive gap in the generated penalty function.
+where `δ` is the historical objective gap estimate from `PBO.maxgap`.
+The selected policy, objective bounds, and any fallback reasons are exposed
+through [`ToQUBO.Attributes.PenaltyPolicyMetadata`](@ref) and the
+`"penalty_policy"` field in reformulation metadata.
 
 The precedence is:
 
@@ -62,20 +79,25 @@ The precedence is:
    [`ToQUBO.Attributes.ConstraintPenaltyOffset`](@ref) apply to the source
    constraint and to the slack-variable encoding penalty generated for that
    constraint.
-3. Global [`ToQUBO.Attributes.PenaltyScale`](@ref) and
+3. Global [`ToQUBO.Attributes.PenaltyPolicy`](@ref),
+   [`ToQUBO.Attributes.PenaltyScale`](@ref), and
    [`ToQUBO.Attributes.PenaltyOffset`](@ref) apply everywhere else.
 
-The defaults are `PenaltyScale() == 1.0` and `PenaltyOffset() == 1.0`, matching
-the previous heuristic. The coefficient is positive for minimization models and
-negative for maximization models, so explicit hints should use the same sign as
-the coefficient you want the compiler to apply.
+The defaults are `PenaltyPolicy() == ObjectiveRangePenalty()`,
+`PenaltyScale() == 1.0`, and `PenaltyOffset() == 1.0`. The coefficient is
+positive for minimization models and negative for maximization models, so
+explicit hints should use the same sign as the coefficient you want the
+compiler to apply.
 
 Use the controls according to how much of the model you want to change:
 
+- Use [`ToQUBO.Attributes.PenaltyPolicy`](@ref) to select the automatic
+  inference policy. Set it to [`ToQUBO.Attributes.LegacyPenalty`](@ref) only
+  when you need to reproduce the historical maxgap-based coefficients.
 - Use [`ToQUBO.Attributes.PenaltyScale`](@ref) and
   [`ToQUBO.Attributes.PenaltyOffset`](@ref) to change all automatically
-  inferred penalties while preserving their relative dependence on the
-  generated objective and penalty gaps.
+  inferred penalties while preserving their policy-dependent objective and
+  penalty-gap dependence.
 - Use [`ToQUBO.Attributes.ConstraintPenaltyScale`](@ref) and
   [`ToQUBO.Attributes.ConstraintPenaltyOffset`](@ref) when one source
   constraint needs a different automatic penalty. These overrides also apply to
@@ -94,10 +116,11 @@ Use the controls according to how much of the model you want to change:
 
 ### Changing Penalty Values
 
-For feasibility tuning, start by sweeping `PenaltyScale()` while keeping
-explicit hints unset. If only one constraint needs adjustment, override that
-constraint's automatic scale or offset. Pin exact penalty values only when you
-have a known coefficient to apply.
+For feasibility tuning, start by inspecting
+[`ToQUBO.Attributes.PenaltyPolicyMetadata`](@ref) and sweeping `PenaltyScale()`
+while keeping explicit hints unset. If only one constraint needs adjustment,
+override that constraint's automatic scale or offset. Pin exact penalty values
+only when you have a known coefficient to apply.
 
 ```@example penalty-settings
 using JuMP
@@ -135,17 +158,19 @@ rho_capacity = get_attribute(capacity, Attributes.ConstraintEncodingPenalty())
 rho_assignment = get_attribute(assignment, Attributes.ConstraintEncodingPenalty())
 eta_capacity = get_attribute(capacity, Attributes.SlackVariableEncodingPenalty())
 theta_z = get_attribute(z, Attributes.VariableEncodingPenalty())
+policy_metadata = get_attribute(model, Attributes.PenaltyPolicyMetadata())
 
-# The capacity penalty is inferred by the automatic heuristic.
+# The capacity penalty is inferred by the automatic policy.
 @assert rho_capacity !== nothing
 @assert rho_assignment == 12.0
 @assert eta_capacity == 9.0
 @assert theta_z == 6.0
+@assert policy_metadata["policy"] == "ObjectiveRangePenalty"
 ```
 
-Very small `ϵ` values can produce large penalties. That usually means the
-penalty function has nearly tied infeasible states, so treat the heuristic as a
-starting point and compare feasibility across several scales.
+Very small `ϵ` values or broad objective ranges can produce large penalties.
+Inspect the policy metadata before overriding the policy or pinning explicit
+penalties.
 
 ### Constraint Penalty Methods
 
@@ -223,6 +248,10 @@ ToQUBO.Attributes.SlackVariableEncodingATol
 ToQUBO.Attributes.SlackVariableEncodingBits
 ToQUBO.Attributes.SlackVariableEncodingPenaltyHint
 ToQUBO.Attributes.SlackVariableEncodingPenalty
+ToQUBO.Attributes.ObjectiveRangePenalty
+ToQUBO.Attributes.LegacyPenalty
+ToQUBO.Attributes.PenaltyPolicy
+ToQUBO.Attributes.PenaltyPolicyMetadata
 ToQUBO.Attributes.PenaltyOffset
 ToQUBO.Attributes.PenaltyScale
 ToQUBO.Attributes.ConstraintPenaltyOffset

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -62,6 +62,45 @@ MOI.supports(::Optimizer, ::A) where {A<:CompilerAttribute} = true
 
 _copy_or_nothing(x) = isnothing(x) ? nothing : copy(x)
 
+abstract type AutomaticPenaltyPolicy end
+
+@doc raw"""
+    ObjectiveRangePenalty()
+
+Infer automatic penalty coefficients from a sufficient exact-penalty bound
+based on the compiled objective range. When ToQUBO can certify finite objective
+bounds and a positive violation gap for a generated nonnegative penalty
+function, penalties are inferred as
+``scale * sigma * ((objective_range + margin) / epsilon)``.
+
+This is the default policy. If the bound cannot be certified for a particular
+penalty function, ToQUBO falls back to [`LegacyPenalty`](@ref) for that
+coefficient and records the fallback in reformulation metadata.
+"""
+struct ObjectiveRangePenalty <: AutomaticPenaltyPolicy end
+
+@doc raw"""
+    LegacyPenalty()
+
+Use the historical ToQUBO automatic penalty heuristic
+``scale * sigma * (delta / epsilon + beta)``, where `delta` is computed with
+`PBO.maxgap` on the compiled source objective. This policy remains available
+for compatibility and as a fallback when [`ObjectiveRangePenalty`](@ref) cannot
+be certified.
+"""
+struct LegacyPenalty <: AutomaticPenaltyPolicy end
+
+function MOIU.map_indices(::Function, policy::AutomaticPenaltyPolicy)
+    return policy
+end
+
+function MOIU.map_indices(
+    ::AbstractDict{T,T},
+    policy::AutomaticPenaltyPolicy,
+) where {T<:Union{MOI.VariableIndex,MOI.ConstraintIndex}}
+    return policy
+end
+
 @doc raw"""
     SourceModel()
 """
@@ -242,15 +281,74 @@ function ignore_feasible_constraints(model::Optimizer)::Bool
 end
 
 @doc raw"""
+    PenaltyPolicy()
+
+Select the automatic penalty inference policy used when no explicit penalty
+hint is set. The default is [`ObjectiveRangePenalty`](@ref), which uses a
+certified objective-range exact-penalty bound when available and falls back to
+[`LegacyPenalty`](@ref) otherwise.
+"""
+struct PenaltyPolicy <: CompilerAttribute end
+
+_attribute_from_key(::Val{:penalty_policy}) = PenaltyPolicy
+
+function MOI.get(model::Optimizer, ::PenaltyPolicy)::AutomaticPenaltyPolicy
+    return get(model.compiler_settings, :penalty_policy, ObjectiveRangePenalty())
+end
+
+function MOI.set(model::Optimizer, ::PenaltyPolicy, policy::AutomaticPenaltyPolicy)
+    model.compiler_settings[:penalty_policy] = policy
+
+    return nothing
+end
+
+function MOI.set(model::Optimizer, ::PenaltyPolicy, ::Nothing)
+    delete!(model.compiler_settings, :penalty_policy)
+
+    return nothing
+end
+
+function penalty_policy(model::Optimizer)::AutomaticPenaltyPolicy
+    return MOI.get(model, PenaltyPolicy())
+end
+
+@doc raw"""
+    PenaltyPolicyMetadata()
+
+Return diagnostic metadata for the automatic penalty policy used during the
+last compilation, including objective bounds and any fallback reasons.
+"""
+struct PenaltyPolicyMetadata <: CompilerAttribute end
+
+MOI.is_set_by_optimize(::PenaltyPolicyMetadata) = true
+
+function MOIU.map_indices(::Any, ::PenaltyPolicyMetadata, metadata::AbstractDict)
+    return copy(metadata)
+end
+
+function MOIU.map_indices(::Any, ::PenaltyPolicyMetadata, ::Nothing)
+    return nothing
+end
+
+function MOI.get(model::Optimizer, ::PenaltyPolicyMetadata)
+    return get(model.compiler_settings, :penalty_policy_metadata, nothing)
+end
+
+function penalty_policy_metadata(model::Optimizer)
+    return MOI.get(model, PenaltyPolicyMetadata())
+end
+
+@doc raw"""
     PenaltyOffset()
 
-Set the global offset ``\beta`` used by the automatic penalty heuristic.
+Set the global offset or margin used by automatic penalty inference.
 
-When no explicit penalty hint is set, ToQUBO infers penalty coefficients as
-``scale * sigma * (delta / epsilon + beta)``. The default is `1.0`, which
-preserves the original heuristic. Use [`ConstraintPenaltyOffset`](@ref) to
-override this value for a specific source constraint and its slack-variable
-encoding penalty.
+Under [`ObjectiveRangePenalty`](@ref), this is the objective-range margin in
+``scale * sigma * ((objective_range + beta) / epsilon)``. Under
+[`LegacyPenalty`](@ref), this is the historical additive offset in
+``scale * sigma * (delta / epsilon + beta)``. The default is `1.0`.
+Use [`ConstraintPenaltyOffset`](@ref) to override this value for a specific
+source constraint and its slack-variable encoding penalty.
 """
 struct PenaltyOffset <: CompilerAttribute end
 
@@ -282,11 +380,10 @@ end
 Set the global multiplier applied to automatically inferred penalty
 coefficients.
 
-When no explicit penalty hint is set, ToQUBO infers penalty coefficients as
-``scale * sigma * (delta / epsilon + beta)``. The default is `1.0`, which
-preserves the original heuristic. Use [`ConstraintPenaltyScale`](@ref) to
-override this value for a specific source constraint and its slack-variable
-encoding penalty.
+When no explicit penalty hint is set, ToQUBO infers penalty coefficients from
+[`PenaltyPolicy`](@ref). The default scale is `1.0`. Use
+[`ConstraintPenaltyScale`](@ref) to override this value for a specific source
+constraint and its slack-variable encoding penalty.
 """
 struct PenaltyScale <: CompilerAttribute end
 
@@ -933,9 +1030,9 @@ end
 Set a fixed penalty coefficient for a variable encoding that generates a
 penalty function.
 
-When unset, ToQUBO infers the coefficient from [`PenaltyScale`](@ref),
-[`PenaltyOffset`](@ref), the objective gap estimate, and the generated penalty
-function gap. The hint is used as-is and bypasses the automatic heuristic.
+When unset, ToQUBO infers the coefficient from [`PenaltyPolicy`](@ref),
+[`PenaltyScale`](@ref), [`PenaltyOffset`](@ref), and the generated penalty
+function gap. The hint is used as-is and bypasses automatic inference.
 """
 struct VariableEncodingPenaltyHint <: CompilerVariableAttribute end
 
@@ -1051,7 +1148,7 @@ end
 
 Set a fixed penalty coefficient for a source constraint.
 
-When unset, ToQUBO infers the coefficient from the automatic penalty heuristic,
+When unset, ToQUBO infers the coefficient from the automatic penalty policy,
 unless the constraint uses [`LinearPenalty`](@ref). Linear penalties require an
 explicit hint because their sign and magnitude control whether the residual
 discourages infeasible assignments.
@@ -1114,7 +1211,7 @@ Return the applied source-constraint penalty coefficient after compilation.
 
 Use [`ConstraintEncodingPenaltyHint`](@ref) before compilation to pin a
 specific coefficient, or [`ConstraintPenaltyScale`](@ref) and
-[`ConstraintPenaltyOffset`](@ref) to tune the automatic heuristic for one
+[`ConstraintPenaltyOffset`](@ref) to tune automatic inference for one
 source constraint.
 """
 struct ConstraintEncodingPenalty <: CompilerConstraintAttribute end
@@ -1614,7 +1711,7 @@ end
 Set a fixed penalty coefficient for a slack-variable encoding generated by a
 source constraint.
 
-When unset, ToQUBO infers the coefficient from the automatic penalty heuristic.
+When unset, ToQUBO infers the coefficient from the automatic penalty policy.
 [`ConstraintPenaltyScale`](@ref) and [`ConstraintPenaltyOffset`](@ref) apply to
 the source constraint and to its generated slack-variable encoding penalty.
 """

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -316,7 +316,19 @@ end
     PenaltyPolicyMetadata()
 
 Return diagnostic metadata for the automatic penalty policy used during the
-last compilation, including objective bounds and any fallback reasons.
+last compilation.
+
+The returned dictionary includes the selected automatic policy, objective
+bounds, the legacy objective gap, fallback records, and `inferred_penalties`.
+`inferred_penalties` is grouped under `"constraints"`, `"variables"`, and
+`"slack_variables"`. Each entry records the source item kind and id, final
+automatic coefficient, `epsilon`, `epsilon_source`, scale, offset, automatic
+policy, selected policy, and any fallback reason.
+
+Only automatically inferred coefficients are included in `inferred_penalties`.
+Explicit penalty hints bypass automatic inference; use [`AppliedPenalty`](@ref)
+or reformulation metadata's `applied_penalties` section when a complete list of
+applied coefficients is needed.
 """
 struct PenaltyPolicyMetadata <: CompilerAttribute end
 

--- a/src/compiler/compiler.jl
+++ b/src/compiler/compiler.jl
@@ -98,6 +98,7 @@ function reset!(model::Virtual.Model, ::AbstractArchitecture = GenericArchitectu
     MOI.set(model, Attributes.CompilationStatus(), nothing)
     MOI.set(model, Attributes.CompilationTime(), nothing)
     delete!(model.compiler_settings, :qubo_fast_path)
+    delete!(model.compiler_settings, :penalty_policy_metadata)
     delete!(model.moi_settings, :raw_status_string)
 
     return nothing

--- a/src/compiler/penalties.jl
+++ b/src/compiler/penalties.jl
@@ -3,8 +3,112 @@ function _uses_linear_equality_penalty(model::Virtual.Model, ci::CI)::Bool
            Attributes.constraint_encoding_method(model, ci) isa Attributes.LinearPenalty
 end
 
-function _inferred_penalty_factor(sign, δ, ϵ, scale, offset)
+function _legacy_penalty_factor(sign, δ, ϵ, scale, offset)
     return scale * sign * (δ / ϵ + offset)
+end
+
+function _objective_range_metadata(model::Virtual.Model)
+    lower, upper = PBO.bounds(model.f)
+    range = upper - lower
+    finite = isfinite(lower) && isfinite(upper) && isfinite(range) && range >= zero(range)
+
+    return Dict{String,Any}(
+        "source" => "compiled_pbf_bounds",
+        "lower" => lower,
+        "upper" => upper,
+        "range" => range,
+        "finite" => finite,
+    )
+end
+
+function _penalty_context(model::Virtual.Model)
+    policy = Attributes.penalty_policy(model)
+    objective_bounds = _objective_range_metadata(model)
+
+    return Dict{String,Any}(
+        "policy" => string(nameof(typeof(policy))),
+        "objective_bounds" => objective_bounds,
+        "fallbacks" => Dict{String,Any}[],
+    )
+end
+
+function _fallback!(context::AbstractDict, kind::String, id::Integer, reason::String)
+    push!(
+        context["fallbacks"],
+        Dict{String,Any}(
+            "kind" => kind,
+            "id" => id,
+            "reason" => reason,
+            "fallback_policy" => "LegacyPenalty",
+        ),
+    )
+
+    return nothing
+end
+
+function _objective_range_penalty_factor(
+    sign,
+    range,
+    ϵ,
+    scale,
+    offset,
+)
+    return scale * sign * ((range + offset) / ϵ)
+end
+
+function _is_integer_valued(p::PBO.PBF)
+    for (_ω, coefficient) in p
+        isinteger(coefficient) || return false
+    end
+
+    return true
+end
+
+function _positive_penalty_gap(p::PBO.PBF{VI,T}) where {T}
+    if _is_integer_valued(p)
+        return one(T), "integer_valued_penalty"
+    else
+        return PBO.mingap(p), "pbo_mingap"
+    end
+end
+
+function _inferred_penalty_factor(
+    model::Virtual.Model,
+    context::AbstractDict,
+    sign,
+    δ,
+    ϵ,
+    scale,
+    offset,
+    kind::String,
+    id::Integer,
+)
+    policy = Attributes.penalty_policy(model)
+
+    if policy isa Attributes.LegacyPenalty
+        return _legacy_penalty_factor(sign, δ, ϵ, scale, offset)
+    end
+
+    objective_bounds = context["objective_bounds"]
+
+    if !(policy isa Attributes.ObjectiveRangePenalty)
+        _fallback!(context, kind, id, "Unknown automatic penalty policy")
+        return _legacy_penalty_factor(sign, δ, ϵ, scale, offset)
+    elseif !objective_bounds["finite"]
+        _fallback!(context, kind, id, "Objective range is not finite")
+        return _legacy_penalty_factor(sign, δ, ϵ, scale, offset)
+    elseif !(isfinite(ϵ) && ϵ > zero(ϵ))
+        _fallback!(context, kind, id, "Penalty function positive gap is not finite")
+        return _legacy_penalty_factor(sign, δ, ϵ, scale, offset)
+    end
+
+    return _objective_range_penalty_factor(
+        sign,
+        objective_bounds["range"],
+        ϵ,
+        scale,
+        offset,
+    )
 end
 
 function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
@@ -12,6 +116,7 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
     σ = MOI.get(model, MOI.ObjectiveSense()) === MOI.MAX_SENSE ? -1 : 1
 
     δ = PBO.maxgap(model.f)
+    context = _penalty_context(model)
 
     for (ci, g) in model.g
         ρ = Attributes.constraint_encoding_penalty_hint(model, ci)
@@ -25,13 +130,17 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
                 )
             end
 
-            ϵ = PBO.mingap(g)
+            ϵ, _gap_source = _positive_penalty_gap(g)
             ρ = _inferred_penalty_factor(
+                model,
+                context,
                 σ,
                 δ,
                 ϵ,
                 Attributes.constraint_penalty_scale(model, ci),
                 Attributes.constraint_penalty_offset(model, ci),
+                "constraint",
+                ci.value,
             )
         end
 
@@ -42,13 +151,17 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
         θ = Attributes.variable_encoding_penalty_hint(model, vi)
 
         if isnothing(θ)
-            ϵ = PBO.mingap(h)
+            ϵ, _gap_source = _positive_penalty_gap(h)
             θ = _inferred_penalty_factor(
+                model,
+                context,
                 σ,
                 δ,
                 ϵ,
                 Attributes.penalty_scale(model),
                 Attributes.penalty_offset(model),
+                "variable",
+                vi.value,
             )
         end
 
@@ -59,18 +172,26 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
         η = Attributes.slack_variable_encoding_penalty_hint(model, ci)
 
         if isnothing(η)
-            ϵ = PBO.mingap(s)
+            ϵ, _gap_source = _positive_penalty_gap(s)
             η = _inferred_penalty_factor(
+                model,
+                context,
                 σ,
                 δ,
                 ϵ,
                 Attributes.constraint_penalty_scale(model, ci),
                 Attributes.constraint_penalty_offset(model, ci),
+                "slack_variable",
+                ci.value,
             )
         end
 
         MOI.set(model, Attributes.SlackVariableEncodingPenalty(), ci, η)
     end
+
+    context["fallback_count"] = length(context["fallbacks"])
+    context["legacy_objective_gap"] = δ
+    model.compiler_settings[:penalty_policy_metadata] = context
 
     return nothing
 end

--- a/src/compiler/penalties.jl
+++ b/src/compiler/penalties.jl
@@ -28,6 +28,11 @@ function _penalty_context(model::Virtual.Model)
     return Dict{String,Any}(
         "policy" => string(nameof(typeof(policy))),
         "objective_bounds" => objective_bounds,
+        "inferred_penalties" => Dict{String,Any}(
+            "constraints" => Dict{String,Any}[],
+            "variables" => Dict{String,Any}[],
+            "slack_variables" => Dict{String,Any}[],
+        ),
         "fallbacks" => Dict{String,Any}[],
     )
 end
@@ -111,6 +116,82 @@ function _inferred_penalty_factor(
     )
 end
 
+function _inferred_penalty_bucket(kind::String)
+    if kind == "constraint"
+        return "constraints"
+    elseif kind == "variable"
+        return "variables"
+    elseif kind == "slack_variable"
+        return "slack_variables"
+    else
+        return kind
+    end
+end
+
+function _record_inferred_penalty!(
+    context::AbstractDict,
+    kind::String,
+    id::Integer,
+    ρ,
+    ϵ,
+    gap_source::String,
+    scale,
+    offset,
+    fallback,
+)
+    entry = Dict{String,Any}(
+        "kind" => kind,
+        "id" => id,
+        "penalty" => ρ,
+        "epsilon" => ϵ,
+        "epsilon_source" => gap_source,
+        "scale" => scale,
+        "offset" => offset,
+        "automatic_policy" => context["policy"],
+        "selected_policy" =>
+            isnothing(fallback) ? context["policy"] : fallback["fallback_policy"],
+    )
+
+    if !isnothing(fallback)
+        entry["fallback_reason"] = fallback["reason"]
+    end
+
+    push!(context["inferred_penalties"][_inferred_penalty_bucket(kind)], entry)
+
+    return nothing
+end
+
+function _infer_and_record_penalty_factor(
+    model::Virtual.Model,
+    context::AbstractDict,
+    sign,
+    δ,
+    p::PBO.PBF,
+    scale,
+    offset,
+    kind::String,
+    id::Integer,
+)
+    ϵ, gap_source = _positive_penalty_gap(p)
+    fallback_count = length(context["fallbacks"])
+    ρ = _inferred_penalty_factor(
+        model,
+        context,
+        sign,
+        δ,
+        ϵ,
+        scale,
+        offset,
+        kind,
+        id,
+    )
+    fallback = length(context["fallbacks"]) > fallback_count ? last(context["fallbacks"]) : nothing
+
+    _record_inferred_penalty!(context, kind, id, ρ, ϵ, gap_source, scale, offset, fallback)
+
+    return ρ
+end
+
 function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
     # Adjust Sign
     σ = MOI.get(model, MOI.ObjectiveSense()) === MOI.MAX_SENSE ? -1 : 1
@@ -130,15 +211,16 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
                 )
             end
 
-            ϵ, _gap_source = _positive_penalty_gap(g)
-            ρ = _inferred_penalty_factor(
+            scale = Attributes.constraint_penalty_scale(model, ci)
+            offset = Attributes.constraint_penalty_offset(model, ci)
+            ρ = _infer_and_record_penalty_factor(
                 model,
                 context,
                 σ,
                 δ,
-                ϵ,
-                Attributes.constraint_penalty_scale(model, ci),
-                Attributes.constraint_penalty_offset(model, ci),
+                g,
+                scale,
+                offset,
                 "constraint",
                 ci.value,
             )
@@ -151,15 +233,16 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
         θ = Attributes.variable_encoding_penalty_hint(model, vi)
 
         if isnothing(θ)
-            ϵ, _gap_source = _positive_penalty_gap(h)
-            θ = _inferred_penalty_factor(
+            scale = Attributes.penalty_scale(model)
+            offset = Attributes.penalty_offset(model)
+            θ = _infer_and_record_penalty_factor(
                 model,
                 context,
                 σ,
                 δ,
-                ϵ,
-                Attributes.penalty_scale(model),
-                Attributes.penalty_offset(model),
+                h,
+                scale,
+                offset,
                 "variable",
                 vi.value,
             )
@@ -172,15 +255,16 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
         η = Attributes.slack_variable_encoding_penalty_hint(model, ci)
 
         if isnothing(η)
-            ϵ, _gap_source = _positive_penalty_gap(s)
-            η = _inferred_penalty_factor(
+            scale = Attributes.constraint_penalty_scale(model, ci)
+            offset = Attributes.constraint_penalty_offset(model, ci)
+            η = _infer_and_record_penalty_factor(
                 model,
                 context,
                 σ,
                 δ,
-                ϵ,
-                Attributes.constraint_penalty_scale(model, ci),
-                Attributes.constraint_penalty_offset(model, ci),
+                s,
+                scale,
+                offset,
                 "slack_variable",
                 ci.value,
             )

--- a/src/compiler/penalties.jl
+++ b/src/compiler/penalties.jl
@@ -123,9 +123,9 @@ function _inferred_penalty_bucket(kind::String)
         return "variables"
     elseif kind == "slack_variable"
         return "slack_variables"
-    else
-        return kind
     end
+
+    error("Unknown inferred penalty kind: $(kind)")
 end
 
 function _record_inferred_penalty!(

--- a/src/reformulation.jl
+++ b/src/reformulation.jl
@@ -374,6 +374,8 @@ function reformulation_metadata(model::Virtual.Model)
         "slack_variables" => _slack_variable_entries(model),
         "constraint_encodings" => _constraint_encoding_entries(model),
         "applied_penalties" => _applied_penalty_metadata(model),
+        "penalty_policy" =>
+            MOI.get(model, Attributes.PenaltyPolicyMetadata()),
         "guarantees" => Dict{String,Any}(
             "project_original_state" => true,
             "auxiliary_consistency" => "encoding-specific",

--- a/test/integration/examples/logical/logical_sos.jl
+++ b/test/integration/examples/logical/logical_sos.jl
@@ -9,13 +9,13 @@ function test_logical_sos1()
         ]
 
         # Penalty Choice
-        ρ̄ = -13.5
+        ρ̄ = -26.0
 
         # Solution Data
         Q̄ = [
-            -1  33   0
-             0 -33  33
-             0   0 -33
+            -1  58   0
+             0 -58  58
+             0   0 -58
         ]
 
         ᾱ = 1

--- a/test/integration/interface.jl
+++ b/test/integration/interface.jl
@@ -523,6 +523,19 @@ function test_interface_jump()
                 JuMP.set_attribute(model, Attributes.Warnings(), false)
                 @test JuMP.get_attribute(model, Attributes.Warnings()) === false
 
+                @test JuMP.get_attribute(model, Attributes.PenaltyPolicy()) isa
+                      Attributes.ObjectiveRangePenalty
+                JuMP.set_attribute(model, Attributes.PenaltyPolicy(), Attributes.LegacyPenalty())
+                @test JuMP.get_attribute(model, Attributes.PenaltyPolicy()) isa
+                      Attributes.LegacyPenalty
+                JuMP.set_attribute(
+                    model,
+                    Attributes.PenaltyPolicy(),
+                    Attributes.ObjectiveRangePenalty(),
+                )
+                @test JuMP.get_attribute(model, Attributes.PenaltyPolicy()) isa
+                      Attributes.ObjectiveRangePenalty
+
                 @test JuMP.get_attribute(model, Attributes.QuadratizationMethod()) isa PBO.DEFAULT
                 JuMP.set_attribute(model, Attributes.QuadratizationMethod(), PBO.PTR_BG())
                 @test JuMP.get_attribute(model, Attributes.QuadratizationMethod()) isa PBO.PTR_BG
@@ -662,6 +675,10 @@ function test_interface_jump()
 
                 @test JuMP.get_attribute(c[1], Attributes.ConstraintEncodingPenalty()) == -10.0
                 @test JuMP.get_attribute(c[2], Attributes.ConstraintEncodingPenalty()) == -4.0
+                penalty_metadata =
+                    JuMP.get_attribute(model, Attributes.PenaltyPolicyMetadata())
+                @test penalty_metadata["policy"] == "ObjectiveRangePenalty"
+                @test penalty_metadata["fallback_count"] == 0
             end
         end
     end

--- a/test/unit/attributes/attributes.jl
+++ b/test/unit/attributes/attributes.jl
@@ -250,6 +250,29 @@ function test_compiler_attributes()
             end
         end
 
+        @testset "PenaltyPolicy" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                @test MOI.supports(model, Attributes.PenaltyPolicy())
+                @test MOI.supports(model, Attributes.PenaltyPolicyMetadata())
+                @test MOI.get(model, Attributes.PenaltyPolicy()) isa
+                      Attributes.ObjectiveRangePenalty
+                @test Attributes.penalty_policy(model) isa Attributes.ObjectiveRangePenalty
+                @test MOI.get(model, Attributes.PenaltyPolicyMetadata()) === nothing
+                @test Attributes.penalty_policy_metadata(model) === nothing
+
+                MOI.set(model, Attributes.PenaltyPolicy(), Attributes.LegacyPenalty())
+                @test MOI.get(model, Attributes.PenaltyPolicy()) isa Attributes.LegacyPenalty
+
+                MOI.set(model, Attributes.PenaltyPolicy(), Attributes.ObjectiveRangePenalty())
+                @test MOI.get(model, Attributes.PenaltyPolicy()) isa
+                      Attributes.ObjectiveRangePenalty
+
+                MOI.set(model, Attributes.PenaltyPolicy(), nothing)
+                @test MOI.get(model, Attributes.PenaltyPolicy()) isa
+                      Attributes.ObjectiveRangePenalty
+            end
+        end
+
         @testset "IgnoreFeasibleConstraints" begin
             let model = ToQUBO.Optimizer{Float64}()
                 @test MOI.supports(model, Attributes.IgnoreFeasibleConstraints())

--- a/test/unit/compiler/penalties.jl
+++ b/test/unit/compiler/penalties.jl
@@ -1,3 +1,5 @@
+struct _UnknownPenaltyPolicy <: Attributes.AutomaticPenaltyPolicy end
+
 function _constraint_penalty_test_model(;
     scale = nothing,
     offset = nothing,
@@ -78,6 +80,36 @@ function _variable_penalty_test_model(; scale = nothing, offset = nothing, polic
     return model, x
 end
 
+function _fractional_gap_penalty_test_model()
+    model = ToQUBO.Optimizer{Float64}()
+    x = MOI.add_variable(model)
+
+    MOI.set(model, Attributes.Discretize(), false)
+    MOI.add_constraint(model, x, MOI.ZeroOne())
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[MOI.ScalarAffineTerm{Float64}(1.0, x)],
+            0.0,
+        ),
+    )
+
+    c = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[MOI.ScalarAffineTerm{Float64}(0.5, x)],
+            0.0,
+        ),
+        MOI.LessThan{Float64}(0.0),
+    )
+
+    MOI.optimize!(model)
+
+    return model, c
+end
+
 function test_compiler_penalty_default_policy()
     model, c = _constraint_penalty_test_model()
     penalty = MOI.get(model, Attributes.ConstraintEncodingPenalty(), c)
@@ -93,6 +125,14 @@ function test_compiler_penalty_default_policy()
     @test metadata["objective_bounds"]["finite"] === true
     @test metadata["fallback_count"] == 0
     @test isempty(metadata["fallbacks"])
+    inferred = only(metadata["inferred_penalties"]["constraints"])
+    @test inferred["kind"] == "constraint"
+    @test inferred["id"] == c.value
+    @test inferred["penalty"] == penalty
+    @test inferred["epsilon"] == 1.0
+    @test inferred["epsilon_source"] == "integer_valued_penalty"
+    @test inferred["automatic_policy"] == "ObjectiveRangePenalty"
+    @test inferred["selected_policy"] == "ObjectiveRangePenalty"
 
     return nothing
 end
@@ -106,6 +146,46 @@ function test_compiler_legacy_penalty_policy()
     @test metadata["policy"] == "LegacyPenalty"
     @test metadata["fallback_count"] == 0
     @test isempty(metadata["fallbacks"])
+
+    return nothing
+end
+
+function test_compiler_fractional_penalty_gap_metadata()
+    model, c = _fractional_gap_penalty_test_model()
+    penalty = MOI.get(model, Attributes.ConstraintEncodingPenalty(), c)
+    metadata = MOI.get(model, Attributes.PenaltyPolicyMetadata())
+    inferred = only(metadata["inferred_penalties"]["constraints"])
+
+    @test metadata["objective_bounds"]["range"] == 1.0
+    @test penalty == 4.0
+    @test inferred["penalty"] == penalty
+    @test inferred["epsilon"] == 0.5
+    @test inferred["epsilon_source"] == "pbo_mingap"
+    @test inferred["scale"] == 1.0
+    @test inferred["offset"] == 1.0
+    @test inferred["selected_policy"] == "ObjectiveRangePenalty"
+    @test metadata["fallback_count"] == 0
+
+    return nothing
+end
+
+function test_compiler_penalty_policy_fallback_metadata()
+    model, c = _constraint_penalty_test_model(; policy = _UnknownPenaltyPolicy())
+    metadata = MOI.get(model, Attributes.PenaltyPolicyMetadata())
+    fallback = only(metadata["fallbacks"])
+    inferred = only(metadata["inferred_penalties"]["constraints"])
+
+    @test metadata["policy"] == "_UnknownPenaltyPolicy"
+    @test metadata["fallback_count"] == 1
+    @test fallback["kind"] == "constraint"
+    @test fallback["id"] == c.value
+    @test fallback["reason"] == "Unknown automatic penalty policy"
+    @test fallback["fallback_policy"] == "LegacyPenalty"
+    @test inferred["penalty"] == MOI.get(model, Attributes.ConstraintEncodingPenalty(), c)
+    @test inferred["epsilon"] == 1.0
+    @test inferred["epsilon_source"] == "integer_valued_penalty"
+    @test inferred["selected_policy"] == "LegacyPenalty"
+    @test inferred["fallback_reason"] == fallback["reason"]
 
     return nothing
 end
@@ -209,6 +289,8 @@ function test_compiler_penalties()
     @testset "Penalty inference" begin
         test_compiler_penalty_default_policy()
         test_compiler_legacy_penalty_policy()
+        test_compiler_fractional_penalty_gap_metadata()
+        test_compiler_penalty_policy_fallback_metadata()
         test_compiler_penalty_scale_and_offset()
         test_compiler_applied_penalty_metadata()
     end

--- a/test/unit/compiler/penalties.jl
+++ b/test/unit/compiler/penalties.jl
@@ -5,6 +5,7 @@ function _constraint_penalty_test_model(;
     constraint_offset = nothing,
     hint = nothing,
     slack_encoding = nothing,
+    policy = nothing,
 )
     model = ToQUBO.Optimizer{Float64}()
     x = [MOI.add_variable(model) for _ = 1:2]
@@ -47,13 +48,14 @@ function _constraint_penalty_test_model(;
     !isnothing(hint) && MOI.set(model, Attributes.ConstraintEncodingPenaltyHint(), c, hint)
     !isnothing(slack_encoding) &&
         MOI.set(model, Attributes.SlackVariableEncodingMethod(), c, slack_encoding)
+    !isnothing(policy) && MOI.set(model, Attributes.PenaltyPolicy(), policy)
 
     MOI.optimize!(model)
 
     return model, c
 end
 
-function _variable_penalty_test_model(; scale = nothing, offset = nothing)
+function _variable_penalty_test_model(; scale = nothing, offset = nothing, policy = nothing)
     model = ToQUBO.Optimizer{Float64}()
     x = MOI.add_variable(model)
 
@@ -69,20 +71,41 @@ function _variable_penalty_test_model(; scale = nothing, offset = nothing)
 
     !isnothing(scale) && MOI.set(model, Attributes.PenaltyScale(), scale)
     !isnothing(offset) && MOI.set(model, Attributes.PenaltyOffset(), offset)
+    !isnothing(policy) && MOI.set(model, Attributes.PenaltyPolicy(), policy)
 
     MOI.optimize!(model)
 
     return model, x
 end
 
-function test_compiler_penalty_defaults_match_previous_heuristic()
-    default_model, default_c = _constraint_penalty_test_model()
-    explicit_model, explicit_c = _constraint_penalty_test_model(; scale = 1.0, offset = 1.0)
+function test_compiler_penalty_default_policy()
+    model, c = _constraint_penalty_test_model()
+    penalty = MOI.get(model, Attributes.ConstraintEncodingPenalty(), c)
+    metadata = MOI.get(model, Attributes.PenaltyPolicyMetadata())
 
-    @test MOI.get(default_model, Attributes.ConstraintEncodingPenalty(), default_c) ==
-          MOI.get(explicit_model, Attributes.ConstraintEncodingPenalty(), explicit_c)
-    @test MOI.get(default_model, Attributes.CompiledHamiltonian()) ==
-          MOI.get(explicit_model, Attributes.CompiledHamiltonian())
+    @test MOI.get(model, Attributes.PenaltyPolicy()) isa Attributes.ObjectiveRangePenalty
+    @test penalty == -3.0
+    @test metadata["policy"] == "ObjectiveRangePenalty"
+    @test metadata["objective_bounds"]["source"] == "compiled_pbf_bounds"
+    @test metadata["objective_bounds"]["lower"] == 0.0
+    @test metadata["objective_bounds"]["upper"] == 2.0
+    @test metadata["objective_bounds"]["range"] == 2.0
+    @test metadata["objective_bounds"]["finite"] === true
+    @test metadata["fallback_count"] == 0
+    @test isempty(metadata["fallbacks"])
+
+    return nothing
+end
+
+function test_compiler_legacy_penalty_policy()
+    model, c = _constraint_penalty_test_model(; policy = Attributes.LegacyPenalty())
+    metadata = MOI.get(model, Attributes.PenaltyPolicyMetadata())
+
+    @test MOI.get(model, Attributes.PenaltyPolicy()) isa Attributes.LegacyPenalty
+    @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), c) == -3.0
+    @test metadata["policy"] == "LegacyPenalty"
+    @test metadata["fallback_count"] == 0
+    @test isempty(metadata["fallbacks"])
 
     return nothing
 end
@@ -175,13 +198,17 @@ function test_compiler_applied_penalty_metadata()
     @test only(metadata["constraint_encodings"])["penalty"] == penalty
     @test only(metadata["applied_penalties"]["slack_variables"])["penalty"] ==
           MOI.get(model, Attributes.SlackVariableEncodingPenalty(), c)
+    @test metadata["penalty_policy"]["policy"] == "ObjectiveRangePenalty"
+    @test metadata["penalty_policy"]["objective_bounds"]["range"] == 2.0
+    @test metadata["penalty_policy"]["fallback_count"] == 0
 
     return nothing
 end
 
 function test_compiler_penalties()
-    @testset "Penalty heuristic" begin
-        test_compiler_penalty_defaults_match_previous_heuristic()
+    @testset "Penalty inference" begin
+        test_compiler_penalty_default_policy()
+        test_compiler_legacy_penalty_policy()
         test_compiler_penalty_scale_and_offset()
         test_compiler_applied_penalty_metadata()
     end

--- a/test/unit/compiler/penalties.jl
+++ b/test/unit/compiler/penalties.jl
@@ -249,6 +249,15 @@ function test_compiler_penalty_scale_and_offset()
     )
     default_variable_penalty =
         MOI.get(default_variable_model, Attributes.VariableEncodingPenalty(), default_x)
+    default_variable_metadata =
+        MOI.get(default_variable_model, Attributes.PenaltyPolicyMetadata())
+    variable_inferred = only(default_variable_metadata["inferred_penalties"]["variables"])
+    @test variable_inferred["kind"] == "variable"
+    @test variable_inferred["id"] == default_x.value
+    @test variable_inferred["penalty"] == default_variable_penalty
+    @test variable_inferred["epsilon"] == 1.0
+    @test variable_inferred["epsilon_source"] == "integer_valued_penalty"
+    @test variable_inferred["selected_policy"] == "ObjectiveRangePenalty"
     variable_gap_ratio = default_variable_penalty - 1.0
     @test MOI.get(scaled_variable_model, Attributes.VariableEncodingPenalty(), scaled_x) ==
           2.0 * (variable_gap_ratio + 3.0)
@@ -263,7 +272,9 @@ function test_compiler_applied_penalty_metadata()
         slack_encoding = Encoding.OneHot(),
     )
     penalty = MOI.get(model, Attributes.AppliedPenalty(), c)
+    slack_penalty = MOI.get(model, Attributes.SlackVariableEncodingPenalty(), c)
     metadata = ToQUBO.reformulation_metadata(model)
+    penalty_metadata = metadata["penalty_policy"]
 
     @test metadata["applied_penalties"]["constraints"] == [
         Dict{String,Any}(
@@ -277,10 +288,17 @@ function test_compiler_applied_penalty_metadata()
     ]
     @test only(metadata["constraint_encodings"])["penalty"] == penalty
     @test only(metadata["applied_penalties"]["slack_variables"])["penalty"] ==
-          MOI.get(model, Attributes.SlackVariableEncodingPenalty(), c)
-    @test metadata["penalty_policy"]["policy"] == "ObjectiveRangePenalty"
-    @test metadata["penalty_policy"]["objective_bounds"]["range"] == 2.0
-    @test metadata["penalty_policy"]["fallback_count"] == 0
+          slack_penalty
+    @test penalty_metadata["policy"] == "ObjectiveRangePenalty"
+    @test penalty_metadata["objective_bounds"]["range"] == 2.0
+    @test penalty_metadata["fallback_count"] == 0
+    slack_inferred = only(penalty_metadata["inferred_penalties"]["slack_variables"])
+    @test slack_inferred["kind"] == "slack_variable"
+    @test slack_inferred["id"] == c.value
+    @test slack_inferred["penalty"] == slack_penalty
+    @test slack_inferred["epsilon"] == 1.0
+    @test slack_inferred["epsilon_source"] == "integer_valued_penalty"
+    @test slack_inferred["selected_policy"] == "ObjectiveRangePenalty"
 
     return nothing
 end

--- a/test/unit/qoblib_benchmark.jl
+++ b/test/unit/qoblib_benchmark.jl
@@ -271,7 +271,7 @@ function test_qoblib_benchmark_pilot()
         @test report["provenance"]["qoblib_model_license"] ==
               "Apache License, Version 2.0"
         @test report["provenance"]["penalty_scaling_follow_up"] ==
-              "https://github.com/JuliaQUBO/ToQUBO.jl/issues/160"
+              "https://github.com/JuliaQUBO/ToQUBO.jl/issues/172"
         @test report["provenance"]["canonical_qubo_metrics_csv_row"] ==
               "network05.qs,3640,0.05271012974940467,-4.75713475713e+17,4.5260616934376417e+18"
         @test report["instance"]["qoblib_id"] == "network05"
@@ -320,9 +320,9 @@ function test_qoblib_benchmark_pilot()
         @test target["num_terms"] == 350272
         @test target["num_quadratic_terms"] == 346611
         @test isapprox(target["density"], 0.05225373626178544; rtol = 1e-14)
-        @test isapprox(target["min_coeff"], -2.3688802611453573e26; rtol = 1e-14)
-        @test isapprox(target["max_coeff"], 2.3688762012720738e26; rtol = 1e-14)
-        @test isapprox(target["objective_offset"], 2.737918134653359e23; rtol = 1e-14)
+        @test isapprox(target["min_coeff"], -1.418426307690889e24; rtol = 1e-14)
+        @test isapprox(target["max_coeff"], 1.821469821468e24; rtol = 1e-14)
+        @test isapprox(target["objective_offset"], 6.113365033359323e20; rtol = 1e-14)
 
         metadata = report["toqubo"]["metadata"]
         @test metadata["source_variable_count"] == 101
@@ -330,7 +330,7 @@ function test_qoblib_benchmark_pilot()
         @test metadata["auxiliary_variable_count"] == 2021
         @test metadata["slack_variable_count"] == 100
         @test metadata["constraint_penalty_count"] == 130
-        @test length(metadata["constraint_penalties"]) == 23
+        @test metadata["constraint_penalties"] == [1_000_001.0]
         @test metadata["encoding_types"] == ["Binary"]
 
         source_encoding = metadata["source_encoding"]
@@ -342,23 +342,26 @@ function test_qoblib_benchmark_pilot()
 
         penalty_diagnostics = report["toqubo"]["penalty_diagnostics"]
         @test penalty_diagnostics["heuristic"] ==
-              "scale * sigma * (delta / epsilon + beta)"
+              "objective-range exact penalty with legacy fallback"
+        @test penalty_diagnostics["automatic_penalty_policy"] == "ObjectiveRangePenalty"
+        @test penalty_diagnostics["objective_range"] == 1_000_000.0
+        @test penalty_diagnostics["fallback_count"] == 0
         @test penalty_diagnostics["default_penalty_scale"] == 1.0
         @test penalty_diagnostics["default_penalty_offset"] == 1.0
-        @test penalty_diagnostics["largest_applied_penalty_family"] == "flow_balance"
+        @test penalty_diagnostics["largest_applied_penalty_family"] == "out_degree"
         @test isapprox(
             penalty_diagnostics["largest_applied_penalty"],
-            5.2338627500000094e14;
+            1_000_001.0;
             rtol = 1e-14,
         )
         @test penalty_diagnostics["largest_expanded_residual_scale_family"] ==
-              "flow_balance"
+              "arc_linking"
         family_by_category = Dict(
             family["category"] => family for
             family in penalty_diagnostics["constraint_families"]
         )
         @test family_by_category["flow_balance"]["constraint_count"] == 20
-        @test family_by_category["flow_balance"]["distinct_penalty_count"] == 15
+        @test family_by_category["flow_balance"]["distinct_penalty_count"] == 1
         @test isapprox(
             family_by_category["flow_balance"]["max_penalty"],
             penalty_diagnostics["largest_applied_penalty"];
@@ -373,25 +376,25 @@ function test_qoblib_benchmark_pilot()
 
         scaling_diagnostics = report["toqubo"]["scaling_diagnostics"]
         @test scaling_diagnostics["largest_expanded_residual_scale_family"] ==
-              "flow_balance"
-        @test scaling_diagnostics["largest_expanded_residual_coefficient"] == 475_713.0
+              "arc_linking"
+        @test scaling_diagnostics["largest_expanded_residual_coefficient"] == 1.0e6
         @test isapprox(
             scaling_diagnostics["largest_penalty_times_expanded_residual_coefficient_squared"],
-            1.1844381006360369e26;
+            1.000001e18;
             rtol = 1e-14,
         )
         @test isapprox(
             scaling_diagnostics["qoblib_symmetric_to_canonical_abs_ratio"],
-            2.624386183067761e7;
+            402440.34324785223;
             rtol = 1e-14,
         )
         @test isapprox(
             scaling_diagnostics["qoblib_symmetric_min_to_canonical_min_abs_ratio"],
-            2.4898183277180412e8;
+            1.4908409999999998e6;
             rtol = 1e-14,
         )
         @test occursin(
-            "default automatic penalty heuristic",
+            "objective-range exact-penalty policy",
             scaling_diagnostics["assessment"],
         )
 
@@ -440,16 +443,17 @@ function test_qoblib_benchmark_pilot()
         @test occursin("Reproduced converter penalty: 1.000001e6", markdown)
         @test occursin("match the pinned metrics row exactly", markdown)
         @test occursin("Model license: Apache License, Version 2.0", markdown)
-        @test occursin("Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/160", markdown)
+        @test occursin("Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/172", markdown)
         @test occursin("Target variable delta note", markdown)
         @test occursin("Source Variable Encoding", markdown)
         @test occursin("z and flow target binary variables: 1620", markdown)
         @test occursin("Penalty Scaling Diagnostics", markdown)
-        @test occursin("Largest applied penalty family: flow-balance", markdown)
-        @test occursin("Largest expanded residual scale family: flow-balance", markdown)
+        @test occursin("Automatic penalty policy: `ObjectiveRangePenalty`", markdown)
+        @test occursin("Largest applied penalty family: out-degree", markdown)
+        @test occursin("Largest expanded residual scale family: arc-linking", markdown)
         @test occursin("QOBLIB-style minimum-coefficient absolute ratio", markdown)
         @test occursin("Flow-balance constraints: 20", markdown)
-        @test occursin("major coefficient-scaling gap", markdown)
+        @test occursin("remaining coefficient-range gap is no longer caused", markdown)
         @test occursin("QOBLIB solution artifact consistency check: pass", markdown)
         @test markdown == _normalized_file(report_path)
 
@@ -489,19 +493,19 @@ function test_qoblib_benchmark_pilot()
         @test target["num_terms"] == 117882
         @test target["num_quadratic_terms"] == 113531
         @test isapprox(target["density"], 0.012450864912731353; rtol = 1e-14)
-        @test isapprox(target["min_coeff"], -1.4036904381157936e13; rtol = 1e-14)
-        @test isapprox(target["max_coeff"], 2.793883852788166e13; rtol = 1e-14)
+        @test isapprox(target["min_coeff"], -1.243353432550125e10; rtol = 1e-14)
+        @test isapprox(target["max_coeff"], 8.891018959017647e9; rtol = 1e-14)
         @test isapprox(
             target["qoblib_symmetric_min_coeff"],
-            -1.4036904364404846e13;
+            -1.243353432550125e10;
             rtol = 1e-14,
         )
         @test isapprox(
             target["qoblib_symmetric_max_coeff"],
-            1.5646506544178379e13;
+            8.019282334520212e9;
             rtol = 1e-14,
         )
-        @test isapprox(target["objective_offset"], 1.5412343291804879e13; rtol = 1e-14)
+        @test isapprox(target["objective_offset"], 3.573179430255874e11; rtol = 1e-14)
 
         metadata = report["toqubo"]["metadata"]
         @test metadata["source_variable_count"] == 441
@@ -509,7 +513,12 @@ function test_qoblib_benchmark_pilot()
         @test metadata["auxiliary_variable_count"] == 3763
         @test metadata["slack_variable_count"] == 421
         @test metadata["constraint_penalty_count"] == 461
-        @test length(metadata["constraint_penalties"]) == 3
+        @test length(metadata["constraint_penalties"]) == 1
+        @test isapprox(
+            only(metadata["constraint_penalties"]),
+            16_697.376350318606;
+            rtol = 1e-14,
+        )
         @test metadata["encoding_types"] == ["Binary"]
 
         comparison = report["comparison"]
@@ -553,7 +562,7 @@ function test_qoblib_benchmark_pilot()
         @test occursin("Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/162", markdown)
         @test occursin("Rounded CVRPLIB route cost", markdown)
         @test occursin("Redundant source constraints detected: 22", markdown)
-        @test occursin("major coefficient-scaling gap", markdown)
+        @test occursin("same order as the pinned QOBLIB QS metrics row", markdown)
         @test occursin("QOBLIB solution artifact consistency check: pass", markdown)
         @test markdown == _normalized_file(report_path)
 

--- a/test/unit/qoblib_benchmark.jl
+++ b/test/unit/qoblib_benchmark.jl
@@ -270,8 +270,6 @@ function test_qoblib_benchmark_pilot()
               "08-network/models/integer_lp/d3ver0int.zpl"
         @test report["provenance"]["qoblib_model_license"] ==
               "Apache License, Version 2.0"
-        @test report["provenance"]["penalty_scaling_follow_up"] ==
-              "https://github.com/JuliaQUBO/ToQUBO.jl/issues/172"
         @test report["provenance"]["canonical_qubo_metrics_csv_row"] ==
               "network05.qs,3640,0.05271012974940467,-4.75713475713e+17,4.5260616934376417e+18"
         @test report["instance"]["qoblib_id"] == "network05"
@@ -443,7 +441,6 @@ function test_qoblib_benchmark_pilot()
         @test occursin("Reproduced converter penalty: 1.000001e6", markdown)
         @test occursin("match the pinned metrics row exactly", markdown)
         @test occursin("Model license: Apache License, Version 2.0", markdown)
-        @test occursin("Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/172", markdown)
         @test occursin("Target variable delta note", markdown)
         @test occursin("Source Variable Encoding", markdown)
         @test occursin("z and flow target binary variables: 1620", markdown)


### PR DESCRIPTION
## Summary
- Add an objective-range exact-penalty policy as the default automatic penalty inference path.
- Keep the legacy maxgap heuristic available through `LegacyPenalty` and use it as the recorded fallback when objective-range inference cannot be certified.
- Expose `PenaltyPolicy` and `PenaltyPolicyMetadata`, including JuMP-facing get/set and metadata retrieval.
- Update QOBLib network/routing diagnostics, documentation, release notes, and golden tests for the tighter default penalties.

## Validation
- `julia --project=. -e 'using Test; import MathOptInterface as MOI; import ToQUBO; using ToQUBO: Attributes, Encoding; include("test/unit/compiler/penalties.jl"); test_compiler_penalties()'` (28/28)
- `julia --project=. -e 'import Pkg; Pkg.test()'` (1500/1500)
- `julia --project=docs docs/make.jl --skip-deploy`
- `git diff --check`

## Branch Hygiene
- Base branch: `main`
- Source branch point: `origin/main` at `b1406fea2db989bc9137569b7f2d2252da6f7b39`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #172.