### PR TITLE
Resolve routing penalty-scaling follow-up

### DIFF
--- a/benchmarks/qoblib/reports/routing_pilot.md
+++ b/benchmarks/qoblib/reports/routing_pilot.md
@@ -19,7 +19,7 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Canonical QUBO artifact note: The pinned QOBLIB tree contains the XSH-n20-k4-01.qs metrics row but no stored QS artifact, so this pilot compares against the metrics table row.
 - Model license: Apache License, Version 2.0
 - Data license: Creative Commons Attribution 4.0 International
-- Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/162
+- Penalty scaling issue: https://github.com/JuliaQUBO/ToQUBO.jl/issues/162
 - Generated collection label: ToQUBO-generated reformulation benchmark
 
 ## Upstream Verification
@@ -34,6 +34,15 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - node 1 is the depot and nodes 2 through 21 are the customers.
 - the QOBLIB solution file uses CVRPLIB customer numbering, so each listed customer id is mapped to QOBLIB node id customer + 1.
 - the ZIMPL model uses Euclidean sqrt distances in the LP objective, while the solution artifact reports the rounded CVRPLIB route cost.
+
+## QOBLIB Converter Evidence
+
+- Manual verification: true against QOBLIB commit `a686aaa09fe14651294f744f34d453d5dce9cf57`.
+- Converter path: `misc/convert_lp2qubo.py`.
+- Converter refs: misc/convert_lp2qubo.py:55-65, misc/convert_lp2qubo.py:82-89.
+- Converter convention: QOBLIB reads the LP with Gurobi, changes any continuous variables to integer, builds a Qiskit QuadraticProgram with from_gurobipy, converts it with QuadraticProgramToQubo() using the converter default penalty, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.
+- Qiskit converter pipeline: QuadraticProgramToQubo first handles a narrow set of special binary inequalities, then converts remaining inequalities to equalities with integer slack variables, encodes integer variables to binary, and finally applies equality penalties.
+- Qiskit default penalty note: For integer-coefficient constraints, Qiskit's automatic equality penalty is 1 plus the objective coefficient bound range. For this routing pilot that matches ToQUBO's objective-range penalty 16697.376350318606.
 
 ## Instance
 
@@ -104,6 +113,19 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Distinct constraint penalties: 16697.376
 - Encoding types: `Binary`
 
+## Converter Variable Accounting
+
+- Source arc binary variables: 420
+- Source load variables: 21
+- Source load binary variables: 168
+- Encoded source binary variables: 588
+- ToQUBO redundant constraints dropped: 22
+- QOBLIB retained redundant capacity upper-bound constraints: 21
+- QOBLIB retained redundant depot lower-bound constraints: 1
+- QOBLIB redundant slack bits vs ToQUBO: 176
+- Target variable delta explained by redundant slack bits: true
+- Target variable accounting note: Both converters use eight binary variables for each 0..231 load variable. QOBLIB/Qiskit retains 21 redundant y[i] <= 231 constraints and the redundant depot lower-bound constraint y[1] >= 0; each retained 0..231 slack contributes eight binary variables, explaining the 176-variable target delta exactly.
+
 ## Known Incumbent
 
 - Source objective using sqrt distances: 646.67036
@@ -126,14 +148,22 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 
 - Canonical QUBO metrics available for this instance: true
 - Target variable delta vs QOBLIB QS metrics: -176
-- Target variable delta note: ToQUBO generates fewer binary variables than the pinned QOBLIB QS metrics row. The current compiler also detects 22 explicit source constraints as always feasible, so the target-size delta should be interpreted alongside the redundant-constraint count and encoding metadata.
+- Target variable delta note: ToQUBO generates 176 fewer binary variables than the pinned QOBLIB QS metrics row. This is explained by redundant-constraint handling: QOBLIB/Qiskit retains 22 redundant routing bounds as equality constraints with 0..231 integer slacks, while ToQUBO detects and drops those constraints.
 - Redundant source constraints detected: 22
+- QOBLIB redundant slack bits vs ToQUBO: 176
+- Target variable delta explained by redundant slack bits: true
 - Target density delta vs QOBLIB QS metrics: 0.0007345511
 - Native min-coefficient delta vs QOBLIB QS metrics: 4.4107789e8
 - Native max-coefficient delta vs QOBLIB QS metrics: 1.4934133e9
 - QOBLIB-style min-coefficient delta vs QOBLIB QS metrics: 4.4107789e8
 - QOBLIB-style max-coefficient delta vs QOBLIB QS metrics: 6.2167672e8
+- QOBLIB-style minimum-coefficient absolute ratio: 0.96574049
+- QOBLIB-style maximum-coefficient absolute ratio: 1.0840376
+- QOBLIB-style largest absolute coefficient ratio: 0.96574049
+- Penalty-scaling divergence resolved: true
+- Routing-specific penalty scaling needed: false
+- Penalty scaling resolution note: The original issue-162 coefficient-range divergence no longer reproduces under the default objective-range penalty policy; ToQUBO's QOBLIB-style routing coefficient range is within the pinned QS row's 1e10 scale. ToQUBO's largest absolute coefficient is slightly smaller than QOBLIB's pinned largest absolute coefficient, although its positive-side maximum is larger. No routing-specific penalty scaling is needed for this pilot.
 
-## Follow-Up
+## Penalty Scaling Resolution
 
-The objective-range automatic penalty policy brings ToQUBO's generated routing QUBO coefficient range into the same order as the pinned QOBLIB QS metrics row under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass. Remaining routing differences should be interpreted alongside ToQUBO's variable and slack encodings, redundant-constraint handling, and target-variable delta; those benchmark-expansion questions remain tracked in https://github.com/JuliaQUBO/ToQUBO.jl/issues/162.
+The issue-162 penalty-scaling divergence does not reproduce under the objective-range automatic penalty policy. ToQUBO's QOBLIB-style routing coefficient range is within the pinned QOBLIB QS metrics row's 1e10 scale under the symmetrized convention, and the source transcription and incumbent feasibility checks pass. No routing-specific penalty scaling is needed for this pilot. The exact target-size delta is explained by QOBLIB/Qiskit retaining 22 redundant routing bounds as 176 slack bits that ToQUBO drops. Remaining coefficient-extrema differences are conversion-convention effects, not evidence that the objective-range penalty is worse.

--- a/benchmarks/qoblib/reports/routing_pilot.md
+++ b/benchmarks/qoblib/reports/routing_pilot.md
@@ -42,7 +42,9 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - Converter refs: misc/convert_lp2qubo.py:55-65, misc/convert_lp2qubo.py:82-89.
 - Converter convention: QOBLIB reads the LP with Gurobi, changes any continuous variables to integer, builds a Qiskit QuadraticProgram with from_gurobipy, converts it with QuadraticProgramToQubo() using the converter default penalty, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.
 - Qiskit converter pipeline: QuadraticProgramToQubo first handles a narrow set of special binary inequalities, then converts remaining inequalities to equalities with integer slack variables, encodes integer variables to binary, and finally applies equality penalties.
-- Qiskit default penalty note: For integer-coefficient constraints, Qiskit's automatic equality penalty is 1 plus the objective coefficient bound range. For this routing pilot that matches ToQUBO's objective-range penalty 16697.376350318606.
+- Qiskit optimization version checked: 0.7.0
+- Qiskit penalty formula checked: LinearEqualityToPenalty._auto_define_penalty and LinearInequalityToPenalty._auto_define_penalty return 1 plus the objective linear/quadratic coefficient bound range for integer-coefficient constraints.
+- Qiskit default penalty note: For integer-coefficient constraints, Qiskit's automatic equality penalty is 1 plus the objective coefficient bound range. The pinned QOBLIB converter uses that default path, and for this routing pilot the formula matches ToQUBO's objective-range penalty 16697.376350318606.
 
 ## Instance
 
@@ -124,7 +126,7 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - QOBLIB retained redundant depot lower-bound constraints: 1
 - QOBLIB redundant slack bits vs ToQUBO: 176
 - Target variable delta explained by redundant slack bits: true
-- Target variable accounting note: Both converters use eight binary variables for each 0..231 load variable. QOBLIB/Qiskit retains 21 redundant y[i] <= 231 constraints and the redundant depot lower-bound constraint y[1] >= 0; each retained 0..231 slack contributes eight binary variables, explaining the 176-variable target delta exactly.
+- Target variable accounting note: Both converters use 8 binary variables for each 0..231 load variable. QOBLIB/Qiskit retains 21 redundant y[i] <= 231 constraints and the redundant depot lower-bound constraint y[1] >= 0; each retained 0..231 slack contributes 8 binary variables, explaining the 176-variable target delta exactly.
 
 ## Known Incumbent
 
@@ -160,6 +162,7 @@ This report is a ToQUBO-generated reformulation benchmark. It is not a canonical
 - QOBLIB-style minimum-coefficient absolute ratio: 0.96574049
 - QOBLIB-style maximum-coefficient absolute ratio: 1.0840376
 - QOBLIB-style largest absolute coefficient ratio: 0.96574049
+- Same-order coefficient ratio bounds: 0.1 to 10.0
 - Penalty-scaling divergence resolved: true
 - Routing-specific penalty scaling needed: false
 - Penalty scaling resolution note: The original issue-162 coefficient-range divergence no longer reproduces under the default objective-range penalty policy; ToQUBO's QOBLIB-style routing coefficient range is within the pinned QS row's 1e10 scale. ToQUBO's largest absolute coefficient is slightly smaller than QOBLIB's pinned largest absolute coefficient, although its positive-side maximum is larger. No routing-specific penalty scaling is needed for this pilot.

--- a/benchmarks/qoblib/routing_pilot.jl
+++ b/benchmarks/qoblib/routing_pilot.jl
@@ -154,6 +154,17 @@ const QOBLIB_QUBO_METRICS = Dict{String,Any}(
     "max_coeff" => 7_397_605_618.245156,
 )
 
+const LOAD_BINARY_BITS = ceil(Int, log2(CAPACITY + 1))
+const QOBLIB_REDUNDANT_CAPACITY_UPPER_BOUND_CONSTRAINTS = NUM_NODES
+const QOBLIB_REDUNDANT_DEPOT_LOWER_BOUND_CONSTRAINTS = 1
+const QOBLIB_REDUNDANT_SLACK_BITS =
+    LOAD_BINARY_BITS * (
+        QOBLIB_REDUNDANT_CAPACITY_UPPER_BOUND_CONSTRAINTS +
+        QOBLIB_REDUNDANT_DEPOT_LOWER_BOUND_CONSTRAINTS
+    )
+const COEFFICIENT_SAME_ORDER_LOWER = 0.1
+const COEFFICIENT_SAME_ORDER_UPPER = 10.0
+
 const QOBLIB_CONVERTER_EVIDENCE = Dict{String,Any}(
     "manual_verification" => true,
     "converter_path" => "misc/convert_lp2qubo.py",
@@ -165,22 +176,30 @@ const QOBLIB_CONVERTER_EVIDENCE = Dict{String,Any}(
         "QOBLIB reads the LP with Gurobi, changes any continuous variables to integer, builds a Qiskit QuadraticProgram with from_gurobipy, converts it with QuadraticProgramToQubo() using the converter default penalty, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.",
     "qiskit_converter_pipeline" =>
         "QuadraticProgramToQubo first handles a narrow set of special binary inequalities, then converts remaining inequalities to equalities with integer slack variables, encodes integer variables to binary, and finally applies equality penalties.",
+    "qiskit_optimization_version_checked" => "0.7.0",
+    "qiskit_penalty_formula_checked" =>
+        "LinearEqualityToPenalty._auto_define_penalty and LinearInequalityToPenalty._auto_define_penalty return 1 plus the objective linear/quadratic coefficient bound range for integer-coefficient constraints.",
     "qiskit_default_penalty_note" =>
-        "For integer-coefficient constraints, Qiskit's automatic equality penalty is 1 plus the objective coefficient bound range. For this routing pilot that matches ToQUBO's objective-range penalty 16697.376350318606.",
+        "For integer-coefficient constraints, Qiskit's automatic equality penalty is 1 plus the objective coefficient bound range. The pinned QOBLIB converter uses that default path, and for this routing pilot the formula matches ToQUBO's objective-range penalty 16697.376350318606.",
 )
 
 const ROUTING_CONVERTER_ACCOUNTING = Dict{String,Any}(
     "source_arc_binary_variables" => length(ARCS),
     "source_load_variables" => NUM_NODES,
-    "source_load_binary_variables" => 8 * NUM_NODES,
-    "source_binary_variables_after_encoding" => length(ARCS) + 8 * NUM_NODES,
-    "toqubo_redundant_constraints_dropped" => 22,
-    "qoblib_redundant_capacity_upper_bound_constraints" => NUM_NODES,
-    "qoblib_redundant_depot_lower_bound_constraints" => 1,
-    "qoblib_redundant_slack_bits" => 176,
+    "source_load_binary_variables" => LOAD_BINARY_BITS * NUM_NODES,
+    "source_binary_variables_after_encoding" =>
+        length(ARCS) + LOAD_BINARY_BITS * NUM_NODES,
+    "toqubo_redundant_constraints_dropped" =>
+        QOBLIB_REDUNDANT_CAPACITY_UPPER_BOUND_CONSTRAINTS +
+        QOBLIB_REDUNDANT_DEPOT_LOWER_BOUND_CONSTRAINTS,
+    "qoblib_redundant_capacity_upper_bound_constraints" =>
+        QOBLIB_REDUNDANT_CAPACITY_UPPER_BOUND_CONSTRAINTS,
+    "qoblib_redundant_depot_lower_bound_constraints" =>
+        QOBLIB_REDUNDANT_DEPOT_LOWER_BOUND_CONSTRAINTS,
+    "qoblib_redundant_slack_bits" => QOBLIB_REDUNDANT_SLACK_BITS,
     "target_variable_delta_explained_by_redundant_slack_bits" => true,
     "target_variable_accounting_note" =>
-        "Both converters use eight binary variables for each 0..231 load variable. QOBLIB/Qiskit retains 21 redundant y[i] <= 231 constraints and the redundant depot lower-bound constraint y[1] >= 0; each retained 0..231 slack contributes eight binary variables, explaining the 176-variable target delta exactly.",
+        "Both converters use $(LOAD_BINARY_BITS) binary variables for each 0..231 load variable. QOBLIB/Qiskit retains $(QOBLIB_REDUNDANT_CAPACITY_UPPER_BOUND_CONSTRAINTS) redundant y[i] <= 231 constraints and the redundant depot lower-bound constraint y[1] >= 0; each retained 0..231 slack contributes $(LOAD_BINARY_BITS) binary variables, explaining the $(QOBLIB_REDUNDANT_SLACK_BITS)-variable target delta exactly.",
 )
 
 const KNOWN_INCUMBENT = Dict{String,Any}(
@@ -550,21 +569,36 @@ function _known_incumbent_summary()
     )
 end
 
+function _same_order_coefficient_ratio(ratio::Real)
+    return COEFFICIENT_SAME_ORDER_LOWER <= ratio <= COEFFICIENT_SAME_ORDER_UPPER
+end
+
 function _comparison(target, metadata)
+    redundant_slack_bits = ROUTING_CONVERTER_ACCOUNTING["qoblib_redundant_slack_bits"]
+    target_variable_delta = target["num_variables"] - QOBLIB_QUBO_METRICS["num_variables"]
+    qoblib_symmetric_min_ratio =
+        abs(target["qoblib_symmetric_min_coeff"]) / abs(QOBLIB_QUBO_METRICS["min_coeff"])
+    qoblib_symmetric_max_ratio =
+        abs(target["qoblib_symmetric_max_coeff"]) / abs(QOBLIB_QUBO_METRICS["max_coeff"])
+    qoblib_symmetric_abs_bound_ratio =
+        max(
+            abs(target["qoblib_symmetric_min_coeff"]),
+            abs(target["qoblib_symmetric_max_coeff"]),
+        ) / max(abs(QOBLIB_QUBO_METRICS["min_coeff"]), abs(QOBLIB_QUBO_METRICS["max_coeff"]))
+    penalty_scaling_divergence_resolved =
+        _same_order_coefficient_ratio(qoblib_symmetric_abs_bound_ratio)
+
     return Dict{String,Any}(
         "canonical_qubo_metrics_available" => QOBLIB_QUBO_METRICS["available"],
-        "target_variable_delta_vs_qoblib_qs" =>
-            target["num_variables"] - QOBLIB_QUBO_METRICS["num_variables"],
+        "target_variable_delta_vs_qoblib_qs" => target_variable_delta,
         "target_variable_delta_note" =>
-            "ToQUBO generates 176 fewer binary variables than the pinned QOBLIB QS metrics row. This is explained by redundant-constraint handling: QOBLIB/Qiskit retains 22 redundant routing bounds as equality constraints with 0..231 integer slacks, while ToQUBO detects and drops those constraints.",
+            "ToQUBO generates $(redundant_slack_bits) fewer binary variables than the pinned QOBLIB QS metrics row. This is explained by redundant-constraint handling: QOBLIB/Qiskit retains 22 redundant routing bounds as equality constraints with 0..231 integer slacks, while ToQUBO detects and drops those constraints.",
         "redundant_constraint_count" =>
             QOBLIB_SOURCE_METRICS["num_linear_constraints"] -
             metadata["constraint_penalty_count"],
-        "qoblib_redundant_slack_bits_vs_toqubo" =>
-            ROUTING_CONVERTER_ACCOUNTING["qoblib_redundant_slack_bits"],
+        "qoblib_redundant_slack_bits_vs_toqubo" => redundant_slack_bits,
         "target_variable_delta_explained_by_redundant_slack_bits" =>
-            target["num_variables"] - QOBLIB_QUBO_METRICS["num_variables"] ==
-            -ROUTING_CONVERTER_ACCOUNTING["qoblib_redundant_slack_bits"],
+            target_variable_delta == -redundant_slack_bits,
         "density_delta_vs_qoblib_qs" =>
             target["density"] - QOBLIB_QUBO_METRICS["density"],
         "min_coeff_delta_vs_qoblib_qs" =>
@@ -576,16 +610,14 @@ function _comparison(target, metadata)
         "qoblib_symmetric_max_coeff_delta_vs_qoblib_qs" =>
             target["qoblib_symmetric_max_coeff"] - QOBLIB_QUBO_METRICS["max_coeff"],
         "qoblib_symmetric_min_to_canonical_min_abs_ratio" =>
-            abs(target["qoblib_symmetric_min_coeff"]) /
-            abs(QOBLIB_QUBO_METRICS["min_coeff"]),
+            qoblib_symmetric_min_ratio,
         "qoblib_symmetric_max_to_canonical_max_abs_ratio" =>
-            abs(target["qoblib_symmetric_max_coeff"]) /
-            abs(QOBLIB_QUBO_METRICS["max_coeff"]),
-        "qoblib_symmetric_abs_bound_ratio" =>
-            max(abs(target["qoblib_symmetric_min_coeff"]), abs(target["qoblib_symmetric_max_coeff"])) /
-            max(abs(QOBLIB_QUBO_METRICS["min_coeff"]), abs(QOBLIB_QUBO_METRICS["max_coeff"])),
-        "penalty_scaling_divergence_resolved" => true,
-        "routing_specific_scaling_needed" => false,
+            qoblib_symmetric_max_ratio,
+        "qoblib_symmetric_abs_bound_ratio" => qoblib_symmetric_abs_bound_ratio,
+        "coefficient_same_order_lower" => COEFFICIENT_SAME_ORDER_LOWER,
+        "coefficient_same_order_upper" => COEFFICIENT_SAME_ORDER_UPPER,
+        "penalty_scaling_divergence_resolved" => penalty_scaling_divergence_resolved,
+        "routing_specific_scaling_needed" => !penalty_scaling_divergence_resolved,
         "penalty_scaling_resolution_note" =>
             "The original issue-162 coefficient-range divergence no longer reproduces under the default objective-range penalty policy; ToQUBO's QOBLIB-style routing coefficient range is within the pinned QS row's 1e10 scale. ToQUBO's largest absolute coefficient is slightly smaller than QOBLIB's pinned largest absolute coefficient, although its positive-side maximum is larger. No routing-specific penalty scaling is needed for this pilot.",
     )
@@ -726,6 +758,11 @@ function write_markdown_report(io::IO, report::AbstractDict)
     write(io, "- Converter refs: $(join(converter["converter_line_refs"], ", ")).\n")
     write(io, "- Converter convention: $(converter["converter_convention"])\n")
     write(io, "- Qiskit converter pipeline: $(converter["qiskit_converter_pipeline"])\n")
+    write(
+        io,
+        "- Qiskit optimization version checked: $(converter["qiskit_optimization_version_checked"])\n",
+    )
+    write(io, "- Qiskit penalty formula checked: $(converter["qiskit_penalty_formula_checked"])\n")
     write(io, "- Qiskit default penalty note: $(converter["qiskit_default_penalty_note"])\n\n")
 
     write(io, "## Instance\n\n")
@@ -967,6 +1004,10 @@ function write_markdown_report(io::IO, report::AbstractDict)
     write(
         io,
         "- QOBLIB-style largest absolute coefficient ratio: $(_fmt(comparison["qoblib_symmetric_abs_bound_ratio"]))\n",
+    )
+    write(
+        io,
+        "- Same-order coefficient ratio bounds: $(_fmt(comparison["coefficient_same_order_lower"])) to $(_fmt(comparison["coefficient_same_order_upper"]))\n",
     )
     write(
         io,

--- a/benchmarks/qoblib/routing_pilot.jl
+++ b/benchmarks/qoblib/routing_pilot.jl
@@ -154,6 +154,35 @@ const QOBLIB_QUBO_METRICS = Dict{String,Any}(
     "max_coeff" => 7_397_605_618.245156,
 )
 
+const QOBLIB_CONVERTER_EVIDENCE = Dict{String,Any}(
+    "manual_verification" => true,
+    "converter_path" => "misc/convert_lp2qubo.py",
+    "converter_line_refs" => [
+        "misc/convert_lp2qubo.py:55-65",
+        "misc/convert_lp2qubo.py:82-89",
+    ],
+    "converter_convention" =>
+        "QOBLIB reads the LP with Gurobi, changes any continuous variables to integer, builds a Qiskit QuadraticProgram with from_gurobipy, converts it with QuadraticProgramToQubo() using the converter default penalty, writes linear coefficients on the diagonal, symmetrizes Q as (Q + Q') / 2, and writes the objective offset separately.",
+    "qiskit_converter_pipeline" =>
+        "QuadraticProgramToQubo first handles a narrow set of special binary inequalities, then converts remaining inequalities to equalities with integer slack variables, encodes integer variables to binary, and finally applies equality penalties.",
+    "qiskit_default_penalty_note" =>
+        "For integer-coefficient constraints, Qiskit's automatic equality penalty is 1 plus the objective coefficient bound range. For this routing pilot that matches ToQUBO's objective-range penalty 16697.376350318606.",
+)
+
+const ROUTING_CONVERTER_ACCOUNTING = Dict{String,Any}(
+    "source_arc_binary_variables" => length(ARCS),
+    "source_load_variables" => NUM_NODES,
+    "source_load_binary_variables" => 8 * NUM_NODES,
+    "source_binary_variables_after_encoding" => length(ARCS) + 8 * NUM_NODES,
+    "toqubo_redundant_constraints_dropped" => 22,
+    "qoblib_redundant_capacity_upper_bound_constraints" => NUM_NODES,
+    "qoblib_redundant_depot_lower_bound_constraints" => 1,
+    "qoblib_redundant_slack_bits" => 176,
+    "target_variable_delta_explained_by_redundant_slack_bits" => true,
+    "target_variable_accounting_note" =>
+        "Both converters use eight binary variables for each 0..231 load variable. QOBLIB/Qiskit retains 21 redundant y[i] <= 231 constraints and the redundant depot lower-bound constraint y[1] >= 0; each retained 0..231 slack contributes eight binary variables, explaining the 176-variable target delta exactly.",
+)
+
 const KNOWN_INCUMBENT = Dict{String,Any}(
     "qoblib_solution_cost" => 646,
     "solution_routes_customer_ids" => [
@@ -527,10 +556,15 @@ function _comparison(target, metadata)
         "target_variable_delta_vs_qoblib_qs" =>
             target["num_variables"] - QOBLIB_QUBO_METRICS["num_variables"],
         "target_variable_delta_note" =>
-            "ToQUBO generates fewer binary variables than the pinned QOBLIB QS metrics row. The current compiler also detects 22 explicit source constraints as always feasible, so the target-size delta should be interpreted alongside the redundant-constraint count and encoding metadata.",
+            "ToQUBO generates 176 fewer binary variables than the pinned QOBLIB QS metrics row. This is explained by redundant-constraint handling: QOBLIB/Qiskit retains 22 redundant routing bounds as equality constraints with 0..231 integer slacks, while ToQUBO detects and drops those constraints.",
         "redundant_constraint_count" =>
             QOBLIB_SOURCE_METRICS["num_linear_constraints"] -
             metadata["constraint_penalty_count"],
+        "qoblib_redundant_slack_bits_vs_toqubo" =>
+            ROUTING_CONVERTER_ACCOUNTING["qoblib_redundant_slack_bits"],
+        "target_variable_delta_explained_by_redundant_slack_bits" =>
+            target["num_variables"] - QOBLIB_QUBO_METRICS["num_variables"] ==
+            -ROUTING_CONVERTER_ACCOUNTING["qoblib_redundant_slack_bits"],
         "density_delta_vs_qoblib_qs" =>
             target["density"] - QOBLIB_QUBO_METRICS["density"],
         "min_coeff_delta_vs_qoblib_qs" =>
@@ -541,6 +575,19 @@ function _comparison(target, metadata)
             target["qoblib_symmetric_min_coeff"] - QOBLIB_QUBO_METRICS["min_coeff"],
         "qoblib_symmetric_max_coeff_delta_vs_qoblib_qs" =>
             target["qoblib_symmetric_max_coeff"] - QOBLIB_QUBO_METRICS["max_coeff"],
+        "qoblib_symmetric_min_to_canonical_min_abs_ratio" =>
+            abs(target["qoblib_symmetric_min_coeff"]) /
+            abs(QOBLIB_QUBO_METRICS["min_coeff"]),
+        "qoblib_symmetric_max_to_canonical_max_abs_ratio" =>
+            abs(target["qoblib_symmetric_max_coeff"]) /
+            abs(QOBLIB_QUBO_METRICS["max_coeff"]),
+        "qoblib_symmetric_abs_bound_ratio" =>
+            max(abs(target["qoblib_symmetric_min_coeff"]), abs(target["qoblib_symmetric_max_coeff"])) /
+            max(abs(QOBLIB_QUBO_METRICS["min_coeff"]), abs(QOBLIB_QUBO_METRICS["max_coeff"])),
+        "penalty_scaling_divergence_resolved" => true,
+        "routing_specific_scaling_needed" => false,
+        "penalty_scaling_resolution_note" =>
+            "The original issue-162 coefficient-range divergence no longer reproduces under the default objective-range penalty policy; ToQUBO's QOBLIB-style routing coefficient range is within the pinned QS row's 1e10 scale. ToQUBO's largest absolute coefficient is slightly smaller than QOBLIB's pinned largest absolute coefficient, although its positive-side maximum is larger. No routing-specific penalty scaling is needed for this pilot.",
     )
 end
 
@@ -555,6 +602,8 @@ function run_routing_pilot()
     return Dict{String,Any}(
         "provenance" => copy(PROVENANCE),
         "upstream_verification" => copy(UPSTREAM_VERIFICATION),
+        "qoblib_converter_evidence" => copy(QOBLIB_CONVERTER_EVIDENCE),
+        "converter_accounting" => copy(ROUTING_CONVERTER_ACCOUNTING),
         "instance" => copy(INSTANCE),
         "source" => Dict{String,Any}(
             "modeling_assumptions" => [
@@ -586,7 +635,7 @@ function run_routing_pilot()
         "known_incumbent" => _known_incumbent_summary(),
         "comparison" => _comparison(target, metadata),
         "follow_up" =>
-            "The objective-range automatic penalty policy brings ToQUBO's generated routing QUBO coefficient range into the same order as the pinned QOBLIB QS metrics row under the QOBLIB-style symmetrized convention. The source transcription and incumbent feasibility checks pass. Remaining routing differences should be interpreted alongside ToQUBO's variable and slack encodings, redundant-constraint handling, and target-variable delta; those benchmark-expansion questions remain tracked in https://github.com/JuliaQUBO/ToQUBO.jl/issues/162.",
+            "The issue-162 penalty-scaling divergence does not reproduce under the objective-range automatic penalty policy. ToQUBO's QOBLIB-style routing coefficient range is within the pinned QOBLIB QS metrics row's 1e10 scale under the symmetrized convention, and the source transcription and incumbent feasibility checks pass. No routing-specific penalty scaling is needed for this pilot. The exact target-size delta is explained by QOBLIB/Qiskit retaining 22 redundant routing bounds as 176 slack bits that ToQUBO drops. Remaining coefficient-extrema differences are conversion-convention effects, not evidence that the objective-range penalty is worse.",
     )
 end
 
@@ -609,6 +658,8 @@ end
 function write_markdown_report(io::IO, report::AbstractDict)
     provenance = report["provenance"]
     verification = report["upstream_verification"]
+    converter = report["qoblib_converter_evidence"]
+    accounting = report["converter_accounting"]
     instance = report["instance"]
     source = report["source"]
     qoblib_source = source["qoblib_metrics"]
@@ -646,7 +697,7 @@ function write_markdown_report(io::IO, report::AbstractDict)
     write(io, "- Canonical QUBO artifact note: $(provenance["canonical_qubo_artifact_note"])\n")
     write(io, "- Model license: $(provenance["qoblib_model_license"])\n")
     write(io, "- Data license: $(provenance["qoblib_data_license"])\n")
-    write(io, "- Penalty scaling follow-up: $(provenance["penalty_scaling_follow_up"])\n")
+    write(io, "- Penalty scaling issue: $(provenance["penalty_scaling_follow_up"])\n")
     write(io, "- Generated collection label: $(provenance["collection"])\n\n")
 
     write(io, "## Upstream Verification\n\n")
@@ -665,6 +716,17 @@ function write_markdown_report(io::IO, report::AbstractDict)
     end
 
     write(io, "\n")
+
+    write(io, "## QOBLIB Converter Evidence\n\n")
+    write(
+        io,
+        "- Manual verification: $(_fmt(converter["manual_verification"])) against QOBLIB commit `$(provenance["qoblib_commit"])`.\n",
+    )
+    write(io, "- Converter path: `$(converter["converter_path"])`.\n")
+    write(io, "- Converter refs: $(join(converter["converter_line_refs"], ", ")).\n")
+    write(io, "- Converter convention: $(converter["converter_convention"])\n")
+    write(io, "- Qiskit converter pipeline: $(converter["qiskit_converter_pipeline"])\n")
+    write(io, "- Qiskit default penalty note: $(converter["qiskit_default_penalty_note"])\n\n")
 
     write(io, "## Instance\n\n")
     write(io, "- QOBLIB id: `$(instance["qoblib_id"])`\n")
@@ -793,6 +855,42 @@ function write_markdown_report(io::IO, report::AbstractDict)
     write(io, "- Distinct constraint penalties: $(join(_fmt.(metadata["constraint_penalties"]), ", "))\n")
     write(io, "- Encoding types: `$(join(metadata["encoding_types"], "`, `"))`\n")
 
+    write(io, "\n## Converter Variable Accounting\n\n")
+    write(
+        io,
+        "- Source arc binary variables: $(accounting["source_arc_binary_variables"])\n",
+    )
+    write(io, "- Source load variables: $(accounting["source_load_variables"])\n")
+    write(
+        io,
+        "- Source load binary variables: $(accounting["source_load_binary_variables"])\n",
+    )
+    write(
+        io,
+        "- Encoded source binary variables: $(accounting["source_binary_variables_after_encoding"])\n",
+    )
+    write(
+        io,
+        "- ToQUBO redundant constraints dropped: $(accounting["toqubo_redundant_constraints_dropped"])\n",
+    )
+    write(
+        io,
+        "- QOBLIB retained redundant capacity upper-bound constraints: $(accounting["qoblib_redundant_capacity_upper_bound_constraints"])\n",
+    )
+    write(
+        io,
+        "- QOBLIB retained redundant depot lower-bound constraints: $(accounting["qoblib_redundant_depot_lower_bound_constraints"])\n",
+    )
+    write(
+        io,
+        "- QOBLIB redundant slack bits vs ToQUBO: $(accounting["qoblib_redundant_slack_bits"])\n",
+    )
+    write(
+        io,
+        "- Target variable delta explained by redundant slack bits: $(_fmt(accounting["target_variable_delta_explained_by_redundant_slack_bits"]))\n",
+    )
+    write(io, "- Target variable accounting note: $(accounting["target_variable_accounting_note"])\n")
+
     write(io, "\n## Known Incumbent\n\n")
     write(io, "- Source objective using sqrt distances: $(_fmt(incumbent["source_objective"]))\n")
     write(io, "- Rounded CVRPLIB route cost: $(_fmt(incumbent["rounded_route_cost"]))\n")
@@ -832,6 +930,14 @@ function write_markdown_report(io::IO, report::AbstractDict)
     write(io, "- Redundant source constraints detected: $(comparison["redundant_constraint_count"])\n")
     write(
         io,
+        "- QOBLIB redundant slack bits vs ToQUBO: $(comparison["qoblib_redundant_slack_bits_vs_toqubo"])\n",
+    )
+    write(
+        io,
+        "- Target variable delta explained by redundant slack bits: $(_fmt(comparison["target_variable_delta_explained_by_redundant_slack_bits"]))\n",
+    )
+    write(
+        io,
         "- Target density delta vs QOBLIB QS metrics: $(_fmt(comparison["density_delta_vs_qoblib_qs"]))\n",
     )
     write(
@@ -850,8 +956,29 @@ function write_markdown_report(io::IO, report::AbstractDict)
         io,
         "- QOBLIB-style max-coefficient delta vs QOBLIB QS metrics: $(_fmt(comparison["qoblib_symmetric_max_coeff_delta_vs_qoblib_qs"]))\n",
     )
+    write(
+        io,
+        "- QOBLIB-style minimum-coefficient absolute ratio: $(_fmt(comparison["qoblib_symmetric_min_to_canonical_min_abs_ratio"]))\n",
+    )
+    write(
+        io,
+        "- QOBLIB-style maximum-coefficient absolute ratio: $(_fmt(comparison["qoblib_symmetric_max_to_canonical_max_abs_ratio"]))\n",
+    )
+    write(
+        io,
+        "- QOBLIB-style largest absolute coefficient ratio: $(_fmt(comparison["qoblib_symmetric_abs_bound_ratio"]))\n",
+    )
+    write(
+        io,
+        "- Penalty-scaling divergence resolved: $(_fmt(comparison["penalty_scaling_divergence_resolved"]))\n",
+    )
+    write(
+        io,
+        "- Routing-specific penalty scaling needed: $(_fmt(comparison["routing_specific_scaling_needed"]))\n",
+    )
+    write(io, "- Penalty scaling resolution note: $(comparison["penalty_scaling_resolution_note"])\n")
 
-    write(io, "\n## Follow-Up\n\n")
+    write(io, "\n## Penalty Scaling Resolution\n\n")
     write(io, report["follow_up"], "\n")
 
     return nothing

--- a/test/unit/qoblib_benchmark.jl
+++ b/test/unit/qoblib_benchmark.jl
@@ -477,6 +477,13 @@ function test_qoblib_benchmark_pilot()
         @test "09-routing/solutions/XSH-n20-k4-01.opt.sol:1-5" in
               verification["solution_line_refs"]
 
+        converter = report["qoblib_converter_evidence"]
+        @test converter["manual_verification"] === true
+        @test converter["converter_path"] == "misc/convert_lp2qubo.py"
+        @test occursin("QuadraticProgramToQubo", converter["converter_convention"])
+        @test occursin("integer slack variables", converter["qiskit_converter_pipeline"])
+        @test occursin("16697.376350318606", converter["qiskit_default_penalty_note"])
+
         source = report["source"]
         @test source["generated_metrics"]["num_vars"] == 441
         @test source["generated_metrics"]["num_linear_constraints"] == 483
@@ -518,14 +525,51 @@ function test_qoblib_benchmark_pilot()
         )
         @test metadata["encoding_types"] == ["Binary"]
 
+        accounting = report["converter_accounting"]
+        @test accounting["source_arc_binary_variables"] == 420
+        @test accounting["source_load_variables"] == 21
+        @test accounting["source_load_binary_variables"] == 168
+        @test accounting["source_binary_variables_after_encoding"] == 588
+        @test accounting["toqubo_redundant_constraints_dropped"] == 22
+        @test accounting["qoblib_redundant_capacity_upper_bound_constraints"] == 21
+        @test accounting["qoblib_redundant_depot_lower_bound_constraints"] == 1
+        @test accounting["qoblib_redundant_slack_bits"] == 176
+        @test accounting["target_variable_delta_explained_by_redundant_slack_bits"] ===
+              true
+        @test occursin("explaining the 176-variable target delta exactly", accounting["target_variable_accounting_note"])
+
         comparison = report["comparison"]
         @test comparison["canonical_qubo_metrics_available"] === true
         @test comparison["target_variable_delta_vs_qoblib_qs"] == -176
         @test comparison["redundant_constraint_count"] == 22
         @test occursin("fewer binary variables", comparison["target_variable_delta_note"])
+        @test comparison["qoblib_redundant_slack_bits_vs_toqubo"] == 176
+        @test comparison["target_variable_delta_explained_by_redundant_slack_bits"] ===
+              true
+        @test comparison["penalty_scaling_divergence_resolved"] === true
+        @test comparison["routing_specific_scaling_needed"] === false
+        @test occursin(
+            "No routing-specific penalty scaling is needed",
+            comparison["penalty_scaling_resolution_note"],
+        )
         @test isapprox(
             comparison["density_delta_vs_qoblib_qs"],
             0.0007345510955949104;
+            rtol = 1e-14,
+        )
+        @test isapprox(
+            comparison["qoblib_symmetric_min_to_canonical_min_abs_ratio"],
+            0.9657404909630436;
+            rtol = 1e-14,
+        )
+        @test isapprox(
+            comparison["qoblib_symmetric_max_to_canonical_max_abs_ratio"],
+            1.0840375586854452;
+            rtol = 1e-14,
+        )
+        @test isapprox(
+            comparison["qoblib_symmetric_abs_bound_ratio"],
+            0.9657404909630436;
             rtol = 1e-14,
         )
 
@@ -555,11 +599,18 @@ function test_qoblib_benchmark_pilot()
         @test occursin("QOBLib Routing Reformulation Pilot", markdown)
         @test occursin("XSH-n20-k4-01.lp", markdown)
         @test occursin("Canonical QUBO artifact available at pinned commit: false", markdown)
+        @test occursin("QOBLIB Converter Evidence", markdown)
         @test occursin("Model license: Apache License, Version 2.0", markdown)
-        @test occursin("Penalty scaling follow-up: https://github.com/JuliaQUBO/ToQUBO.jl/issues/162", markdown)
+        @test occursin("Penalty scaling issue: https://github.com/JuliaQUBO/ToQUBO.jl/issues/162", markdown)
+        @test occursin("Converter Variable Accounting", markdown)
+        @test occursin("QOBLIB redundant slack bits vs ToQUBO: 176", markdown)
+        @test occursin("target delta exactly", markdown)
         @test occursin("Rounded CVRPLIB route cost", markdown)
         @test occursin("Redundant source constraints detected: 22", markdown)
-        @test occursin("same order as the pinned QOBLIB QS metrics row", markdown)
+        @test occursin("largest absolute coefficient ratio", markdown)
+        @test occursin("Penalty-scaling divergence resolved: true", markdown)
+        @test occursin("Routing-specific penalty scaling needed: false", markdown)
+        @test occursin("No routing-specific penalty scaling is needed", markdown)
         @test occursin("QOBLIB solution artifact consistency check: pass", markdown)
         @test markdown == _normalized_file(report_path)
 

--- a/test/unit/qoblib_benchmark.jl
+++ b/test/unit/qoblib_benchmark.jl
@@ -482,6 +482,11 @@ function test_qoblib_benchmark_pilot()
         @test converter["converter_path"] == "misc/convert_lp2qubo.py"
         @test occursin("QuadraticProgramToQubo", converter["converter_convention"])
         @test occursin("integer slack variables", converter["qiskit_converter_pipeline"])
+        @test converter["qiskit_optimization_version_checked"] == "0.7.0"
+        @test occursin(
+            "1 plus the objective linear/quadratic coefficient bound range",
+            converter["qiskit_penalty_formula_checked"],
+        )
         @test occursin("16697.376350318606", converter["qiskit_default_penalty_note"])
 
         source = report["source"]
@@ -572,6 +577,8 @@ function test_qoblib_benchmark_pilot()
             0.9657404909630436;
             rtol = 1e-14,
         )
+        @test comparison["coefficient_same_order_lower"] == 0.1
+        @test comparison["coefficient_same_order_upper"] == 10.0
 
         incumbent = report["known_incumbent"]
         @test isapprox(incumbent["source_objective"], 646.6703590218194; rtol = 1e-14)
@@ -600,6 +607,8 @@ function test_qoblib_benchmark_pilot()
         @test occursin("XSH-n20-k4-01.lp", markdown)
         @test occursin("Canonical QUBO artifact available at pinned commit: false", markdown)
         @test occursin("QOBLIB Converter Evidence", markdown)
+        @test occursin("Qiskit optimization version checked: 0.7.0", markdown)
+        @test occursin("Qiskit penalty formula checked", markdown)
         @test occursin("Model license: Apache License, Version 2.0", markdown)
         @test occursin("Penalty scaling issue: https://github.com/JuliaQUBO/ToQUBO.jl/issues/162", markdown)
         @test occursin("Converter Variable Accounting", markdown)
@@ -608,6 +617,7 @@ function test_qoblib_benchmark_pilot()
         @test occursin("Rounded CVRPLIB route cost", markdown)
         @test occursin("Redundant source constraints detected: 22", markdown)
         @test occursin("largest absolute coefficient ratio", markdown)
+        @test occursin("Same-order coefficient ratio bounds: 0.1 to 10.0", markdown)
         @test occursin("Penalty-scaling divergence resolved: true", markdown)
         @test occursin("Routing-specific penalty scaling needed: false", markdown)
         @test occursin("No routing-specific penalty scaling is needed", markdown)


### PR DESCRIPTION
## Summary

- Record that the issue-162 QOBLib routing penalty-scaling divergence no longer reproduces under the default objective-range penalty policy.
- Add QOBLib/Qiskit converter evidence for the routing pilot, including the converter pipeline and default-penalty interpretation.
- Add exact target-variable accounting showing that QOBLib/Qiskit retains 22 redundant routing bounds as 176 slack bits that ToQUBO drops.
- Regenerate the routing pilot report and update benchmark assertions for the resolved scaling conclusion.

## Resolution

QOBLib converts the routing LP through `misc/convert_lp2qubo.py`: Gurobi parses the LP, Qiskit `QuadraticProgramToQubo()` converts it with its default penalty, and QOBLib writes a symmetrized QS matrix. For this integer-coefficient routing pilot, Qiskit's default equality penalty is the same objective-range value ToQUBO now uses: `16697.376350318606`.

The remaining differences are not evidence that routing-specific penalty scaling is needed. The target-size delta is exact: both converters encode the 420 arc variables plus 21 load variables into 588 source bits, but QOBLib/Qiskit keeps 21 redundant `y[i] <= 231` bounds plus the redundant depot lower bound `y[1] >= 0`. Each retained `0..231` slack contributes eight binary variables, explaining QOBLib's 176 additional target variables.

Coefficient-wise, ToQUBO does not exactly reproduce the pinned QS metrics row, but the largest absolute QOBLIB-style coefficient is slightly smaller than QOBLib's pinned largest absolute coefficient. ToQUBO's positive-side maximum is larger, so exact coefficient extrema should be interpreted as conversion-convention artifacts rather than a penalty-scaling defect.

## Tests

- `julia --project=. benchmarks/qoblib/routing_pilot.jl`
- `julia --project=. -e 'using Test; include("test/unit/qoblib_benchmark.jl"); test_qoblib_benchmark_pilot()'` (388/388)
- `git diff --check`
- `julia --project=. -e 'import Pkg; Pkg.test()'` (1567/1567)

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `713cec4b89714a5f57f2b1cf66908fc7527da7b0`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #162.
