### PR TITLE
[codex] Add release process guardrails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## v0.5.0 - 2026-06-22
 
+### Breaking changes
+
+- Use the objective-range policy as the default automatic penalty inference path; downstream checks that assert exact legacy maxgap-derived coefficients should request the legacy fallback policy or update their expectations.
+
 ### Added
 
 - Add QOBLib network and routing reformulation benchmark pilots with provenance, comparison metrics, and incumbent feasibility checks.

--- a/docs/dev/release-notes-template.md
+++ b/docs/dev/release-notes-template.md
@@ -1,0 +1,19 @@
+@JuliaRegistrator register
+
+Release notes:
+
+## Breaking changes
+
+- No breaking changes, or list the behavioral/API change that makes this release breaking.
+
+## Added
+
+- TODO
+
+## Fixed
+
+- TODO
+
+## Maintenance
+
+- TODO

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -1,0 +1,65 @@
+# Release Process
+
+Release changes live in this repository first. The checks here cover ToQUBO-specific metadata that can drift during a release. If the process works well, copy or generalize the script and templates for adjacent JuliaQUBO packages.
+
+## Prepare the Release PR
+
+1. Update `Project.toml` to the target version.
+2. Move the top `NEWS.md` section from `Unreleased` to `vX.Y.Z - YYYY-MM-DD`.
+3. Update `docs/Project.toml` self-compat for `ToQUBO`.
+   - For `0.Y.Z`, use `0.Y`.
+   - For `0.0.Z`, use `0.0.Z`.
+   - For `X.Y.Z` with `X > 0`, use `X`.
+4. Run the static release preflight:
+
+```sh
+julia --project=. scripts/release_check.jl
+```
+
+5. Run the package and documentation checks:
+
+```sh
+julia --project=. -e 'import Pkg; Pkg.test()'
+julia --project=docs docs/make.jl --skip-deploy
+```
+
+6. Open and merge the release PR after CI is green.
+
+## Register
+
+After the release PR is merged, invoke Registrator on the merge commit, not on the pull request. Use the template in `docs/dev/release-notes-template.md`.
+
+The release notes should always include a `Breaking changes` or `Changelog` section. General may label pre-1.0 minor releases as `BREAKING`, and AutoMerge requires one of those words in the release notes when that label is present.
+
+```sh
+gh api repos/JuliaQUBO/ToQUBO.jl/commits/<merge-sha>/comments -f body="$(cat docs/dev/release-notes-template.md)"
+```
+
+Watch the General registry PR:
+
+```sh
+gh pr checks <general-pr-number> --repo JuliaRegistries/General --watch
+gh pr view <general-pr-number> --repo JuliaRegistries/General --json state,mergedAt,mergeCommit,url
+```
+
+If AutoMerge fails because release notes are missing the breaking-change wording, re-invoke Registrator on the same merge commit with corrected release notes.
+
+## Verify TagBot
+
+After the General PR merges, wait for TagBot and verify the tag and release:
+
+```sh
+gh run list --workflow TagBot.yml --limit 10
+git ls-remote --tags origin vX.Y.Z
+gh release view vX.Y.Z
+```
+
+## Verify Pkg.add
+
+Use a fresh depot and project so the check does not reuse a local development path:
+
+```sh
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/depot" "$tmp/proj"
+JULIA_DEPOT_PATH="$tmp/depot" julia --startup-file=no --project="$tmp/proj" -e 'using Pkg; Pkg.add("ToQUBO"); deps = Pkg.dependencies(); versions = [(pkg.name, pkg.version) for pkg in values(deps) if pkg.name == "ToQUBO"]; @show versions'
+```

--- a/scripts/release_check.jl
+++ b/scripts/release_check.jl
@@ -1,0 +1,114 @@
+#!/usr/bin/env julia
+
+using TOML
+
+const ROOT = normpath(joinpath(@__DIR__, ".."))
+
+function release_line_compat(version::VersionNumber)
+    if version.major == 0
+        return version.minor == 0 ? "0.0.$(version.patch)" : "0.$(version.minor)"
+    end
+
+    return string(version.major)
+end
+
+function check!(failures::Vector{String}, condition::Bool, message::String)
+    condition || push!(failures, message)
+    return nothing
+end
+
+function project_file(parts...)
+    return joinpath(ROOT, parts...)
+end
+
+function read_toml(parts...)
+    return TOML.parsefile(project_file(parts...))
+end
+
+function release_section(news::String, version::VersionNumber)
+    heading = "## v$(version) - "
+    lines = split(news, '\n')
+    start = findfirst(line -> startswith(line, heading), lines)
+    start === nothing && return nothing
+
+    next_heading = findnext(line -> startswith(line, "## "), lines, start + 1)
+    stop = next_heading === nothing ? lastindex(lines) : next_heading - 1
+    return join(lines[start:stop], "\n")
+end
+
+function main()
+    failures = String[]
+    warnings = String[]
+
+    project = read_toml("Project.toml")
+    docs_project = read_toml("docs", "Project.toml")
+    test_project = read_toml("test", "Project.toml")
+
+    version = VersionNumber(project["version"])
+    expected_self_compat = release_line_compat(version)
+
+    check!(failures, project["name"] == "ToQUBO", "Project.toml name is not ToQUBO.")
+
+    docs_deps = docs_project["deps"]
+    docs_compat = docs_project["compat"]
+    test_compat = test_project["compat"]
+    project_compat = project["compat"]
+
+    check!(
+        failures,
+        get(docs_deps, "ToQUBO", nothing) == project["uuid"],
+        "docs/Project.toml must depend on this package UUID for ToQUBO.",
+    )
+    check!(
+        failures,
+        get(docs_compat, "ToQUBO", nothing) == expected_self_compat,
+        "docs/Project.toml compat for ToQUBO must be \"$expected_self_compat\" for version $version.",
+    )
+    check!(
+        failures,
+        get(docs_compat, "julia", nothing) == project_compat["julia"],
+        "docs/Project.toml Julia compat must match Project.toml.",
+    )
+    check!(
+        failures,
+        get(test_compat, "julia", nothing) == project_compat["julia"],
+        "test/Project.toml Julia compat must match Project.toml.",
+    )
+    check!(
+        failures,
+        get(test_compat, "QUBOTools", nothing) == project_compat["QUBOTools"],
+        "test/Project.toml QUBOTools compat must match Project.toml.",
+    )
+
+    news = read(project_file("NEWS.md"), String)
+    section = release_section(news, version)
+    check!(
+        failures,
+        section !== nothing,
+        "NEWS.md must contain a release heading like `## v$(version) - YYYY-MM-DD`.",
+    )
+
+    if section !== nothing && !occursin(r"(?i)\b(breaking|changelog)\b", section)
+        push!(
+            warnings,
+            "NEWS.md section for v$version does not mention `breaking` or `changelog`; General AutoMerge may require one of those words if the registry labels the release BREAKING.",
+        )
+    end
+
+    if isempty(failures)
+        println("Release preflight passed for ToQUBO v$version.")
+        println("Expected docs self-compat: ToQUBO = \"$expected_self_compat\".")
+    else
+        println(stderr, "Release preflight failed:")
+        foreach(message -> println(stderr, "- ", message), failures)
+    end
+
+    if !isempty(warnings)
+        println(stderr, "\nWarnings:")
+        foreach(message -> println(stderr, "- ", message), warnings)
+    end
+
+    return isempty(failures) ? 0 : 1
+end
+
+exit(main())

--- a/test/unit/compat.jl
+++ b/test/unit/compat.jl
@@ -1,3 +1,11 @@
+function _release_line_compat(version::VersionNumber)
+    if version.major == 0
+        return version.minor == 0 ? "0.0.$(version.patch)" : "0.$(version.minor)"
+    end
+
+    return string(version.major)
+end
+
 function test_compat()
     @testset "Compatibility and CI" begin
         root = normpath(joinpath(@__DIR__, "..", ".."))
@@ -17,7 +25,7 @@ function test_compat()
         @test occursin(r"(^|,\s*)0\.4(\s*(,|$))", docs_compat["QUBODrivers"])
         @test occursin(r"(^|,\s*)0\.6(\s*(,|$))", docs_compat["QUBODrivers"])
         @test docs_compat["QUBOTools"] == "0.12, 0.13"
-        @test docs_compat["ToQUBO"] == "0.5"
+        @test docs_compat["ToQUBO"] == _release_line_compat(VersionNumber(project["version"]))
         @test occursin(r"(^|,\s*)0\.11(\s*(,|$))", test_compat["QUBOTools"])
         @test occursin(r"(^|,\s*)0\.12(\s*(,|$))", test_compat["QUBOTools"])
         @test occursin(r"(^|,\s*)0\.13(\s*(,|$))", test_compat["QUBOTools"])


### PR DESCRIPTION
## Summary

- Add a static release preflight script for ToQUBO version/docs/test/changelog metadata.
- Document the release flow, Registrator notes, TagBot checks, and fresh Pkg.add verification.
- Derive docs self-compat expectations from Project.toml instead of hardcoding the current release line.
- Align NEWS.md with the v0.5.0 breaking-change release notes used for registry AutoMerge.

## Validation

- julia --project=. scripts/release_check.jl
- julia --project=. -e 'using Test, TOML; include("test/unit/compat.jl"); test_compat()'
- git diff --cached --check