### PR TITLE
Document continuous-variable bit-count inference

### DIFF
--- a/docs/src/booklet/4-encoding.md
+++ b/docs/src/booklet/4-encoding.md
@@ -68,6 +68,7 @@ ToQUBO.Encoding.encoding_points
 ```
 
 Let ``\set{x_{i}}_{i \in [k]}`` be the collection of ``k`` evenly spaced samples from the discretization of an interval ``[a, b] \subseteq \mathbb{R}``.
+Its interval length is ``L = \left|b - a\right|``.
 
 The representation error for a given point ``x`` with respect to ``\set{x_{i}}_{i \in [k]}`` is
 
@@ -79,18 +80,40 @@ Assuming that ``x`` behaves as a uniformly distributed random variable, the expe
 
 ```math
 \begin{align*}
-\mathbb{E}\left[{e_{k}(x)}\right] &= \frac{1}{b - a} \int_{a}^{b} e_{k}(x) ~\mathrm{d}x \\
-                              &= \frac{1}{4} \frac{b - a}{k - 1}
+\mathbb{E}\left[{e_{k}(x)}\right] &= \frac{1}{L} \int_{a}^{b} e_{k}(x) ~\mathrm{d}x \\
+                              &= \frac{1}{4} \frac{L}{k - 1}
 \end{align*}
 ```
 
 Thus, for encoding methods that rely on the regular division of an interval, it is possible to define the number of samples ``k`` necessary to limit the expected error according to an upper bound ``\tau``, that is,
 
 ```math
-\mathbb{E}\left[{e_{k}(x)}\right] \le \tau \implies k \ge 1 + \frac{b - a}{4 \tau}
+\mathbb{E}\left[{e_{k}(x)}\right] \le \tau \implies k \ge 1 + \frac{L}{4 \tau}
 ```
 
 This allows the compiler to automatically infer the number of bits to allocate for an encoded variable given the tolerance factor.
+For a bounded continuous variable, an explicit
+[`ToQUBO.Attributes.VariableEncodingBits`](@ref) value fixes the bit count
+directly. When no bit count is set, the compiler reads
+[`ToQUBO.Attributes.VariableEncodingATol`](@ref), falling back to
+[`ToQUBO.Attributes.DefaultVariableEncodingATol`](@ref), and calls
+[`ToQUBO.Encoding.encoding_bits`](@ref) for the selected encoding method and
+the variable bounds.
+
+For the default [`ToQUBO.Encoding.Binary`](@ref) method, ``k = 2^n`` evenly
+spaced values are represented by ``n`` target binary variables. Combining
+``k = 2^n`` with the tolerance bound gives
+
+```math
+n \ge \log_{2} \left(1 + \frac{L}{4 \tau}\right),
+```
+
+so the compiler uses
+``\left\lceil \log_{2} \left(1 + L / 4\tau\right) \right\rceil`` bits.
+Other continuous-variable encoding methods use the same tolerance and bounds
+inputs with their method-specific
+[`ToQUBO.Encoding.encoding_bits`](@ref) or
+[`ToQUBO.Encoding.encoding_points`](@ref) rule.
 
 ## Constraints
 

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -183,6 +183,22 @@ Very small `ϵ` values or broad objective ranges can produce large penalties.
 Inspect the policy metadata before overriding the policy or pinning explicit
 penalties.
 
+### Continuous Variable Resolution
+
+Bounded continuous variables need a finite binary representation before the
+compiler can build the QUBO. Set
+[`ToQUBO.Attributes.VariableEncodingBits`](@ref) or
+[`ToQUBO.Attributes.DefaultVariableEncodingBits`](@ref) to choose that bit
+count explicitly. When the bit count is unset, ToQUBO derives it from the
+variable bounds and [`ToQUBO.Attributes.VariableEncodingATol`](@ref), falling
+back to [`ToQUBO.Attributes.DefaultVariableEncodingATol`](@ref).
+
+The tolerance rule is described in the booklet's [Representation Error](@ref)
+section. Smaller tolerances or wider bounds generally allocate more target
+binary variables. Slack variables generated from constraints use the analogous
+[`ToQUBO.Attributes.SlackVariableEncodingATol`](@ref) and
+[`ToQUBO.Attributes.SlackVariableEncodingBits`](@ref) settings.
+
 ### Constraint Penalty Methods
 
 Equality constraints are encoded with

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -742,6 +742,11 @@ end
     DefaultVariableEncodingATol()
 
 Fallback value for [`VariableEncodingATol`](@ref).
+
+This tolerance is used to infer the number of target binary variables for a
+bounded continuous variable when neither [`VariableEncodingBits`](@ref) nor
+[`DefaultVariableEncodingBits`](@ref) supplies an explicit bit count. See
+[Representation Error](@ref).
 """
 struct DefaultVariableEncodingATol <: CompilerAttribute end
 
@@ -765,6 +770,10 @@ end
 
 @doc raw"""
     DefaultVariableEncodingBits()
+
+Fallback value for [`VariableEncodingBits`](@ref). When set, this fixes the
+number of target binary variables used for bounded continuous variables that do
+not have their own [`VariableEncodingBits`](@ref) value.
 """
 struct DefaultVariableEncodingBits <: CompilerAttribute end
 
@@ -866,6 +875,11 @@ end
 
 @doc raw"""
     VariableEncodingATol()
+
+Set the tolerance used to infer the number of target binary variables for a
+bounded continuous variable when [`VariableEncodingBits`](@ref) is unset. The
+compiler falls back to [`DefaultVariableEncodingATol`](@ref) when this attribute
+is unset. See [Representation Error](@ref).
 """
 struct VariableEncodingATol <: CompilerVariableAttribute end
 
@@ -919,6 +933,10 @@ end
 
 @doc raw"""
     VariableEncodingBits()
+
+Set the number of target binary variables used to encode a bounded continuous
+variable. This explicit bit count takes precedence over
+[`VariableEncodingATol`](@ref).
 """
 struct VariableEncodingBits <: CompilerVariableAttribute end
 

--- a/src/compiler/variables.jl
+++ b/src/compiler/variables.jl
@@ -267,19 +267,8 @@ end
 
 function variable_ℝ!(model::Virtual.Model{T}, vi::VI, (a, b)::Tuple{A,B}) where {T,A<:Union{T,Nothing},B<:Union{T,Nothing}}
     if !isnothing(a) && !isnothing(b)
-        # TODO: Solve this bit-guessing magic??? (DONE)
-        # IDEA: 
-        #     Let x̂ ~ U[a, b], K = 2ᴺ, γ = [a, b]
-        #       𝔼[|xᵢ - x̂|] = ∫ᵧ |xᵢ - x̂| f(x̂) dx̂
-        #                   = 1 / |b - a| ∫ᵧ |xᵢ - x̂| dx̂
-        #                   = |b - a| / 4 (K - 1)
-        #
-        #     For 𝔼[|xᵢ - x̂|] ≤ τ we have
-        #       N ≥ log₂(1 + |b - a| / 4τ)
-        # 
-        # where τ is the (absolute) tolerance
-        # TODO: Add τ as parameter (DONE)
-        # TODO: Move this comment to the documentation
+        # Tolerance-based bit inference is documented in
+        # docs/src/booklet/4-encoding.md.
         let e = Attributes.variable_encoding_method(model, vi)
             n = Attributes.variable_encoding_bits(model, vi)
             S = (a, b)

--- a/src/compiler/variables.jl
+++ b/src/compiler/variables.jl
@@ -267,8 +267,8 @@ end
 
 function variable_ℝ!(model::Virtual.Model{T}, vi::VI, (a, b)::Tuple{A,B}) where {T,A<:Union{T,Nothing},B<:Union{T,Nothing}}
     if !isnothing(a) && !isnothing(b)
-        # Tolerance-based bit inference is documented in
-        # docs/src/booklet/4-encoding.md.
+        # Tolerance-based bit inference is documented in the Representation
+        # Error section of the encoding booklet.
         let e = Attributes.variable_encoding_method(model, vi)
             n = Attributes.variable_encoding_bits(model, vi)
             S = (a, b)

--- a/src/encoding/interface.jl
+++ b/src/encoding/interface.jl
@@ -24,6 +24,14 @@ function encodes end
 
 @doc raw"""
     encoding_bits(e::VariableEncodingMethod, S::Tuple{T,T}, tol::T) where {T}
+
+Return the number of target binary variables selected by encoding method `e`
+for a bounded continuous interval `S` when no explicit variable bit count is
+set.
+
+The tolerance `tol` is the upper bound used by the method's representation
+error rule. See [Representation Error](@ref) for the derivation and compiler
+precedence between explicit bit counts and tolerance-based inference.
 """
 function encoding_bits end
 
@@ -36,6 +44,9 @@ abstract type SetVariableEncodingMethod <: VariableEncodingMethod end
 
 @doc raw"""
     encoding_points(e::SetVariableEncodingMethod, S::Tuple{T,T}, tol::T) where {T}
+
+Return the number of discretization points selected by a set encoding method
+for a bounded continuous interval `S` and tolerance `tol`.
 """
 function encoding_points end
 


### PR DESCRIPTION
## Summary

- Document how bounded continuous variables infer encoding resolution from bounds and `VariableEncodingATol` when no explicit bit count is set.
- Cross-link compiler settings and encoding API docs to the representation-error derivation.
- Replace the stale long compiler TODO/derivation comment with a short docs pointer.

## Tests

- `julia --project=docs docs/make.jl --skip-deploy` - passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` - passed, 1594/1594.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `542e763c05429baed29ab2df1e66cf7a7ec81bdd`
- Stacked status: not stacked; this branch contains one commit on top of current `origin/main`.
- Prerequisite PRs: none.

Closes #179
