### PR TITLE
Clarify slack-variable encoding penalty provenance

### DIFF
--- a/docs/src/manual/3-results.md
+++ b/docs/src/manual/3-results.md
@@ -240,9 +240,11 @@ constraint/slack ownership for generated target variables, penalty terms
 recorded by the compiler, and an `applied_penalties` section with the applied
 constraint, variable-encoding, and slack-variable penalty coefficients.
 `applied_penalties` is a convenience view of values also stored on the
-corresponding metadata records. This is enough to project a full QUBO state back
-to original variables. Exact auxiliary consistency checks and repair remain
-encoding-specific and are not guaranteed by this metadata contract.
+corresponding metadata records. Slack-variable penalty entries are keyed by the
+source constraint that generated the slack variable. This is enough to project a
+full QUBO state back to original variables. Exact auxiliary consistency checks
+and repair remain encoding-specific and are not guaranteed by this metadata
+contract.
 
 Full reformulation metadata is intentionally generated on request. Dense models
 can create one metadata record per source-to-target expansion term and per

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -1809,14 +1809,16 @@ compilation.
 This returns `nothing` when the constraint does not generate a slack-variable
 encoding penalty. Use [`SlackVariableEncodingPenaltyHint`](@ref) before
 compilation to pin a specific coefficient.
+
+Slack variables are generated from source constraints, so the applied penalty is
+owned by the source constraint index rather than by any generated target
+variable.
 """
 struct SlackVariableEncodingPenalty <: CompilerConstraintAttribute end
 
 MOI.is_set_by_optimize(::SlackVariableEncodingPenalty) = true
 
 function slack_variable_encoding_penalty(model::Optimizer, ci::CI)
-    # TODO
-    # return MOI.get(model, SlackVariableEncodingPenalty(), ci)
     return MOI.get(model, SlackVariableEncodingPenalty(), ci)
 end
 
@@ -1825,10 +1827,6 @@ function MOI.get(
     ::SlackVariableEncodingPenalty,
     ci::CI,
 )::Union{T,Nothing} where {T}
-    # TODO
-    # vi = Virtual.source(model.slack[ci])
-
-    # return MOI.get(model, VariableEncodingPenalty(), vi)
     return get(model.η, ci, nothing)
 end
 
@@ -1838,10 +1836,6 @@ function MOI.set(
     ci::CI,
     η::Any,
 )::Nothing where {T}
-    # TODO: This doesn't work since slack variables have no source!
-    # vi = Virtual.source(model.slack[ci])
-
-    # MOI.set(model, VariableEncodingPenalty(), vi, η)
     model.η[ci] = convert(T, η)
 
     return nothing

--- a/src/reformulation.jl
+++ b/src/reformulation.jl
@@ -14,7 +14,8 @@ when a returned QUBOTools model needs embedded reformulation metadata.
 
 The `applied_penalties` section is a convenience view. Its entries duplicate
 the applied penalty coefficients also attached to the corresponding variable,
-constraint, and slack-variable metadata records.
+constraint, and slack-variable metadata records. Slack-variable penalties are
+keyed by the source constraint that generated the slack variable.
 """
 function reformulation_metadata end
 

--- a/test/unit/compiler/penalties.jl
+++ b/test/unit/compiler/penalties.jl
@@ -303,6 +303,45 @@ function test_compiler_applied_penalty_metadata()
     return nothing
 end
 
+function test_compiler_slack_variable_encoding_penalty_is_constraint_keyed()
+    model, c = _constraint_penalty_test_model(; slack_encoding = Encoding.OneHot())
+    targets = MOI.get(model, Attributes.SlackVariableTargetVariables(), c)
+    original_penalty = MOI.get(model, Attributes.SlackVariableEncodingPenalty(), c)
+
+    @test !isempty(targets)
+    @test original_penalty == model.η[c]
+
+    MOI.set(model, Attributes.SlackVariableEncodingPenalty(), c, -11.0)
+
+    @test MOI.get(model, Attributes.SlackVariableEncodingPenalty(), c) == -11.0
+    @test model.η[c] == -11.0
+
+    metadata = ToQUBO.reformulation_metadata(model)
+    slack_entry = only(metadata["slack_variables"])
+    applied_slack_entry = only(metadata["applied_penalties"]["slack_variables"])
+
+    @test slack_entry["constraint"]["id"] == c.value
+    @test slack_entry["target_variables"] == [vi.value for vi in targets]
+    @test slack_entry["penalty"] == -11.0
+    @test applied_slack_entry["constraint"] == slack_entry["constraint"]
+    @test applied_slack_entry["penalty"] == -11.0
+
+    MOI.set(model, Attributes.SlackVariableEncodingPenalty(), c, nothing)
+
+    @test MOI.get(model, Attributes.SlackVariableEncodingPenalty(), c) === nothing
+    @test !haskey(model.η, c)
+
+    cleared_metadata = ToQUBO.reformulation_metadata(model)
+    cleared_slack_entry = only(cleared_metadata["slack_variables"])
+
+    @test cleared_slack_entry["constraint"] == slack_entry["constraint"]
+    @test cleared_slack_entry["target_variables"] == [vi.value for vi in targets]
+    @test cleared_slack_entry["penalty"] === nothing
+    @test isempty(cleared_metadata["applied_penalties"]["slack_variables"])
+
+    return nothing
+end
+
 function test_compiler_penalties()
     @testset "Penalty inference" begin
         test_compiler_penalty_default_policy()
@@ -311,6 +350,7 @@ function test_compiler_penalties()
         test_compiler_penalty_policy_fallback_metadata()
         test_compiler_penalty_scale_and_offset()
         test_compiler_applied_penalty_metadata()
+        test_compiler_slack_variable_encoding_penalty_is_constraint_keyed()
     end
 
     return nothing


### PR DESCRIPTION
Summary
- Documents that `SlackVariableEncodingPenalty` is owned by the source constraint that generates the slack variable.
- Removes stale TODO/commented code that suggested routing slack penalties through variable-encoding penalties.
- Adds focused coverage for retrieving, setting, clearing, and metadata-reporting slack-variable encoding penalties after compilation.

Tests
- `julia --project=. -e 'using Test; import MathOptInterface as MOI; using ToQUBO; using ToQUBO: Attributes, Encoding; include("test/unit/compiler/penalties.jl"); test_compiler_penalties()'`
- `julia --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`
- `julia --project=docs docs/make.jl --skip-deploy` from `/tmp/toqubo-doccheck.0Zt9BY`
- `git diff --check`

Branch Hygiene
- Base branch: `main`
- Source branch point: `origin/main` at `4d31132d4e416bcffaabaada2fa91f3cf2bac110`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #178
