### PR TITLE
Optimize dense QUBO fast path

### DIFF
--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -62,6 +62,40 @@ MOI.supports(::Optimizer, ::A) where {A<:CompilerAttribute} = true
 
 _copy_or_nothing(x) = isnothing(x) ? nothing : copy(x)
 
+function _is_qubo_fast_path(model::Optimizer)
+    return get(model.compiler_settings, :qubo_fast_path, false) === true
+end
+
+function _compiled_qubo_objective_from_target(model::Optimizer{T}) where {T}
+    objective = MOI.get(
+        model.target_model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{T}}(),
+    )
+    f = PBO.PBF{VI,T}()
+
+    for term in objective.quadratic_terms
+        x = term.variable_1
+        y = term.variable_2
+        c = term.coefficient
+
+        if x == y
+            f[x] += c / 2
+        elseif x.value <= y.value
+            f[VI[x, y]] += c
+        else
+            f[VI[y, x]] += c
+        end
+    end
+
+    for term in objective.affine_terms
+        f[term.variable] += term.coefficient
+    end
+
+    f[nothing] += objective.constant
+
+    return f
+end
+
 abstract type AutomaticPenaltyPolicy end
 
 @doc raw"""
@@ -137,6 +171,10 @@ function MOI.get(
     model::Optimizer{T},
     ::CompiledObjectiveFunction,
 )::PBO.PBF{VI,T} where {T}
+    if _is_qubo_fast_path(model)
+        return _compiled_qubo_objective_from_target(model)
+    end
+
     return copy(model.f)
 end
 
@@ -158,6 +196,10 @@ function MOI.get(
     model::Optimizer{T},
     ::CompiledHamiltonian,
 )::PBO.PBF{VI,T} where {T}
+    if _is_qubo_fast_path(model)
+        return _compiled_qubo_objective_from_target(model)
+    end
+
     return copy(model.H)
 end
 

--- a/src/compiler/compiler.jl
+++ b/src/compiler/compiler.jl
@@ -164,6 +164,12 @@ function _add_or_drop!(terms::Dict{K,T}, key::K, value::T) where {K,T}
     return nothing
 end
 
+function _add_qubo_linear!(terms::Dict{VI,T}, key::VI, value::T) where {T}
+    terms[key] = get(terms, key, zero(T)) + value
+
+    return nothing
+end
+
 function _qubo_backend_sense(sense::MOI.OptimizationSense)
     return sense === MOI.MIN_SENSE ? :min : :max
 end
@@ -240,7 +246,7 @@ function _copy_qubo_objective!(
         c = term.coefficient
 
         push!(affine_terms, SAT{T}(c, y))
-        _add_or_drop!(linear_terms, y, c)
+        _add_qubo_linear!(linear_terms, y, c)
     end
 
     MOI.set(
@@ -272,7 +278,7 @@ function _copy_qubo_objective!(
         push!(quadratic_terms, SQT{T}(c, x, y))
 
         if x == y
-            _add_or_drop!(backend_linear_terms, x, c / 2)
+            _add_qubo_linear!(backend_linear_terms, x, c / 2)
         else
             u, v = _ordered_qubo_pair(x, y)
             _add_or_drop!(backend_quadratic_terms, (u, v), c)
@@ -284,7 +290,7 @@ function _copy_qubo_objective!(
         c = term.coefficient
 
         push!(affine_terms, SAT{T}(c, y))
-        _add_or_drop!(backend_linear_terms, y, c)
+        _add_qubo_linear!(backend_linear_terms, y, c)
     end
 
     MOI.set(

--- a/src/compiler/compiler.jl
+++ b/src/compiler/compiler.jl
@@ -5,6 +5,7 @@ import MathOptInterface as MOI
 import MathOptInterface: empty!
 import PseudoBooleanOptimization as PBO
 
+import QUBOTools
 import QUBOTools: AbstractArchitecture, GenericArchitecture
 
 import ..Attributes
@@ -93,6 +94,7 @@ function reset!(model::Virtual.Model, ::AbstractArchitecture = GenericArchitectu
     Base.empty!(model.s)
     Base.empty!(model.η)
     Base.empty!(model.H)
+    model.qubo_backend_cache = nothing
 
     # Optimize-generated status
     MOI.set(model, Attributes.CompilationStatus(), nothing)
@@ -116,8 +118,6 @@ function Compiler.copy!(model::Virtual.Model{T}, arch::AbstractArchitecture) whe
     )
 
     _copy_qubo_objective!(model, variable_map)
-    _copy_qubo_hamiltonian!(model)
-    _output_qubo_objective!(model)
 
     model.compiler_settings[:qubo_fast_path] = true
 
@@ -148,82 +148,49 @@ function _copy_qubo_variables!(model::Virtual.Model{T}) where {T}
     return variable_map
 end
 
-function _qubo_term(x::VI)
-    return PBO.Term{VI}(VI[x])
+function _ordered_qubo_pair(x::VI, y::VI)
+    return x.value <= y.value ? (x, y) : (y, x)
 end
 
-function _qubo_term(x::VI, y::VI)
-    if x.value <= y.value
-        return PBO.Term{VI}(VI[x, y])
+function _add_or_drop!(terms::Dict{K,T}, key::K, value::T) where {K,T}
+    new_value = get(terms, key, zero(T)) + value
+
+    if iszero(new_value)
+        delete!(terms, key)
     else
-        return PBO.Term{VI}(VI[y, x])
-    end
-end
-
-function _add_qubo_affine_term!(f::PBO.PBF{VI,T}, variable_map, a::SAT{T}) where {T}
-    f[_qubo_term(variable_map[a.variable])] += a.coefficient
-
-    return nothing
-end
-
-function _add_qubo_quadratic_term!(f::PBO.PBF{VI,T}, variable_map, q::SQT{T}) where {T}
-    x = variable_map[q.variable_1]
-    y = variable_map[q.variable_2]
-    c = q.coefficient
-
-    if x == y
-        # MOI stores diagonal quadratic terms with doubled coefficients for
-        # pseudo-boolean variables because x^2 == x.
-        f[_qubo_term(x)] += c / 2
-    else
-        f[_qubo_term(x, y)] += c
+        terms[key] = new_value
     end
 
     return nothing
 end
 
-function _copy_qubo_function!(
-    f::PBO.PBF{VI,T},
-    variable_map,
-    vi::VI,
+function _qubo_backend_sense(sense::MOI.OptimizationSense)
+    return sense === MOI.MIN_SENSE ? :min : :max
+end
+
+function _empty_qubo_linear_terms(::Type{T}, variable_map::Dict{VI,VI}) where {T}
+    linear_terms = sizehint!(Dict{VI,T}(), length(variable_map))
+
+    for y in values(variable_map)
+        linear_terms[y] = zero(T)
+    end
+
+    return linear_terms
+end
+
+function _cache_qubo_backend!(
+    model::Virtual.Model{T},
+    linear_terms::Dict{VI,T},
+    quadratic_terms::Dict{Tuple{VI,VI},T},
+    offset::T,
 ) where {T}
-    f[_qubo_term(variable_map[vi])] += one(T)
-
-    return nothing
-end
-
-function _copy_qubo_function!(
-    f::PBO.PBF{VI,T},
-    variable_map,
-    obj::SAF{T},
-) where {T}
-    sizehint!(f, length(obj.terms) + 1)
-
-    for a in obj.terms
-        _add_qubo_affine_term!(f, variable_map, a)
-    end
-
-    f[nothing] += obj.constant
-
-    return nothing
-end
-
-function _copy_qubo_function!(
-    f::PBO.PBF{VI,T},
-    variable_map,
-    obj::SQF{T},
-) where {T}
-    sizehint!(f, length(obj.quadratic_terms) + length(obj.affine_terms) + 1)
-
-    for q in obj.quadratic_terms
-        _add_qubo_quadratic_term!(f, variable_map, q)
-    end
-
-    for a in obj.affine_terms
-        _add_qubo_affine_term!(f, variable_map, a)
-    end
-
-    f[nothing] += obj.constant
+    model.qubo_backend_cache = QUBOTools.Model{VI,T,Int}(
+        linear_terms,
+        quadratic_terms;
+        offset,
+        sense = _qubo_backend_sense(MOI.get(model.target_model, MOI.ObjectiveSense())),
+        domain = :bool,
+    )
 
     return nothing
 end
@@ -232,43 +199,105 @@ function _copy_qubo_objective!(model::Virtual.Model{T}, variable_map) where {T}
     F = MOI.get(model.source_model, MOI.ObjectiveFunctionType())
     f = MOI.get(model.source_model, MOI.ObjectiveFunction{F}())
 
-    _copy_qubo_function!(model.f, variable_map, f)
+    _copy_qubo_objective!(model, variable_map, f)
 
     return nothing
 end
 
-function _copy_qubo_hamiltonian!(model::Virtual.Model)
-    Base.copy!(model.H, model.f)
+function _copy_qubo_objective!(
+    model::Virtual.Model{T},
+    variable_map::Dict{VI,VI},
+    vi::VI,
+) where {T}
+    y = variable_map[vi]
+    affine_terms = SAT{T}[SAT{T}(one(T), y)]
+    linear_terms = _empty_qubo_linear_terms(T, variable_map)
+    quadratic_terms = Dict{Tuple{VI,VI},T}()
+
+    linear_terms[y] += one(T)
+
+    MOI.set(
+        model.target_model,
+        MOI.ObjectiveFunction{SQF{T}}(),
+        SQF{T}(SQT{T}[], affine_terms, zero(T)),
+    )
+    _cache_qubo_backend!(model, linear_terms, quadratic_terms, zero(T))
 
     return nothing
 end
 
-function _output_qubo_objective!(model::Virtual.Model{T}) where {T}
-    Q = SQT{T}[]
-    a = SAT{T}[]
-    b = zero(T)
+function _copy_qubo_objective!(
+    model::Virtual.Model{T},
+    variable_map::Dict{VI,VI},
+    obj::SAF{T},
+) where {T}
+    affine_terms = sizehint!(SAT{T}[], length(obj.terms))
+    linear_terms = _empty_qubo_linear_terms(T, variable_map)
+    quadratic_terms = Dict{Tuple{VI,VI},T}()
 
-    for (ω, c) in model.H
-        if isempty(ω)
-            b += c
-        elseif length(ω) == 1
-            x, = ω
+    for term in obj.terms
+        y = variable_map[term.variable]
+        c = term.coefficient
 
-            push!(a, SAT{T}(c, x))
-        elseif length(ω) == 2
-            x, y = ω
+        push!(affine_terms, SAT{T}(c, y))
+        _add_or_drop!(linear_terms, y, c)
+    end
 
-            push!(Q, SQT{T}(c, x, y))
+    MOI.set(
+        model.target_model,
+        MOI.ObjectiveFunction{SQF{T}}(),
+        SQF{T}(SQT{T}[], affine_terms, obj.constant),
+    )
+    _cache_qubo_backend!(model, linear_terms, quadratic_terms, obj.constant)
+
+    return nothing
+end
+
+function _copy_qubo_objective!(
+    model::Virtual.Model{T},
+    variable_map::Dict{VI,VI},
+    obj::SQF{T},
+) where {T}
+    quadratic_terms = sizehint!(SQT{T}[], length(obj.quadratic_terms))
+    affine_terms = sizehint!(SAT{T}[], length(obj.affine_terms))
+    backend_linear_terms = _empty_qubo_linear_terms(T, variable_map)
+    backend_quadratic_terms =
+        sizehint!(Dict{Tuple{VI,VI},T}(), length(obj.quadratic_terms))
+
+    for term in obj.quadratic_terms
+        x = variable_map[term.variable_1]
+        y = variable_map[term.variable_2]
+        c = term.coefficient
+
+        push!(quadratic_terms, SQT{T}(c, x, y))
+
+        if x == y
+            _add_or_drop!(backend_linear_terms, x, c / 2)
         else
-            compilation_error!(
-                model,
-                "Fatal: QUBO fast path produced a higher-order term";
-                status="Failure in QUBO fast path",
-            )
+            u, v = _ordered_qubo_pair(x, y)
+            _add_or_drop!(backend_quadratic_terms, (u, v), c)
         end
     end
 
-    MOI.set(model.target_model, MOI.ObjectiveFunction{SQF{T}}(), SQF{T}(Q, a, b))
+    for term in obj.affine_terms
+        y = variable_map[term.variable]
+        c = term.coefficient
+
+        push!(affine_terms, SAT{T}(c, y))
+        _add_or_drop!(backend_linear_terms, y, c)
+    end
+
+    MOI.set(
+        model.target_model,
+        MOI.ObjectiveFunction{SQF{T}}(),
+        SQF{T}(quadratic_terms, affine_terms, obj.constant),
+    )
+    _cache_qubo_backend!(
+        model,
+        backend_linear_terms,
+        backend_quadratic_terms,
+        obj.constant,
+    )
 
     return nothing
 end

--- a/src/virtual/model.jl
+++ b/src/virtual/model.jl
@@ -27,6 +27,7 @@ mutable struct Model{T,O} <: MOI.AbstractOptimizer
     s::Dict{CI,PBO.PBF{VI,T}} # Slack Penalty Functions
     η::Dict{CI,T}             # Slack Penalty Factors
     H::PBO.PBF{VI,T}          # Final Objective Function
+    qubo_backend_cache::Union{Nothing,QUBOTools.Model{VI,T,Int}}
 
     # Settings 
     compiler_settings::Dict{Symbol,Any}
@@ -76,6 +77,7 @@ mutable struct Model{T,O} <: MOI.AbstractOptimizer
             Dict{CI,PBO.PBF{VI,T}}(), # Slack Penalty Functions
             Dict{CI,T}(),             # Slack Penalty Factors
             PBO.PBF{VI,T}(),          # Final Objective Function
+            nothing,                  # QUBOTools backend cache
 
             # Settings 
             Dict{Symbol,Any}(),

--- a/src/virtual/virtual.jl
+++ b/src/virtual/virtual.jl
@@ -3,6 +3,7 @@ module Virtual
 # Imports
 import MathOptInterface as MOI
 import PseudoBooleanOptimization as PBO 
+import QUBOTools
 
 import ..ToQUBO: QUBOModel, PreQUBOModel
 import ..Encoding: Encoding, VariableEncodingMethod, encode!

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -158,7 +158,11 @@ function Base.show(io::IO, model::Optimizer)
 end
 
 function QUBOTools.backend(model::Optimizer{T}; full_metadata::Bool = false) where {T}
-    qubo_model = QUBOTools.Model{T}(model.target_model)
+    qubo_model = if isnothing(model.qubo_backend_cache)
+        QUBOTools.Model{T}(model.target_model)
+    else
+        copy(model.qubo_backend_cache)
+    end
 
     if full_metadata
         _attach_reformulation_metadata!(qubo_model, model)

--- a/test/unit/compiler/copy.jl
+++ b/test/unit/compiler/copy.jl
@@ -139,6 +139,40 @@ function test_compiler_copy()
             end
         end
 
+        @testset "cached backend preserves zero-linear variables" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                x, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                z, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                w, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+
+                obj = MOI.ScalarAffineFunction{Float64}(
+                    [
+                        MOI.ScalarAffineTerm(2.0, x),
+                        MOI.ScalarAffineTerm(0.0, z),
+                        MOI.ScalarAffineTerm(1.0, w),
+                        MOI.ScalarAffineTerm(-1.0, w),
+                    ],
+                    3.0,
+                )
+                _set_objective!(model, MOI.MIN_SENSE, obj)
+
+                MOI.optimize!(model)
+
+                backend = QUBOTools.backend(model)
+                parsed_backend = QUBOTools.Model{Float64}(model.target_model)
+                target_variables = [
+                    only(MOI.get(model, Attributes.VariableTargetVariables(), vi)) for
+                    vi in (x, y, z, w)
+                ]
+
+                @test _compiled_uses_qubo_fast_path(model)
+                @test QUBOTools.variables(backend) == target_variables
+                @test QUBOTools.variables(parsed_backend) == target_variables
+                @test _dense_qubo_data(backend) == _dense_qubo_data(parsed_backend)
+            end
+        end
+
         @testset "metadata and projection stay coherent for pass-through QUBO" begin
             let model = ToQUBO.Optimizer{Float64}()
                 x, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())

--- a/test/unit/compiler/copy.jl
+++ b/test/unit/compiler/copy.jl
@@ -23,6 +23,12 @@ function _compiled_uses_qubo_fast_path(model::ToQUBO.Optimizer)
     return get(model.compiler_settings, :qubo_fast_path, false) === true
 end
 
+function _dense_qubo_data(model)
+    n, L, Q, α, β = QUBOTools.qubo(model, :dense)
+
+    return (; n, L, Q, α, β)
+end
+
 function _set_objective!(model, sense, f)
     MOI.set(model, MOI.ObjectiveSense(), sense)
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
@@ -69,6 +75,16 @@ function test_compiler_copy()
                 @test MOI.get(model, Attributes.CompiledObjectiveFunction()) == expected
                 @test MOI.get(model, Attributes.CompiledHamiltonian()) == expected
                 @test _target_objective_pbf(model) == expected
+
+                cached_backend = model.qubo_backend_cache
+                backend = QUBOTools.backend(model)
+                parsed_backend = QUBOTools.Model{Float64}(model.target_model)
+
+                @test cached_backend !== nothing
+                @test backend !== cached_backend
+                @test QUBOTools.variables(backend) == [x_target, y_target]
+                @test QUBOTools.variables(parsed_backend) == [x_target, y_target]
+                @test _dense_qubo_data(backend) == _dense_qubo_data(parsed_backend)
             end
         end
 
@@ -100,6 +116,7 @@ function test_compiler_copy()
                 @test MOI.get(model.target_model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
                 @test MOI.get(model, Attributes.CompiledObjectiveFunction()) == expected
                 @test _target_objective_pbf(model) == expected
+                @test QUBOTools.sense(QUBOTools.backend(model)) === QUBOTools.Max
             end
 
             let model = ToQUBO.Optimizer{Float64}()
@@ -200,6 +217,20 @@ function test_compiler_copy()
                 @test isempty(model.slack)
                 @test isempty(ToQUBO.auxiliary_variables(model))
                 @test QUBOTools.backend(model) isa QUBOTools.Model
+
+                backend_data = _dense_qubo_data(QUBOTools.backend(model))
+
+                @test backend_data.n == n
+                @test backend_data.α == 1.0
+                @test backend_data.β == total^2
+
+                for i = 1:n
+                    @test backend_data.L[i] ≈ 4 * weights[i]^2 - 4 * total * weights[i]
+
+                    for j = (i + 1):n
+                        @test backend_data.Q[i, j] ≈ 8 * weights[i] * weights[j]
+                    end
+                end
             end
         end
 

--- a/test/unit/wrapper/wrapper.jl
+++ b/test/unit/wrapper/wrapper.jl
@@ -101,6 +101,46 @@ function test_wrapper_optimizer()
                 @test α ≈ α′
                 @test β ≈ β′
             end
+
+            let model = ToQUBO.Optimizer{Float64}()
+                function dense_data(backend)
+                    n, L, Q, α, β = QUBOTools.qubo(backend, :dense)
+
+                    return (; n, L = copy(L), Q = copy(Q), α, β)
+                end
+
+                x, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+                y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+
+                obj = MOI.ScalarQuadraticFunction{Float64}(
+                    [MOI.ScalarQuadraticTerm(3.0, x, y)],
+                    [MOI.ScalarAffineTerm(2.0, x)],
+                    5.0,
+                )
+                MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+                MOI.set(model, MOI.ObjectiveFunction{typeof(obj)}(), obj)
+
+                MOI.optimize!(model)
+
+                backend = QUBOTools.backend(model)
+                cached_data = dense_data(model.qubo_backend_cache)
+                returned_data = dense_data(backend)
+
+                @test model.qubo_backend_cache !== nothing
+                @test returned_data == cached_data
+
+                backend.form.L.data[1] = 99.0
+                backend.form.Q.data[1, 2] = 88.0
+                QUBOTools.metadata(backend)["sentinel"] = "mutated"
+
+                fresh_backend = QUBOTools.backend(model)
+
+                @test dense_data(backend) != cached_data
+                @test dense_data(fresh_backend) == cached_data
+                @test dense_data(model.qubo_backend_cache) == cached_data
+                @test !haskey(QUBOTools.metadata(fresh_backend), "sentinel")
+                @test !haskey(QUBOTools.metadata(model.qubo_backend_cache), "sentinel")
+            end
         end
 
         @testset "Solver Name and Version" begin


### PR DESCRIPTION
## Summary

Closes #183.

This PR optimizes the already-QUBO path for unconstrained binary quadratic models. The compiler now remaps source objective terms directly into the target MOI QUBO model and builds a cached `QUBOTools.Model` backend in the same pass, avoiding the previous MOI -> PBO -> MOI copy and the later target-model reparse in `QUBOTools.backend`.

The generic reformulation path for constrained, encoded, penalty-generated, and non-binary models is unchanged.

## Tests

- `git diff --check`
- `julia --project -e 'using Pkg; Pkg.test()'`
  - Passed: 1639/1639 tests

`JuliaFormatter` was not run because it is not installed in the active project environment.

## Performance

Local MOI-level dense NPP fixture at `n = 1000`, with two warmup runs and ten measured runs:

- `origin/main`: median compile + backend extraction `0.4081747785 s`
- this branch: median compile + backend extraction `0.114548496 s`

This measures ToQUBO-side `MOI.optimize!(model)` plus `QUBOTools.backend(model)` for an already-QUBO dense quadratic objective.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `152bae86907fa2fe7da03c5e3a0cbccc0f8be801`
- Stacked status: not stacked
- Prerequisite PRs: none
