### PR TITLE
Release v0.5.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## v0.5.2 - 2026-06-25
+
+### Breaking changes
+
+- No breaking changes.
+
+### Performance
+
+- Reduce NPP QUBO fast-path compiler overhead by accumulating backend linear and quadratic data directly into sparse-array constructor inputs, avoiding the large intermediate `Dict{Tuple{VI,VI},T}` cache build while still writing the target MOI `ScalarQuadraticFunction` and preserving the `QUBOTools.backend(model)` path.
+
+### Maintenance
+
+- Require QUBOTools 0.15, since the QUBO fast path now relies on its sparse normal-form APIs (`Form`, `SparseLinearForm`, `SparseQuadraticForm`); the previous 0.11–0.14 compatibility no longer applies.
+- Add a `SparseArrays` compatibility bound.
+- Add equivalence coverage for duplicate, reversed, and cancelling quadratic terms so the direct sparse summation path stays equivalent to parsing the target MOI model.
+
 ## v0.5.1 - 2026-06-24
 
 ### Breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name    = "ToQUBO"
 uuid    = "9a412ddf-83fa-43b6-9748-7843c851aa65"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "bernalde <dbernalneira@usra.edu>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 MathOptInterface          = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"


### PR DESCRIPTION
## Summary

Release PR for ToQUBO v0.5.2. Ships the NPP QUBO fast-path compiler-overhead reduction merged in #191 (closing #190).

Diff against `main` is metadata only:

- `Project.toml`: `version` `0.5.1` -> `0.5.2`.
- `NEWS.md`: new `v0.5.2 - 2026-06-25` section (Breaking: none; Performance: sparse-array fast path; Maintenance: QUBOTools 0.15 requirement, SparseArrays compat, duplicate/reversed/cancelling quadratic-term coverage).

No source, test, or compat-value changes beyond what already landed in #191 and passed full CI on merge commit `f38073c`.

## Checks

- `git diff --check`: pass
- `julia --project=. scripts/release_check.jl`: `Release preflight passed for ToQUBO v0.5.2` (docs self-compat `ToQUBO = "0.5"` confirmed)
- Full test matrix and docs build run via this PR's CI.

## Post-merge

Register on the merge commit per `docs/dev/release.md` (not yet done by automation):

- `gh api repos/JuliaQUBO/ToQUBO.jl/commits/<merge-sha>/comments -f body="$(cat docs/dev/release-notes-template.md)"`
- Watch the General registry PR, then verify TagBot tag and `Pkg.add`.

The QUBOTools public sparse-constructor cleanup remains tracked in JuliaQUBO/QUBOTools.jl#115 and is a separate later release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)