### PR TITLE
Profile residual dense NPP-like path

### DIFF
--- a/benchmarks/dense_npp_profile.jl
+++ b/benchmarks/dense_npp_profile.jl
@@ -1,0 +1,328 @@
+module DenseNPPProfile
+
+# In this repository, run with JuMP available from the test environment:
+# JULIA_LOAD_PATH="@:test:@stdlib" julia --project=. benchmarks/dense_npp_profile.jl
+
+import JuMP
+import MathOptInterface as MOI
+import QUBOTools
+import ToQUBO
+import ToQUBO.Attributes
+
+const DEFAULT_N = 1000
+const DEFAULT_REPEATS = 5
+const DEFAULT_NON_NPP_N = 250
+
+const SAMPLE_TYPE = NamedTuple{
+    (:time, :bytes, :gctime, :compile_time),
+    Tuple{Float64,Int64,Float64,Float64},
+}
+
+function _env_int(name::AbstractString, default::Int)
+    return parse(Int, get(ENV, name, string(default)))
+end
+
+function _env_bool(name::AbstractString; default::Bool = false)
+    value = lowercase(get(ENV, name, default ? "true" : "false"))
+
+    return value in ("1", "true", "yes")
+end
+
+function _check_n(n::Integer)
+    n > 0 || throw(ArgumentError("n must be positive"))
+
+    return Int(n)
+end
+
+function _model(mode::Symbol)
+    if mode === :cached
+        return JuMP.Model(() -> ToQUBO.Optimizer{Float64}())
+    elseif mode === :direct
+        return JuMP.direct_model(ToQUBO.Optimizer{Float64}())
+    else
+        throw(ArgumentError("unknown optimizer mode: $mode"))
+    end
+end
+
+function build_npp_model(n::Integer; mode::Symbol = :cached)
+    n = _check_n(n)
+    model = _model(mode)
+    weights = collect(Float64, 1:n)
+
+    JuMP.@variable(model, x[1:n], Bin)
+    residual = JuMP.@expression(model, sum(weights[i] * (2 * x[i] - 1) for i = 1:n))
+    JuMP.@objective(model, Min, residual^2)
+
+    return model
+end
+
+function _dense_quadratic_coefficient(i::Int, j::Int, n::Int)
+    return (Float64(mod(5 * i + 3 * j, 17)) - 8.0) / n
+end
+
+function build_dense_quadratic_model(n::Integer; mode::Symbol = :cached)
+    n = _check_n(n)
+    model = _model(mode)
+
+    JuMP.@variable(model, x[1:n], Bin)
+    JuMP.@objective(
+        model,
+        Min,
+        sum(_dense_quadratic_coefficient(i, j, n) * x[i] * x[j] for i = 1:n for j = i:n) +
+        sum((isodd(i) ? -1.0 : 1.0) * i / n * x[i] for i = 1:n),
+    )
+
+    return model
+end
+
+function _median(values::Vector{Float64})
+    sorted = sort(values)
+    n = length(sorted)
+    mid = n >>> 1
+
+    return isodd(n) ? sorted[mid + 1] : (sorted[mid] + sorted[mid + 1]) / 2
+end
+
+function _sample(time::Float64, bytes::Int64, gctime::Float64; compile_time::Float64 = NaN)
+    return (
+        time = time,
+        bytes = bytes,
+        gctime = gctime,
+        compile_time = compile_time,
+    )::SAMPLE_TYPE
+end
+
+function _compilation_time(model)
+    for target in (model, JuMP.backend(model))
+        try
+            return Float64(MOI.get(target, Attributes.CompilationTime()))
+        catch
+            # Not every JuMP backend layer exposes optimizer attributes.
+        end
+    end
+
+    return NaN
+end
+
+function _summary(samples::Vector{SAMPLE_TYPE})
+    times = [sample.time for sample in samples]
+    bytes = [Float64(sample.bytes) for sample in samples]
+    gctimes = [sample.gctime for sample in samples]
+    compile_times = filter(!isnan, [sample.compile_time for sample in samples])
+
+    return (
+        samples = length(samples),
+        min_time = minimum(times),
+        median_time = _median(times),
+        median_bytes = _median(bytes),
+        median_gctime = _median(gctimes),
+        median_compile_time = isempty(compile_times) ? NaN : _median(compile_times),
+    )
+end
+
+function measure_construction(builder::Function, n::Integer; mode::Symbol, repeats::Int)
+    samples = SAMPLE_TYPE[]
+
+    for _ = 1:repeats
+        GC.gc()
+        stats = @timed begin
+            builder(n; mode)
+            nothing
+        end
+        push!(samples, _sample(stats.time, stats.bytes, stats.gctime))
+    end
+
+    return _summary(samples)
+end
+
+function measure_optimize(builder::Function, n::Integer; mode::Symbol, repeats::Int)
+    samples = SAMPLE_TYPE[]
+
+    for _ = 1:repeats
+        model = builder(n; mode)
+        GC.gc()
+        stats = @timed begin
+            JuMP.optimize!(model)
+            nothing
+        end
+        push!(
+            samples,
+            _sample(
+                stats.time,
+                stats.bytes,
+                stats.gctime;
+                compile_time = _compilation_time(model),
+            ),
+        )
+    end
+
+    return _summary(samples)
+end
+
+function measure_backend(builder::Function, n::Integer; mode::Symbol, repeats::Int)
+    samples = SAMPLE_TYPE[]
+
+    for _ = 1:repeats
+        model = builder(n; mode)
+        JuMP.optimize!(model)
+        GC.gc()
+        stats = @timed begin
+            QUBOTools.backend(model)
+            nothing
+        end
+        push!(samples, _sample(stats.time, stats.bytes, stats.gctime))
+    end
+
+    return _summary(samples)
+end
+
+function profile_fixture(
+    label::AbstractString,
+    builder::Function,
+    n::Integer;
+    modes = (:cached, :direct),
+    repeats::Int = DEFAULT_REPEATS,
+    warmup::Bool = true,
+)
+    n = _check_n(n)
+    repeats > 0 || throw(ArgumentError("repeats must be positive"))
+
+    if warmup
+        for mode in modes
+            warmup_model = builder(n; mode)
+            JuMP.optimize!(warmup_model)
+            QUBOTools.backend(warmup_model)
+        end
+    end
+
+    rows = NamedTuple[]
+
+    for mode in modes
+        push!(
+            rows,
+            (
+                fixture = String(label),
+                n = n,
+                mode = mode,
+                phase = "model construction",
+                summary = measure_construction(builder, n; mode, repeats),
+            ),
+        )
+        push!(
+            rows,
+            (
+                fixture = String(label),
+                n = n,
+                mode = mode,
+                phase = "optimize!",
+                summary = measure_optimize(builder, n; mode, repeats),
+            ),
+        )
+        push!(
+            rows,
+            (
+                fixture = String(label),
+                n = n,
+                mode = mode,
+                phase = "QUBOTools.backend",
+                summary = measure_backend(builder, n; mode, repeats),
+            ),
+        )
+    end
+
+    return rows
+end
+
+function _fmt_seconds(value::Float64)
+    return isnan(value) ? "" : string(round(value; digits = 6))
+end
+
+function _fmt_mib(bytes::Float64)
+    return string(round(bytes / 1024^2; digits = 3))
+end
+
+function print_markdown_table(io::IO, rows)
+    println(
+        io,
+        "| Fixture | n | Mode | Phase | Median time (s) | Min time (s) | Median alloc (MiB) | Median GC (s) | Median compile time (s) |",
+    )
+    println(io, "| --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: |")
+
+    for row in rows
+        summary = row.summary
+        println(
+            io,
+            "| ",
+            row.fixture,
+            " | ",
+            row.n,
+            " | ",
+            row.mode,
+            " | ",
+            row.phase,
+            " | ",
+            _fmt_seconds(summary.median_time),
+            " | ",
+            _fmt_seconds(summary.min_time),
+            " | ",
+            _fmt_mib(summary.median_bytes),
+            " | ",
+            _fmt_seconds(summary.median_gctime),
+            " | ",
+            _fmt_seconds(summary.median_compile_time),
+            " |",
+        )
+    end
+
+    return nothing
+end
+
+function main()
+    n = _env_int("TOQUBO_DENSE_PROFILE_N", DEFAULT_N)
+    repeats = _env_int("TOQUBO_DENSE_PROFILE_REPEATS", DEFAULT_REPEATS)
+    non_npp_n = _env_int("TOQUBO_DENSE_PROFILE_NON_NPP_N", min(n, DEFAULT_NON_NPP_N))
+    modes = _env_bool("TOQUBO_DENSE_PROFILE_DIRECT", default = true) ?
+            (:cached, :direct) :
+            (:cached,)
+
+    rows = NamedTuple[]
+    append!(
+        rows,
+        profile_fixture(
+            "NPP-like squared affine",
+            build_npp_model,
+            n;
+            modes,
+            repeats,
+        ),
+    )
+    append!(
+        rows,
+        profile_fixture(
+            "generic dense quadratic",
+            build_dense_quadratic_model,
+            non_npp_n;
+            modes,
+            repeats,
+        ),
+    )
+
+    println("# Dense quadratic profile")
+    println()
+    println("- NPP-like n: ", n)
+    println("- Generic dense quadratic n: ", non_npp_n)
+    println("- Repeats per phase: ", repeats)
+    println(
+        "- Compilation time column: `ToQUBO.Attributes.CompilationTime()` after `optimize!`",
+    )
+    println()
+    print_markdown_table(stdout, rows)
+
+    return rows
+end
+
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    DenseNPPProfile.main()
+end

--- a/benchmarks/dense_npp_profile.jl
+++ b/benchmarks/dense_npp_profile.jl
@@ -6,6 +6,7 @@ module DenseNPPProfile
 import JuMP
 import MathOptInterface as MOI
 import QUBOTools
+import Statistics
 import ToQUBO
 import ToQUBO.Attributes
 
@@ -75,14 +76,6 @@ function build_dense_quadratic_model(n::Integer; mode::Symbol = :cached)
     return model
 end
 
-function _median(values::Vector{Float64})
-    sorted = sort(values)
-    n = length(sorted)
-    mid = n >>> 1
-
-    return isodd(n) ? sorted[mid + 1] : (sorted[mid] + sorted[mid + 1]) / 2
-end
-
 function _sample(time::Float64, bytes::Int64, gctime::Float64; compile_time::Float64 = NaN)
     return (
         time = time,
@@ -113,10 +106,10 @@ function _summary(samples::Vector{SAMPLE_TYPE})
     return (
         samples = length(samples),
         min_time = minimum(times),
-        median_time = _median(times),
-        median_bytes = _median(bytes),
-        median_gctime = _median(gctimes),
-        median_compile_time = isempty(compile_times) ? NaN : _median(compile_times),
+        median_time = Statistics.median(times),
+        median_bytes = Statistics.median(bytes),
+        median_gctime = Statistics.median(gctimes),
+        median_compile_time = isempty(compile_times) ? NaN : Statistics.median(compile_times),
     )
 end
 

--- a/benchmarks/reports/dense_npp_profile.md
+++ b/benchmarks/reports/dense_npp_profile.md
@@ -1,0 +1,69 @@
+# Dense NPP-Like Profile
+
+This report records a local diagnostic run for issue #196. It is a
+reproducible benchmark note, not a canonical cross-machine performance claim.
+
+## Environment
+
+- Date: 2026-06-25
+- Branch point: `8b80879cd6ca8dcb7c68a89dd8eba8167c3049ba`
+- Julia: 1.10.11
+- ToQUBO.jl: 0.6.0 from this checkout
+- JuMP: 1.30.1 from `test/Manifest.toml`
+- QUBOTools.jl: 0.16.0
+- Command:
+
+```sh
+JULIA_LOAD_PATH="@:test:@stdlib" \
+TOQUBO_DENSE_PROFILE_N=1000 \
+TOQUBO_DENSE_PROFILE_NON_NPP_N=250 \
+TOQUBO_DENSE_PROFILE_REPEATS=5 \
+julia --project=. benchmarks/dense_npp_profile.jl
+```
+
+## Results
+
+The cached mode uses a normal JuMP `Model` backed by `ToQUBO.Optimizer`.
+The direct mode uses `JuMP.direct_model(ToQUBO.Optimizer{Float64}())` as a
+diagnostic comparison. The compile-time column is
+`ToQUBO.Attributes.CompilationTime()` recorded by ToQUBO inside `optimize!`.
+
+| Fixture | n | Mode | Phase | Median time (s) | Min time (s) | Median alloc (MiB) | Median GC (s) | Median compile time (s) |
+| --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| NPP-like squared affine | 1000 | cached | model construction | 0.16786 | 0.163039 | 84.034 | 0.002987 |  |
+| NPP-like squared affine | 1000 | cached | optimize! | 0.062655 | 0.033776 | 106.223 | 0.028829 | 0.025646 |
+| NPP-like squared affine | 1000 | cached | QUBOTools.backend | 0.001072 | 0.00106 | 7.69 | 0.0 |  |
+| NPP-like squared affine | 1000 | direct | model construction | 0.168005 | 0.159682 | 83.887 | 0.003161 |  |
+| NPP-like squared affine | 1000 | direct | optimize! | 0.025643 | 0.024825 | 59.182 | 0.0 | 0.025531 |
+| NPP-like squared affine | 1000 | direct | QUBOTools.backend | 0.001085 | 0.001046 | 7.69 | 0.0 |  |
+| generic dense quadratic | 250 | cached | model construction | 0.010218 | 0.008726 | 22.765 | 0.0 |  |
+| generic dense quadratic | 250 | cached | optimize! | 0.003212 | 0.003143 | 6.968 | 0.0 | 0.001511 |
+| generic dense quadratic | 250 | cached | QUBOTools.backend | 0.000137 | 0.00013 | 0.467 | 0.0 |  |
+| generic dense quadratic | 250 | direct | model construction | 0.010225 | 0.010101 | 22.685 | 0.0 |  |
+| generic dense quadratic | 250 | direct | optimize! | 0.001617 | 0.001605 | 3.891 | 0.0 | 0.001525 |
+| generic dense quadratic | 250 | direct | QUBOTools.backend | 0.000132 | 0.000124 | 0.467 | 0.0 |  |
+
+## Conclusions
+
+- For the NPP-like `n = 1000` case, JuMP model construction is the largest
+  measured phase at about 168 ms median.
+- ToQUBO's recorded compile time is about 25.6 ms. In direct optimizer mode,
+  measured `optimize!` is effectively the same size as the recorded compile
+  time, which indicates the residual cached-mode `optimize!` gap is mostly
+  JuMP/MOI cached-copy overhead and GC rather than compiler work.
+- `QUBOTools.backend(model)` is about 1.1 ms locally for the NPP-like case, so
+  backend extraction is not the material bottleneck in this run.
+- The smaller generic dense quadratic fixture shows the same shape:
+  cached-mode `optimize!` is above recorded compile time, direct-mode
+  `optimize!` tracks recorded compile time, and backend extraction is small.
+- No generic low-risk compiler change is indicated by this diagnostic run. The
+  remaining benchmark gap should be interpreted mainly as JuMP/MOI frontend
+  construction plus cached optimizer overhead and benchmark methodology, not as
+  QUBOTools backend extraction.
+
+## Follow-Up
+
+If absolute NPP benchmark competitiveness remains a goal, compare benchmark
+methodology and JuMP frontend construction separately from ToQUBO compilation.
+Direct optimizer mode is useful as a diagnostic, but it should not replace the
+normal public JuMP usage path without a separate compatibility review.

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,6 +6,7 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 PseudoBooleanOptimization = "c8fa9a04-bc42-452d-8558-dc51757be744"
 QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/test/unit/dense_npp_profile.jl
+++ b/test/unit/dense_npp_profile.jl
@@ -27,7 +27,9 @@ function test_dense_npp_profile_benchmark()
         @test [row.phase for row in rows] ==
               ["model construction", "optimize!", "QUBOTools.backend"]
         @test all(row.summary.samples == 1 for row in rows)
-        @test all(row.summary.median_time >= 0.0 for row in rows)
+        @test all(
+            isfinite(row.summary.min_time) && isfinite(row.summary.median_time) for row in rows
+        )
         @test isfinite(rows[2].summary.median_compile_time)
     end
 

--- a/test/unit/dense_npp_profile.jl
+++ b/test/unit/dense_npp_profile.jl
@@ -1,0 +1,35 @@
+include(joinpath(@__DIR__, "..", "..", "benchmarks", "dense_npp_profile.jl"))
+
+function test_dense_npp_profile_benchmark()
+    @testset "Dense NPP profile benchmark" begin
+        n = 4
+
+        npp_model = DenseNPPProfile.build_npp_model(n)
+        @test JuMP.num_variables(npp_model) == n
+        optimize!(npp_model)
+        @test QUBOTools.backend(npp_model) isa QUBOTools.Model
+
+        dense_model = DenseNPPProfile.build_dense_quadratic_model(n)
+        @test JuMP.num_variables(dense_model) == n
+        optimize!(dense_model)
+        @test QUBOTools.backend(dense_model) isa QUBOTools.Model
+
+        rows = DenseNPPProfile.profile_fixture(
+            "small NPP-like",
+            DenseNPPProfile.build_npp_model,
+            3;
+            modes = (:cached,),
+            repeats = 1,
+            warmup = false,
+        )
+
+        @test length(rows) == 3
+        @test [row.phase for row in rows] ==
+              ["model construction", "optimize!", "QUBOTools.backend"]
+        @test all(row.summary.samples == 1 for row in rows)
+        @test all(row.summary.median_time >= 0.0 for row in rows)
+        @test isfinite(rows[2].summary.median_compile_time)
+    end
+
+    return nothing
+end

--- a/test/unit/unit.jl
+++ b/test/unit/unit.jl
@@ -9,6 +9,7 @@ include("attributes/attributes.jl")
 include("reformulation.jl")
 include("feasibility.jl")
 include("qoblib_benchmark.jl")
+include("dense_npp_profile.jl")
 
 function test_unit()
     @testset "⊚ Unit Tests" verbose = true begin
@@ -23,6 +24,7 @@ function test_unit()
         test_reformulation_metadata()
         test_feasibility()
         test_qoblib_benchmark_pilot()
+        test_dense_npp_profile_benchmark()
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- Add `benchmarks/dense_npp_profile.jl` to measure JuMP model construction, `optimize!`, and `QUBOTools.backend` separately for the NPP-like dense squared-affine binary case.
- Include a non-NPP generic dense quadratic fixture and cached-vs-direct JuMP optimizer mode diagnostics.
- Record a local benchmark note in `benchmarks/reports/dense_npp_profile.md` showing that JuMP construction and cached optimizer overhead dominate the residual path, while backend extraction is not material.
- Add a small unit-test smoke path for the benchmark helpers.

## Tests

- `julia --project=. -e 'using Pkg; Pkg.test(; test_args=["dense-profile-smoke"])'` - passed. The repository test runner ignores `test_args`, so this ran the full package suite: 1680 passed.
- `JULIA_LOAD_PATH="@:test:@stdlib" TOQUBO_DENSE_PROFILE_N=1000 TOQUBO_DENSE_PROFILE_NON_NPP_N=250 TOQUBO_DENSE_PROFILE_REPEATS=5 julia --project=. benchmarks/dense_npp_profile.jl` - passed and produced the report data.
- `JULIA_LOAD_PATH="@:test:@stdlib" TOQUBO_DENSE_PROFILE_N=20 TOQUBO_DENSE_PROFILE_NON_NPP_N=12 TOQUBO_DENSE_PROFILE_REPEATS=1 julia --project=. benchmarks/dense_npp_profile.jl` - passed smoke check.
- `git diff --check` - passed.

## Branch Hygiene

- Base branch: `main`
- Head branch: `fix/issue-196-dense-npp-profile`
- Source branch point: `origin/main` at `8b80879cd6ca8dcb7c68a89dd8eba8167c3049ba`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #196
