### PR TITLE
Standardize CI cache baseline for Wave 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
## Summary

- Add `julia-actions/cache@v2` to the package `CI` workflow so every Julia matrix entry uses the standard cache action.
- Keep the existing package-test matrix: Julia `1.10` and `1` on `ubuntu-latest`, plus Julia `1.10` and `1` on `windows-latest`.
- Keep the existing Dependabot baseline: weekly Julia updates for root/docs/test and monthly GitHub Actions updates.

Remaining drift/exception:
- `Documentation` remains a separate repo-specific workflow, which is allowed by the Wave 1 issue scope and is not promoted to a branch-protection gate here.

Closes #198

## Tests

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/ci.yml .github/dependabot.yml`
- `actionlint .github/workflows/ci.yml`

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `8137f0be65a3fb083aa86c9431e1f255c16c6d03`
- Stacked status: standalone PR
- Prerequisite PRs: none
