### PR TITLE
docs: clarify Neal penalty tuning

### DIFF
--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -133,6 +133,24 @@ while keeping explicit hints unset. If only one constraint needs adjustment,
 override that constraint's automatic scale or offset. Pin exact penalty values
 only when you have a known coefficient to apply.
 
+Finite-run stochastic samplers such as `DWave.Neal` may need stronger penalties
+than the default exact-penalty bound to return feasible samples at a useful
+rate. In that case, prefer targeted
+[`ToQUBO.Attributes.ConstraintPenaltyScale`](@ref) overrides for the source
+constraints that are violated most often, instead of increasing the global
+[`ToQUBO.Attributes.PenaltyScale`](@ref) or replacing automatic inference with
+fixed hints everywhere. For example, if equality constraints `c2`, `c3`, and
+`c4` need about a 400x larger automatic penalty under a sampler:
+
+```julia
+set_attribute.(c2, Ref(Attributes.ConstraintPenaltyScale()), 400.0)
+set_attribute.(c3, Ref(Attributes.ConstraintPenaltyScale()), 400.0)
+set_attribute.(c4, Ref(Attributes.ConstraintPenaltyScale()), 400.0)
+```
+
+This keeps the selected automatic policy and its metadata, while reshaping the
+penalty landscape only around the constraints that need more sampler pressure.
+
 ```@example penalty-settings
 using JuMP
 using QUBODrivers

--- a/test/unit/docs.jl
+++ b/test/unit/docs.jl
@@ -28,6 +28,9 @@ function test_docs()
         @test occursin("Attributes.ConstraintPenaltyScale()", settings_page)
         @test occursin("Attributes.SlackVariableEncodingPenaltyHint()", settings_page)
         @test occursin("ToQUBO-specific settings", settings_page)
+        @test occursin("DWave.Neal", settings_page)
+        @test occursin("Finite-run stochastic samplers", settings_page)
+        @test occursin("Ref(Attributes.ConstraintPenaltyScale())", settings_page)
     end
 
     return nothing


### PR DESCRIPTION
## Summary

Refs #205.

- document finite-run stochastic sampler penalty tuning for `DWave.Neal`
- recommend targeted `ConstraintPenaltyScale()` overrides for frequently violated source constraints instead of global `PenaltyScale()` or fixed hints everywhere
- add a docs unit assertion so the Neal tuning guidance stays present

## Reproduction Notes

The linked reproducer repository from #205, `ZOMEGA-Group/QUBO_UC`, was not accessible from this environment through `gh repo clone` or GitHub search. I therefore used an isolated `/tmp/toqubo-205-repro` Julia project with local ToQUBO plus:

- `DWave v0.7.6`
- `JuMP v1.30.1`
- `QUBODrivers v0.6.5`
- `QUBOTools v0.16.0`

A small UC-style mixed-integer fixture was scaled so ToQUBO inferred the same uniform equality penalty reported in the issue: `26101.0`.

Read-weighted `DWave.Neal` results over 10 seeds and 100 reads per seed showed:

- default penalties: mean feasible rate about `0.895` with Neal default sweeps; demand equality violations in `5%` to `14%` of reads
- fixed `1e7` equality hints: mean feasible rate about `0.997`; demand equality violations `0%`
- targeted `ConstraintPenaltyScale()` on the demand equalities with scale `400`: demand penalties about `1.04404e7`, mean feasible rate about `0.997`, and demand equality violations `0%`
- global `PenaltyScale()` with the same scale was worse in this fixture because it also scaled unrelated penalties and changed the sampler landscape

This supports treating #205 as finite-sampler penalty tuning guidance rather than changing the default exact-penalty policy.

## Local Checks

- `julia --project=test -e 'push!(LOAD_PATH, pwd()); using Test; include("test/unit/docs.jl"); test_docs()'`
- `git diff --check`

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main`
- Stacked status: standalone
- Prerequisite PRs: none
