### PR TITLE
docs: explain slack-resolution penalty contrast

### DIFF
--- a/docs/src/booklet/4-encoding.md
+++ b/docs/src/booklet/4-encoding.md
@@ -172,16 +172,20 @@ tolerance used for bit-count inference. The selected encoding method comes from
 The required real-valued slack can fall between two values on the encoded grid.
 In that case ``g(x) \pm z`` cannot reach zero even though the original
 continuous inequality is feasible, leaving a positive squared-residual floor.
-Finer resolution reduces this representation error but consumes more target
+The floor can be zero when the required slack lands exactly on the grid, and
+grid alignment means it need not decrease strictly at every added bit. Finer
+resolution generally reduces the representation error but consumes more target
 binary variables and can change the effective penalty landscape. The bit-count
-relationship is derived in [Representation Error](@ref), and the user-facing
-settings are summarized under [Continuous Variable Resolution](@ref).
+relationship is derived in [Representation Error](@ref). The user-facing
+settings and the required feasible/infeasible penalty contrast are summarized
+under [Continuous Variable Resolution](@ref) and
+[Slack Resolution and Penalty Contrast](@ref).
 
 Sampling-feasibility behavior that motivated this documentation is tracked in
-[#205](https://github.com/JuliaQUBO/ToQUBO.jl/issues/205). The resolution and
-penalty interaction is being analyzed in
-[#208](https://github.com/JuliaQUBO/ToQUBO.jl/issues/208), while a possible
-slack-free alternative is tracked separately in
+[#205](https://github.com/JuliaQUBO/ToQUBO.jl/issues/205). The
+[issue #208 analysis](https://github.com/JuliaQUBO/ToQUBO.jl/blob/main/benchmarks/reports/slack_resolution_analysis.md)
+found that continuous-slack resolution does not explain that model's reported
+violations, while a possible slack-free alternative is tracked separately in
 [#207](https://github.com/JuliaQUBO/ToQUBO.jl/issues/207).
 
 Equality constraints use a squared residual penalty by default. The compiler

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -54,12 +54,15 @@ where `s` is [`ToQUBO.Attributes.PenaltyScale`](@ref), `β` is
 [`ToQUBO.Attributes.PenaltyOffset`](@ref), `σ` is `1` for minimization models
 and `-1` for maximization models, `U - L` is the compiled pseudo-boolean
 objective range, and `ϵ` is the smallest positive value of the generated
-nonnegative penalty function. With the default scale `s = 1` and `β > 0`, any
-infeasible assignment is penalized by more than the largest possible objective
-improvement available within the compiled objective range. With custom scales,
-the same sufficient exactness condition is `s * (U - L + β) > U - L`; smaller
-scales can make the penalty a tuning heuristic rather than a certified exact
-penalty.
+nonnegative penalty function. When every feasible source assignment has a
+target representation with zero generated constraint penalty, the default
+scale `s = 1` and `β > 0` penalize any infeasible assignment by more than the
+largest possible objective improvement available within the compiled objective
+range. With custom scales, the same sufficient exactness condition is
+`s * (U - L + β) > U - L`; smaller scales can make the penalty a tuning
+heuristic rather than a certified exact penalty. A finite continuous-slack
+encoding can violate the zero-penalty premise; see
+[Slack Resolution and Penalty Contrast](@ref).
 
 The objective range is computed from interval bounds on the compiled PBF over
 encoded target binary variables. For normal finite JuMP/MOI models this bound
@@ -218,6 +221,95 @@ binary variables. Slack variables generated from constraints use the analogous
 [`ToQUBO.Attributes.SlackVariableEncodingBits`](@ref) settings. See
 [Constraint Reformulation](@ref) for how inequality constraints generate these
 slacks and where their finite resolution enters the penalty.
+
+### Slack Resolution and Penalty Contrast
+
+First check whether the constraint actually generates a slack. `EqualTo`
+constraints encode their residual directly and do not own an inequality slack.
+`LessThan`, `GreaterThan`, and the two sides of `Interval` can generate one,
+although a sign-definite shortcut or an always-feasible constraint can avoid
+it. After compilation, inspect:
+
+```julia
+metadata = ToQUBO.reformulation_metadata(JuMP.unsafe_backend(model))
+metadata["slack_variables"]
+```
+
+Those entries identify the source constraints that own generated slacks and
+expose their encoding and expansion terms.
+
+The [`ToQUBO.Attributes.Discretize`](@ref) setting determines which slack path
+is relevant:
+
+- `Discretize(true)` is the default. The compiler discretizes each constraint
+  residual and generates an integer slack, so those generated slacks do not
+  introduce the continuous-grid floor described below.
+- `Discretize(false)` preserves noninteger residual coefficients and generates
+  a continuous slack. Its finite binary encoding may not contain the exact
+  value needed to cancel a feasible residual.
+
+For the default binary encoding of a continuous slack on ``[0, S]`` with ``n``
+bits, the grid spacing is
+
+```math
+\Delta = \frac{S}{2^n - 1}.
+```
+
+If a feasible source assignment needs slack ``z^\star``, its smallest squared
+penalty is
+
+```math
+p_F = \min_k |z^\star - k\Delta|^2 \leq \frac{\Delta^2}{4}.
+```
+
+The floor is zero when ``z^\star`` lies on the grid, and grid alignment means
+that it need not decrease strictly at every added bit. Resolution alone also
+does not determine a safe penalty coefficient. For a minimization model, let
+an infeasible assignment have objective advantage ``B > 0`` and smallest
+penalty ``p_I``. A positive coefficient ``\rho`` prefers the feasible
+assignment only when
+
+```math
+\rho (p_I - p_F) > B.
+```
+
+When `p_I - p_F` is positive, this gives
+``\rho > B / (p_I - p_F)``. When ``p_I \leq p_F``, no positive `rho` can repair
+the ordering; increasing it can strengthen the wrong preference. Refining the
+slack encoding, changing the source model's tolerance, or choosing a different
+reformulation must first make the contrast positive.
+
+ToQUBO does not currently relax a residual to a tolerance band or rescale a
+constraint automatically from slack resolution; the checks above diagnose
+whether either policy could be valid for a particular continuous-slack model.
+
+Use this diagnostic sequence before changing penalties:
+
+1. Classify the violated source constraint and confirm slack ownership in the
+   reformulation metadata. Equality violations are not caused by slack
+   resolution.
+2. Check `Discretize()`. Under the default `true` path, investigate the
+   compiled integer penalty and solver behavior rather than applying a
+   continuous-resolution multiplier.
+3. Under `false`, inspect the slack expansion, estimate ``p_F`` and a relevant
+   ``p_I``, and establish positive contrast before increasing ``\rho``. Use
+   [`ToQUBO.Attributes.SlackVariableEncodingBits`](@ref) or
+   [`ToQUBO.Attributes.SlackVariableEncodingATol`](@ref) when finer resolution
+   is the appropriate tradeoff.
+4. Separate exact-model energy ordering from finite-run sampler behavior. If
+   the energy ordering is correct but a stochastic sampler still returns
+   violations, use targeted
+   [`ToQUBO.Attributes.ConstraintPenaltyScale`](@ref) tuning as described in
+   [Changing Penalty Values](@ref), and check whether violations move to other
+   constraint families.
+
+The [Slack-resolution penalty analysis](https://github.com/JuliaQUBO/ToQUBO.jl/blob/main/benchmarks/reports/slack_resolution_analysis.md)
+derives this condition with an executable public fixture. Its canonical #205
+audit found that the troublesome c2-c4 families were slack-free binary
+equalities and that the model's generated inequality slacks were integral under
+`Discretize(true)`. Their finite-run sampler behavior therefore supports the
+targeted constraint guidance above, not resolution-aware scaling as a remedy
+for #205.
 
 ### Constraint Penalty Methods
 

--- a/test/unit/slack_resolution_docs.jl
+++ b/test/unit/slack_resolution_docs.jl
@@ -1,0 +1,29 @@
+function test_slack_resolution_docs()
+    root = normpath(joinpath(@__DIR__, "..", ".."))
+    settings = replace(
+        read(joinpath(root, "docs", "src", "manual", "4-settings.md"), String),
+        "\r\n" => "\n",
+    )
+    booklet = replace(
+        read(joinpath(root, "docs", "src", "booklet", "4-encoding.md"), String),
+        "\r\n" => "\n",
+    )
+
+    @testset "Slack-resolution guidance" begin
+        @test occursin("### Slack Resolution and Penalty Contrast", settings)
+        @test occursin("`Discretize(true)`", settings)
+        @test occursin("`Discretize(false)`", settings)
+        @test occursin("zero generated constraint penalty", settings)
+        @test occursin("reformulation_metadata", settings)
+        @test occursin("metadata[\"slack_variables\"]", settings)
+        @test occursin("p_I - p_F", settings)
+        @test occursin("no positive `rho`", settings)
+        @test occursin("exact-model energy ordering", settings)
+        @test occursin("finite-run sampler behavior", settings)
+        @test occursin("does not currently relax a residual", settings)
+        @test occursin("Slack-resolution penalty analysis", settings)
+        @test occursin("[Slack Resolution and Penalty Contrast](@ref)", booklet)
+    end
+
+    return nothing
+end

--- a/test/unit/unit.jl
+++ b/test/unit/unit.jl
@@ -12,6 +12,7 @@ include("feasibility.jl")
 include("qoblib_benchmark.jl")
 include("dense_npp_profile.jl")
 include("slack_resolution_analysis.jl")
+include("slack_resolution_docs.jl")
 
 function test_unit()
     @testset "⊚ Unit Tests" verbose = true begin
@@ -29,6 +30,7 @@ function test_unit()
         test_qoblib_benchmark_pilot()
         test_dense_npp_profile_benchmark()
         test_slack_resolution_analysis()
+        test_slack_resolution_docs()
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- qualify the objective-range exact-penalty guidance when a feasible source
  assignment cannot achieve zero generated penalty;
- document the `Discretize(true)` integer-slack path and the
  `Discretize(false)` continuous-slack path;
- derive the continuous-slack floor and the required contrast condition
  `rho * (p_I - p_F) > B`, including the case where no positive penalty can
  repair the ordering;
- add a diagnostic sequence that separates slack ownership, exact-model energy
  ordering, and finite-run sampler behavior;
- update the booklet cross-reference and add a dedicated docs regression guard.

Refs #208.

## Scope and evidence

This is Part 2 of the sequential plan recorded on #208. Part 1 landed in #211
and found that continuous-slack resolution is a real mechanism under
`Discretize(false)`, but it does not explain #205: the reported c2-c4 families
are slack-free binary equalities, and that model's generated inequality slacks
are integral under `Discretize(true)`.

Accordingly, this PR documents targeted `ConstraintPenaltyScale()` tuning for
#205-style finite-run sampler pressure without presenting resolution-aware
scaling as its remedy. It changes no compiler behavior, copies no
access-controlled source or data, and leaves any automatic scaling or
tolerance-band design for a separate decision supported by genuinely
continuous-slack evidence.

Related boundaries remain unchanged:

- #206 owns targeted Neal penalty tuning for #205;
- #207 owns a possible slack-free inequality encoding;
- #210 explains the current constraint reformulations;
- #173 owns the current objective-range penalty policy.

## Verification

- Initial docs guard on unchanged documentation: 11/11 assertions failed.
- Final targeted docs guard: 13/13 assertions passed.
- `julia +1.10 --project=docs docs/make.jl --skip-deploy`: passed with the
  repository's existing local docs environment.
- `julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`: 1,742/1,742 tests
  passed (1,417 unit, 325 integration) with Julia 1.10.11 and the existing
  local package cache.
- `git diff --cached --check`: passed before commit.

## Branch Hygiene

- Base: `main` at `117751958c3ce065543127f7461e8dc9ffcd107a`.
- Branch point: exact `origin/main` tip after merged Part 1 PR #211.
- Source: `docs/issue-208-slack-penalty-guidance`.
- Stacked: no; #211 is already in the base.
- Open-PR file overlap at commit time: none.
