### PR TITLE
feat: add slack-free unbalanced inequality penalties

### DIFF
--- a/docs/src/booklet/4-encoding.md
+++ b/docs/src/booklet/4-encoding.md
@@ -137,7 +137,8 @@ residual ``g(x)`` relative to the set bound. The default reformulations are:
 The `EqualTo` row shows the default
 [`ToQUBO.Attributes.QuadraticPenalty`](@ref) method. Its sign-definite shortcut
 and the optional [`ToQUBO.Attributes.LinearPenalty`](@ref) method are described
-below.
+below. Scalar inequalities can instead select the slack-free
+[`ToQUBO.Attributes.UnbalancedPenalty`](@ref) method.
 
 The one-sided reformulations introduce a bounded nonnegative slack ``z`` so
 that feasible residuals can be brought to zero. If ``L_g`` and ``U_g`` are
@@ -185,8 +186,9 @@ Sampling-feasibility behavior that motivated this documentation is tracked in
 [#205](https://github.com/JuliaQUBO/ToQUBO.jl/issues/205). The
 [issue #208 analysis](https://github.com/JuliaQUBO/ToQUBO.jl/blob/main/benchmarks/reports/slack_resolution_analysis.md)
 found that continuous-slack resolution does not explain that model's reported
-violations, while a possible slack-free alternative is tracked separately in
-[#207](https://github.com/JuliaQUBO/ToQUBO.jl/issues/207).
+violations. The slack-free method added for
+[#207](https://github.com/JuliaQUBO/ToQUBO.jl/issues/207) addresses the separate
+target-variable cost of generated inequality slacks.
 
 Equality constraints use a squared residual penalty by default. The compiler
 can also encode an equality constraint with a signed linear residual through
@@ -197,6 +199,16 @@ method: the sign and magnitude of ``\rho`` affect whether the residual
 discourages the intended violations, so `ToQUBO` requires an explicit
 [`ToQUBO.Attributes.ConstraintEncodingPenaltyHint`](@ref) instead of inferring
 ``\rho`` automatically.
+
+For a `LessThan` residual ``g(x) \leq 0``, `UnbalancedPenalty()` generates
+``\lambda_1 g(x) + \lambda_2 g(x)^2``; for `GreaterThan`, it negates the linear
+term. This quadratic approximation avoids the constraint slack variables for
+affine inequalities, but it is heuristic: feasible assignments can receive
+different nonzero energies. It therefore requires an explicit
+`ConstraintEncodingPenaltyHint`. Prefer it when target-variable savings justify
+tuning and validating the altered energy ordering; keep the default slack
+formulation when a representable feasible slack must give exactly zero penalty.
+Quadratic source inequalities can still require quadratization variables.
 
 When any reformulation creates terms above quadratic degree, the compiler marks
 the model for quadratization and reduces those terms before building the target

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -355,6 +355,55 @@ For mixed models, keep the default method as
 [`ToQUBO.Attributes.ConstraintEncodingMethod`](@ref) only on the constraints
 that should use the linear residual.
 
+For scalar inequalities, [`ToQUBO.Attributes.UnbalancedPenalty`](@ref) removes
+the generated constraint slack. For a `LessThan` residual ``g(x) \leq 0`` it
+uses
+
+```math
+\lambda_1 g(x) + \lambda_2 g(x)^2,
+```
+
+and for a `GreaterThan` residual ``g(x) \geq 0`` it negates the linear term.
+The default ``\lambda_1 = 1`` and ``\lambda_2 = 1/2`` come from truncating an
+exponential barrier at quadratic order; pass two finite positive values to
+`UnbalancedPenalty(linear, quadratic)` to tune their ratio. The explicit
+`ConstraintEncodingPenaltyHint` supplies the overall scale and must have the
+appropriate sign for the model sense.
+
+```julia
+using JuMP
+using ToQUBO
+using ToQUBO: Attributes
+
+model = Model(ToQUBO.Optimizer)
+@variable(model, x[1:3], Bin)
+capacity = @constraint(model, 2x[1] + x[2] + x[3] <= 2)
+
+set_attribute(
+    capacity,
+    Attributes.ConstraintEncodingMethod(),
+    Attributes.UnbalancedPenalty(),
+)
+set_attribute(capacity, Attributes.ConstraintEncodingPenaltyHint(), 4.0)
+```
+
+Prefer this method when the target-variable budget is more important than an
+exact slack reformulation and you can tune and validate the resulting energy
+ordering on representative instances. Feasible assignments need not receive
+equal or zero penalty, so the method can change which feasible point is lowest
+in energy; automatic exact-penalty inference is therefore disabled. Keep the
+default `QuadraticPenalty()` slack formulation when exact zero penalty for a
+representable feasible slack and automatic penalty inference are required.
+Affine inequalities remain quadratic without new variables. A quadratic source
+inequality can still create higher-order terms and quadratization variables,
+and an `Interval` applies the unbalanced form to both bounds.
+
+The method follows the unbalanced penalization formulation of
+Montañez-Barrera et al.[^MontanezBarrera2024] An exact hinge such as
+``\max(0, g(x))^2`` is not generally a QUBO, while the real-coefficient
+approximation in Colucci et al.[^Colucci2023] still uses ``K`` auxiliary binary
+variables. Neither provides the no-new-variable affine QUBO used here.
+
 [^Mirkarimi2024PRR]:
     Puya Mirkarimi, Ishaan Shukla, David C. Hoyle, Ross Williams, and Nicholas
     Chancellor. **Quantum optimization with linear Ising penalty functions for
@@ -372,6 +421,18 @@ that should use the linear residual.
     Chancellor. **Quantum optimization with linear Ising penalty functions for
     customer data science [dataset]**. Durham University data and code archive
     (2024). [{doi}](https://doi.org/10.15128/r2fq977t82m)
+
+[^MontanezBarrera2024]:
+    J. A. Montañez-Barrera, Dennis Willsch, A. Maldonado-Romo, and Kristel
+    Michielsen. **Unbalanced penalization: a new approach to encode inequality
+    constraints of combinatorial problems for quantum optimization
+    algorithms**. _Quantum Science and Technology_ 9, 025022 (2024).
+    [{doi}](https://doi.org/10.1088/2058-9565/ad35e4)
+
+[^Colucci2023]:
+    Giuseppe Colucci, Stan van der Linde, and Frank Phillipson. **Power Network
+    Optimization: A Quantum Approach**. _IEEE Access_ 11, 98926–98938 (2023).
+    [{doi}](https://doi.org/10.1109/ACCESS.2023.3312997)
 
 ```@docs
 ToQUBO.Attributes.VariableEncodingBits
@@ -397,6 +458,7 @@ ToQUBO.Attributes.ConstraintPenaltyOffset
 ToQUBO.Attributes.ConstraintPenaltyScale
 ToQUBO.Attributes.QuadraticPenalty
 ToQUBO.Attributes.LinearPenalty
+ToQUBO.Attributes.UnbalancedPenalty
 ToQUBO.Attributes.DefaultConstraintEncodingMethod
 ToQUBO.Attributes.ConstraintEncodingMethod
 ToQUBO.Attributes.ConstraintEncodingPenaltyHint

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -48,6 +48,54 @@ Ising penalties" ([doi:10.1088/1367-2630/ad7e4a](https://doi.org/10.1088/1367-26
 """
 struct LinearPenalty <: ConstraintPenaltyMethod end
 
+@doc raw"""
+    UnbalancedPenalty(linear = 1.0, quadratic = 0.5)
+
+Encode scalar inequality constraints without a slack variable using an
+unbalanced linear-plus-quadratic penalty.
+
+For a `LessThan` residual ``g(x) \leq 0``, the generated penalty is
+
+```math
+\lambda_1 g(x) + \lambda_2 g(x)^2,
+```
+
+and the linear term is negated for a `GreaterThan` residual
+``g(x) \geq 0``. Both coefficients must be finite and positive. The defaults
+come from the quadratic Taylor approximation of an exponential barrier.
+
+This method is heuristic: feasible points need not have equal or zero penalty,
+so it can change their energy ordering. It requires an explicit
+[`ConstraintEncodingPenaltyHint`](@ref) and is not supported for equality
+constraints. For affine inequalities it introduces no slack or quadratization
+variables; quadratic inequalities can still require quadratization.
+
+This formulation follows the unbalanced penalization method of Montañez-Barrera
+et al., "Unbalanced penalization: a new approach to encode inequality
+constraints of combinatorial problems for quantum optimization algorithms"
+([doi:10.1088/2058-9565/ad35e4](https://doi.org/10.1088/2058-9565/ad35e4)).
+"""
+struct UnbalancedPenalty{T<:Real} <: ConstraintPenaltyMethod
+    linear::T
+    quadratic::T
+
+    function UnbalancedPenalty{T}(linear::T, quadratic::T) where {T<:Real}
+        if !(isfinite(linear) && linear > zero(T))
+            throw(ArgumentError("linear coefficient must be finite and positive"))
+        elseif !(isfinite(quadratic) && quadratic > zero(T))
+            throw(ArgumentError("quadratic coefficient must be finite and positive"))
+        end
+
+        return new{T}(linear, quadratic)
+    end
+end
+
+function UnbalancedPenalty(linear::Real = 1.0, quadratic::Real = 0.5)
+    λ₁, λ₂ = promote(linear, quadratic)
+
+    return UnbalancedPenalty{typeof(λ₁)}(λ₁, λ₂)
+end
+
 function MOIU.map_indices(::Function, method::ConstraintPenaltyMethod)
     return method
 end
@@ -588,11 +636,12 @@ end
 @doc raw"""
     DefaultConstraintEncodingMethod()
 
-Fallback method used to reformulate equality constraints.
+Fallback method used to reformulate constraints.
 
 Available options are:
 - [`QuadraticPenalty`](@ref) (default)
 - [`LinearPenalty`](@ref)
+- [`UnbalancedPenalty`](@ref) (inequalities only)
 """
 struct DefaultConstraintEncodingMethod <: CompilerAttribute end
 
@@ -1221,8 +1270,9 @@ end
 Set a fixed penalty coefficient for a source constraint.
 
 When unset, ToQUBO infers the coefficient from the automatic penalty policy,
-unless the constraint uses [`LinearPenalty`](@ref). Linear penalties require an
-explicit hint because their sign and magnitude control whether the residual
+unless the constraint uses [`LinearPenalty`](@ref) for an equality or
+[`UnbalancedPenalty`](@ref) for an inequality. These heuristic methods require
+an explicit hint because their sign and magnitude control whether the residual
 discourages infeasible assignments.
 """
 struct ConstraintEncodingPenaltyHint <: CompilerConstraintAttribute end
@@ -1450,12 +1500,14 @@ end
 @doc raw"""
     ConstraintEncodingMethod()
 
-Sets the method used to reformulate an equality constraint.
+Sets the method used to reformulate a constraint.
 
 When unset, this falls back to [`DefaultConstraintEncodingMethod`](@ref).
-Inequality constraints keep the existing quadratic slack formulation.
 When set to [`LinearPenalty`](@ref), the constraint must also have an explicit
-[`ConstraintEncodingPenaltyHint`](@ref).
+[`ConstraintEncodingPenaltyHint`](@ref). Inequalities use the existing
+quadratic slack formulation unless set to [`UnbalancedPenalty`](@ref), which
+also requires an explicit hint. `UnbalancedPenalty` is not supported for
+equality constraints.
 """
 struct ConstraintEncodingMethod <: CompilerConstraintAttribute end
 

--- a/src/compiler/constraints.jl
+++ b/src/compiler/constraints.jl
@@ -30,6 +30,10 @@ function _is_quadratic_penalty(model::Virtual.Model, ci::CI)::Bool
     return Attributes.constraint_encoding_method(model, ci) isa Attributes.QuadraticPenalty
 end
 
+function _is_unbalanced_penalty(model::Virtual.Model, ci::CI)::Bool
+    return Attributes.constraint_encoding_method(model, ci) isa Attributes.UnbalancedPenalty
+end
+
 function _is_nonnegative(g::PBO.PBF{VI,T})::Bool where {T}
     l, _ = PBO.bounds(g)
 
@@ -43,11 +47,27 @@ function _is_nonpositive(g::PBO.PBF{VI,T})::Bool where {T}
 end
 
 function _equality_penalty(model::Virtual.Model, ci::CI, g::PBO.PBF)
-    if _is_quadratic_penalty(model, ci) && !_is_nonnegative(g)
+    method = Attributes.constraint_encoding_method(model, ci)
+
+    if method isa Attributes.UnbalancedPenalty
+        compilation_error("UnbalancedPenalty only supports inequality constraints")
+    elseif method isa Attributes.QuadraticPenalty && !_is_nonnegative(g)
         return g^2
     else
         return g
     end
+end
+
+function _unbalanced_penalty(model::Virtual.Model, ci::CI, g::PBO.PBF, ::LT)
+    method = Attributes.constraint_encoding_method(model, ci)::Attributes.UnbalancedPenalty
+
+    return method.linear * g + method.quadratic * g^2
+end
+
+function _unbalanced_penalty(model::Virtual.Model, ci::CI, g::PBO.PBF, ::GT)
+    method = Attributes.constraint_encoding_method(model, ci)::Attributes.UnbalancedPenalty
+
+    return -method.linear * g + method.quadratic * g^2
 end
 
 function _combine_penalties(lhs, rhs)
@@ -291,6 +311,10 @@ function constraint(
         )
     end
 
+    if _is_unbalanced_penalty(model, ci)
+        return _unbalanced_penalty(model, ci, g, s)
+    end
+
     if _is_nonnegative(g)
         return g
     end
@@ -405,6 +429,10 @@ function constraint(
             context,
             _constraint_message("Infeasible", f, ">=", s.lower),
         )
+    end
+
+    if _is_unbalanced_penalty(model, ci)
+        return _unbalanced_penalty(model, ci, g, s)
     end
 
     if _is_nonpositive(g)
@@ -581,6 +609,12 @@ function constraint(
         )
     end
 
+    if _is_unbalanced_penalty(model, ci)
+        MOI.set(model, Attributes.Quadratize(), true)
+
+        return _unbalanced_penalty(model, ci, g, s)
+    end
+
     if _is_nonnegative(g)
         return g
     end
@@ -695,6 +729,12 @@ function constraint(
             context,
             _constraint_message("Infeasible", f, ">=", s.lower),
         )
+    end
+
+    if _is_unbalanced_penalty(model, ci)
+        MOI.set(model, Attributes.Quadratize(), true)
+
+        return _unbalanced_penalty(model, ci, g, s)
     end
 
     if _is_nonpositive(g)

--- a/src/compiler/penalties.jl
+++ b/src/compiler/penalties.jl
@@ -3,6 +3,10 @@ function _uses_linear_equality_penalty(model::Virtual.Model, ci::CI)::Bool
            Attributes.constraint_encoding_method(model, ci) isa Attributes.LinearPenalty
 end
 
+function _uses_unbalanced_penalty(model::Virtual.Model, ci::CI)::Bool
+    return Attributes.constraint_encoding_method(model, ci) isa Attributes.UnbalancedPenalty
+end
+
 function _legacy_penalty_factor(sign, δ, ϵ, scale, offset)
     return scale * sign * (δ / ϵ + offset)
 end
@@ -208,6 +212,12 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
                     model,
                     "LinearPenalty requires an explicit ConstraintEncodingPenaltyHint";
                     status = "Missing linear constraint penalty hint",
+                )
+            elseif _uses_unbalanced_penalty(model, ci)
+                compilation_error!(
+                    model,
+                    "UnbalancedPenalty requires an explicit ConstraintEncodingPenaltyHint";
+                    status = "Missing unbalanced constraint penalty hint",
                 )
             end
 

--- a/test/unit/unbalanced_penalty.jl
+++ b/test/unit/unbalanced_penalty.jl
@@ -1,0 +1,258 @@
+function _issue_207_affine_constraint(set)
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch = ToQUBO.Compiler.GenericArchitecture()
+    x, _ = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 2))
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    f = MOI.ScalarAffineFunction{Float64}(
+        [MOI.ScalarAffineTerm(1.0, x[1]), MOI.ScalarAffineTerm(1.0, x[2])],
+        0.0,
+    )
+    ci = if MOI.supports_constraint(model.source_model, typeof(f), typeof(set))
+        MOI.add_constraint(model.source_model, f, set)
+    else
+        MOI.ConstraintIndex{typeof(f),typeof(set)}(1)
+    end
+
+    return model, arch, x, f, ci
+end
+
+function _issue_207_value(g, x, values)
+    assignment = Dict(xi => value for (xi, value) in zip(x, values))
+
+    return convert(Float64, g(assignment))
+end
+
+function _issue_207_mixed_integer_model(method = nothing)
+    model = ToQUBO.Optimizer{Float64}()
+    x = MOI.add_variable(model)
+    y = MOI.add_variable(model)
+
+    MOI.add_constraint(model, x, MOI.ZeroOne())
+    MOI.add_constraint(model, y, MOI.Integer())
+    MOI.add_constraint(model, y, MOI.Interval{Float64}(0.0, 2.0))
+
+    f = MOI.ScalarAffineFunction{Float64}(
+        [MOI.ScalarAffineTerm(1.0, x), MOI.ScalarAffineTerm(1.0, y)],
+        0.0,
+    )
+    ci = MOI.add_constraint(model, f, MOI.LessThan{Float64}(1.0))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
+    )
+
+    if !isnothing(method)
+        MOI.set(model, Attributes.ConstraintEncodingMethod(), ci, method)
+        MOI.set(model, Attributes.ConstraintEncodingPenaltyHint(), ci, 2.0)
+    end
+
+    MOI.optimize!(model)
+
+    return model, ci
+end
+
+function test_unbalanced_penalty()
+    @testset "Unbalanced inequality penalty" begin
+        @testset "method parameters" begin
+            method = Attributes.UnbalancedPenalty()
+
+            @test method.linear == 1.0
+            @test method.quadratic == 0.5
+            @test Attributes.UnbalancedPenalty(2, 3) == Attributes.UnbalancedPenalty(2, 3)
+            @test_throws ArgumentError Attributes.UnbalancedPenalty(0.0, 0.5)
+            @test_throws ArgumentError Attributes.UnbalancedPenalty(1.0, 0.0)
+        end
+
+        @testset "less-than penalty avoids slack variables" begin
+            set = MOI.LessThan{Float64}(1.0)
+            slack_model, slack_arch, _, slack_f, slack_ci =
+                _issue_207_affine_constraint(set)
+            slack_penalty =
+                ToQUBO.Compiler.constraint(slack_model, slack_ci, slack_f, set, slack_arch)
+
+            model, arch, x, f, ci = _issue_207_affine_constraint(set)
+            MOI.set(
+                model,
+                Attributes.ConstraintEncodingMethod(),
+                ci,
+                Attributes.UnbalancedPenalty(),
+            )
+            penalty = ToQUBO.Compiler.constraint(model, ci, f, set, arch)
+            target = [_target_var(model, xi) for xi in x]
+
+            @test haskey(slack_model.slack, slack_ci)
+            @test length(PBO.variables(slack_penalty)) > length(x)
+            @test !haskey(model.slack, ci)
+            @test Set(PBO.variables(penalty)) == Set(target)
+            @test _issue_207_value(penalty, target, (0, 0)) == -0.5
+            @test _issue_207_value(penalty, target, (1, 0)) == 0.0
+            @test _issue_207_value(penalty, target, (1, 1)) == 1.5
+        end
+
+        @testset "greater-than and interval orientation" begin
+            set = MOI.GreaterThan{Float64}(1.0)
+            model, arch, x, f, ci = _issue_207_affine_constraint(set)
+            MOI.set(
+                model,
+                Attributes.ConstraintEncodingMethod(),
+                ci,
+                Attributes.UnbalancedPenalty(),
+            )
+            penalty = ToQUBO.Compiler.constraint(model, ci, f, set, arch)
+            target = [_target_var(model, xi) for xi in x]
+
+            @test _issue_207_value(penalty, target, (0, 0)) == 1.5
+            @test _issue_207_value(penalty, target, (1, 0)) == 0.0
+            @test _issue_207_value(penalty, target, (1, 1)) == -0.5
+            @test !haskey(model.slack, ci)
+
+            interval = MOI.Interval{Float64}(1.0, 1.0)
+            interval_model, interval_arch, interval_x, interval_f, interval_ci =
+                _issue_207_affine_constraint(interval)
+            MOI.set(
+                interval_model,
+                Attributes.ConstraintEncodingMethod(),
+                interval_ci,
+                Attributes.UnbalancedPenalty(),
+            )
+            interval_penalty = ToQUBO.Compiler.constraint(
+                interval_model,
+                interval_ci,
+                interval_f,
+                interval,
+                interval_arch,
+            )
+            interval_target = [_target_var(interval_model, xi) for xi in interval_x]
+
+            @test _issue_207_value(interval_penalty, interval_target, (0, 0)) == 1.0
+            @test _issue_207_value(interval_penalty, interval_target, (1, 0)) == 0.0
+            @test _issue_207_value(interval_penalty, interval_target, (1, 1)) == 1.0
+            @test !haskey(interval_model.slack, interval_ci)
+        end
+
+        @testset "quadratic inequalities request quadratization" begin
+            model = ToQUBO.Virtual.Model{Float64}()
+            arch = ToQUBO.Compiler.GenericArchitecture()
+            x, _ = MOI.add_constrained_variables(model.source_model, fill(MOI.ZeroOne(), 3))
+
+            ToQUBO.Compiler.variables!(model, arch)
+
+            f = MOI.ScalarQuadraticFunction{Float64}(
+                [MOI.ScalarQuadraticTerm(1.0, x[1], x[2])],
+                [MOI.ScalarAffineTerm(1.0, x[3])],
+                0.0,
+            )
+            set = MOI.LessThan{Float64}(1.0)
+            ci = MOI.add_constraint(model.source_model, f, set)
+            MOI.set(
+                model,
+                Attributes.ConstraintEncodingMethod(),
+                ci,
+                Attributes.UnbalancedPenalty(2.0, 1.0),
+            )
+            penalty = ToQUBO.Compiler.constraint(model, ci, f, set, arch)
+
+            @test !haskey(model.slack, ci)
+            @test MOI.get(model, Attributes.Quadratize()) === true
+            @test any(length(term) > 2 for (term, _) in penalty)
+        end
+
+        @testset "explicit coefficient is required" begin
+            model = ToQUBO.Optimizer{Float64}()
+            x = [MOI.add_variable(model) for _ = 1:2]
+
+            for xi in x
+                MOI.add_constraint(model, xi, MOI.ZeroOne())
+            end
+
+            f = MOI.ScalarAffineFunction{Float64}(
+                [MOI.ScalarAffineTerm(1.0, x[1]), MOI.ScalarAffineTerm(1.0, x[2])],
+                0.0,
+            )
+            ci = MOI.add_constraint(model, f, MOI.LessThan{Float64}(1.0))
+
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+            MOI.set(
+                model,
+                MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+                MOI.ScalarAffineFunction{Float64}(MOI.ScalarAffineTerm{Float64}[], 0.0),
+            )
+            MOI.set(
+                model,
+                Attributes.ConstraintEncodingMethod(),
+                ci,
+                Attributes.UnbalancedPenalty(),
+            )
+
+            @test_throws ToQUBO.Compiler.CompilationError MOI.optimize!(model)
+            @test MOI.get(model, Attributes.CompilationStatus()) == MOI.OTHER_ERROR
+            @test MOI.get(model, MOI.RawStatusString()) ==
+                  "Missing unbalanced constraint penalty hint"
+
+            MOI.set(model, Attributes.ConstraintEncodingPenaltyHint(), ci, 2.0)
+            MOI.optimize!(model)
+
+            @test MOI.get(model, Attributes.CompilationStatus()) == MOI.LOCALLY_SOLVED
+            @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), ci) == 2.0
+        end
+
+        @testset "mixed-integer target variable count" begin
+            slack_model, slack_ci = _issue_207_mixed_integer_model()
+            unbalanced_model, unbalanced_ci =
+                _issue_207_mixed_integer_model(Attributes.UnbalancedPenalty())
+            slack_count =
+                length(MOI.get(slack_model.target_model, MOI.ListOfVariableIndices()))
+            unbalanced_count =
+                length(MOI.get(unbalanced_model.target_model, MOI.ListOfVariableIndices()))
+
+            @test haskey(slack_model.slack, slack_ci)
+            @test !haskey(unbalanced_model.slack, unbalanced_ci)
+            @test unbalanced_count < slack_count
+        end
+
+        @testset "equality constraints reject the method" begin
+            set = MOI.EqualTo{Float64}(1.0)
+            model, arch, _, f, ci = _issue_207_affine_constraint(set)
+            MOI.set(
+                model,
+                Attributes.ConstraintEncodingMethod(),
+                ci,
+                Attributes.UnbalancedPenalty(),
+            )
+
+            @test_throws ToQUBO.Compiler.CompilationError ToQUBO.Compiler.constraint(
+                model,
+                ci,
+                f,
+                set,
+                arch,
+            )
+        end
+
+        @testset "documentation explains the tradeoff" begin
+            root = normpath(joinpath(@__DIR__, "..", ".."))
+            settings = replace(
+                read(joinpath(root, "docs", "src", "manual", "4-settings.md"), String),
+                "\r\n" => "\n",
+            )
+            booklet = replace(
+                read(joinpath(root, "docs", "src", "booklet", "4-encoding.md"), String),
+                "\r\n" => "\n",
+            )
+
+            @test occursin("Attributes.UnbalancedPenalty()", settings)
+            @test occursin("exact zero penalty", settings)
+            @test occursin("target-variable budget", settings)
+            @test occursin("10.1088/2058-9565/ad35e4", settings)
+            @test occursin("K`` auxiliary binary", settings)
+            @test occursin("slack-free", booklet)
+        end
+    end
+
+    return nothing
+end

--- a/test/unit/unit.jl
+++ b/test/unit/unit.jl
@@ -13,6 +13,7 @@ include("qoblib_benchmark.jl")
 include("dense_npp_profile.jl")
 include("slack_resolution_analysis.jl")
 include("slack_resolution_docs.jl")
+include("unbalanced_penalty.jl")
 
 function test_unit()
     @testset "⊚ Unit Tests" verbose = true begin
@@ -31,6 +32,7 @@ function test_unit()
         test_dense_npp_profile_benchmark()
         test_slack_resolution_analysis()
         test_slack_resolution_docs()
+        test_unbalanced_penalty()
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- add `Attributes.UnbalancedPenalty(linear, quadratic)` as a selectable slack-free encoding for scalar `LessThan`, `GreaterThan`, and `Interval` constraints
- generate the correctly oriented linear-plus-quadratic residual without an inequality slack, while retaining quadratization for quadratic source constraints
- require an explicit `ConstraintEncodingPenaltyHint` because the heuristic can change energy ordering among feasible assignments
- document when to prefer target-variable savings over the default zero-penalty slack reformulation
- compare the default and unbalanced encodings on the same mixed-integer constraint and cover penalty orientation, interval behavior, quadratization, validation, and unsupported equalities

## Design choice

For `g(x) <= 0`, the method generates `lambda_1 * g(x) + lambda_2 * g(x)^2`; for `g(x) >= 0`, it negates the linear term. The method follows the QUBO-native unbalanced formulation of Montañez-Barrera et al.

An exact `max(0, g(x))^2` hinge is not generally quadratic. The real-coefficient construction cited in the issue also introduces `K` auxiliary binary variables, so it does not meet the slack-free affine-QUBO goal. The selected formulation preserves the intended qubit-economy scope, with its heuristic energy-ordering tradeoff documented explicitly.

## Verification

- `julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` — 1,780 passed
- `julia +1.10 --project=docs docs/make.jl --skip-deploy` — passed
- `git diff --cached --check` — passed before commit

## Coordination

- #205 is closed as a finite-run sampler-landscape issue and does not determine this encoding design.
- #208/#211/#212 own the continuous-slack resolution evidence and guidance; they explicitly leave slack-free encoding to this issue.
- #209/#210 document the existing constraint reformulations.

## Branch Hygiene

- Base: `main` at `e5b401799b795fe5576d87ba14d7094c0b61e0de`
- Branch: `feat/issue-207-unbalanced-penalty`, created directly from `origin/main`
- Not stacked; no prerequisite PRs and no changed-file overlap with an open PR at creation time

Closes #207
