### PR TITLE
Make compatibility checks Dependabot-safe

### DIFF
--- a/scripts/release_check.jl
+++ b/scripts/release_check.jl
@@ -25,6 +25,8 @@ function read_toml(parts...)
     return TOML.parsefile(project_file(parts...))
 end
 
+compat_entries(value::AbstractString) = Set(strip.(split(value, ',')))
+
 function release_section(news::String, version::VersionNumber)
     heading = "## v$(version) - "
     lines = split(news, '\n')
@@ -76,8 +78,11 @@ function main()
     )
     check!(
         failures,
-        get(test_compat, "QUBOTools", nothing) == project_compat["QUBOTools"],
-        "test/Project.toml QUBOTools compat must match Project.toml.",
+        issubset(
+            compat_entries(test_compat["QUBOTools"]),
+            compat_entries(project_compat["QUBOTools"]),
+        ),
+        "test/Project.toml QUBOTools compat must be supported by Project.toml.",
     )
 
     news = read(project_file("NEWS.md"), String)

--- a/test/unit/compat.jl
+++ b/test/unit/compat.jl
@@ -6,6 +6,8 @@ function _release_line_compat(version::VersionNumber)
     return string(version.major)
 end
 
+_compat_entries(value::AbstractString) = strip.(split(value, ','))
+
 function test_compat()
     @testset "Compatibility and CI" begin
         root = normpath(joinpath(@__DIR__, "..", ".."))
@@ -19,18 +21,18 @@ function test_compat()
         @test compat["julia"] == "1.10"
         @test occursin(r"(^|,\s*)0\.2\.6(\s*(,|$))", compat["PseudoBooleanOptimization"])
         @test occursin(r"(^|,\s*)0\.3(\s*(,|$))", compat["PseudoBooleanOptimization"])
-        @test compat["QUBOTools"] == "0.16"
+        @test "0.16" in _compat_entries(compat["QUBOTools"])
         @test !haskey(compat, "SparseArrays")
         @test !haskey(project["deps"], "SparseArrays")
         @test !haskey(docs_project["deps"], "PySA")
         @test !haskey(docs_compat, "PySA")
         @test occursin(r"(^|,\s*)0\.4(\s*(,|$))", docs_compat["QUBODrivers"])
         @test occursin(r"(^|,\s*)0\.6(\s*(,|$))", docs_compat["QUBODrivers"])
-        @test docs_compat["QUBOTools"] == "0.16"
+        @test "0.16" in _compat_entries(docs_compat["QUBOTools"])
         @test docs_compat["ToQUBO"] == _release_line_compat(VersionNumber(project["version"]))
         @test occursin(r"(^|,\s*)0\.2\.6(\s*(,|$))", test_compat["PseudoBooleanOptimization"])
         @test occursin(r"(^|,\s*)0\.3(\s*(,|$))", test_compat["PseudoBooleanOptimization"])
-        @test test_compat["QUBOTools"] == "0.16"
+        @test "0.16" in _compat_entries(test_compat["QUBOTools"])
 
         ci = replace(
             read(joinpath(root, ".github", "workflows", "ci.yml"), String),


### PR DESCRIPTION
Summary
- Preserve the required QUBOTools support line in the root, docs, and test environments without requiring exact serialization.
- Let the test environment remain a supported subset of the root project during directory-scoped Dependabot updates.

Tests
- Compatibility and CI testset: 23 passed on Julia 1.12
- julia +release --startup-file=no scripts/release_check.jl
- git diff --check