### PR TITLE
ci: collect coverage on one matrix job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,19 @@ jobs:
           - version: '1.10'
             os: ubuntu-latest
             arch: x64
+            coverage: false
           - version: '1.10'
             os: windows-latest
             arch: x64
+            coverage: false
           - version: '1'
             os: ubuntu-latest
             arch: x64
+            coverage: true
           - version: '1'
             os: windows-latest
             arch: x64
+            coverage: false
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
@@ -34,7 +38,11 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: ${{ matrix.coverage }}
       - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.coverage
       - uses: codecov/codecov-action@v7
+        if: matrix.coverage
         with:
           files: lcov.info


### PR DESCRIPTION
## Summary

- make Julia current/Ubuntu the single coverage producer
- disable coverage instrumentation, processing, and upload on the other three matrix jobs
- retain the complete unit and integration suite on all four Julia/OS combinations

## Validation

- `actionlint`
- `git diff --check`
- full Julia 1.10/current × Ubuntu/Windows CI matrix (post-push)

## Measurement

Issue #215 recorded 20.2 aggregate runner-minutes with four coverage reports/uploads for each commit.

- attempt 1: 29.4 aggregate runner-minutes; longest job 8m41s
- warm rerun: 22.6 aggregate runner-minutes; longest job 8m14s
- Julia current/Ubuntu logged `coverage=true` and ran processing/upload; a sampled noncanonical job logged `coverage=false`, and all three noncanonical processing/upload steps were skipped

These two runs were slower than the audited baseline despite the policy change, which indicates runner/test variance dominates this small sample. The deterministic improvement is eliminating three redundant coverage pipelines per run while retaining all four full test jobs. The canonical Codecov action remained green but reported the repository's existing tokenless-upload rejection in its log.

## Branch Hygiene

- Base: `main` at `5455f4c2538fa5b2999c43770143a9153cdc615a`
- Not stacked; open PR #214 changes release and compatibility tests, not the workflow changed here.

Closes #215
