### PR TITLE
Release v0.6.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,35 @@
 # Release Notes
 
+## v0.6.1 - 2026-07-21
+
+### Breaking changes
+
+- No breaking changes.
+
+### Added
+
+- Add `Attributes.UnbalancedPenalty(linear, quadratic)` as an opt-in, slack-free encoding for scalar `LessThan`, `GreaterThan`, and `Interval` constraints. The method preserves quadratization for quadratic source constraints and requires an explicit `ConstraintEncodingPenaltyHint` because it can change the energy ordering of feasible assignments.
+
+### Documentation
+
+- Explain scalar equality, inequality, interval, sign-definite, and quadratization reformulations, including when generated slack variables are introduced.
+- Clarify bounded continuous-variable bit inference, Neal finite-run penalty tuning, and the distinction between integral and continuous slack encodings.
+- Document the continuous-slack residual floor and the penalty-contrast condition required to separate feasible and infeasible assignments.
+
+### Analysis
+
+- Add reproducible dense NPP-like profiling that separates JuMP model construction, compilation, and backend extraction costs.
+- Add an executable slack-resolution analysis and generated report covering grid spacing, feasible residual floors, penalty contrast, and seeded sampler behavior.
+
+### Maintenance
+
+- Standardize CI caching and dependency-maintenance configuration, limit coverage processing to one canonical matrix job, and retain the complete Julia 1.10/current × Ubuntu/Windows test matrix.
+- Make compatibility and release checks robust to supported Dependabot range expansions.
+
+### Tests
+
+- Cover unbalanced-penalty orientation, interval behavior, quadratization, validation, unsupported equalities, and the new documentation and analysis contracts.
+
 ## v0.6.0 - 2026-06-25
 
 ### Breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name    = "ToQUBO"
 uuid    = "9a412ddf-83fa-43b6-9748-7843c851aa65"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "bernalde <dbernalneira@usra.edu>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 MathOptInterface          = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"


### PR DESCRIPTION
## Summary

Release ToQUBO v0.6.1 with the backward-compatible `UnbalancedPenalty` constraint encoding, expanded reformulation and slack-resolution guidance, reproducible performance analyses, and CI/release-maintenance improvements.

## Release metadata

- bump `Project.toml` from v0.6.0 to v0.6.1
- add the dated v0.6.1 section to `NEWS.md`
- keep docs self-compat at `ToQUBO = "0.6"`, which is correct for this patch release

## Breaking changes

None.

## Validation

- `julia +1.10 --project=. scripts/release_check.jl`
- `julia +1.10 --project=. -e 'import Pkg; Pkg.test()'` — 1,780/1,780 passed
- `julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(path=pwd())'`
- `julia +1.10 --project=docs docs/make.jl --skip-deploy`

After this PR merges and the exact merge commit is green on `main`, I will invoke Registrator for v0.6.1 and verify registry and package-server propagation.
