### PR TITLE
Update QUBO.jl references for published journal article

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
     <a href="https://arxiv.org/abs/2307.02577">
         <img src="https://img.shields.io/badge/arXiv-2307.02577-b31b1b.svg" alt="arXiv"/>
     </a>
+    <a href="https://doi.org/10.1080/10556788.2026.2702926">
+        <img src="https://img.shields.io/badge/DOI-10.1080%2F10556788.2026.2702926-blue.svg" alt="Journal article DOI"/>
+    </a>
     <a href="https://codecov.io/gh/JuliaQUBO/ToQUBO.jl">
         <img src="https://codecov.io/gh/JuliaQUBO/ToQUBO.jl/branch/main/graph/badge.svg" alt="Coverage"/>
     </a>

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -73,17 +73,18 @@ If you use `ToQUBO.jl` in your work, we kindly ask you to include the following 
 }
 ```
 
-For the broader `QUBO.jl` ecosystem paper, cite the current preprint:
+For the broader `QUBO.jl` ecosystem paper, cite the published journal article:
 
 ```tex
-@misc{xavier2023qubojl,
+@article{xavier2026qubojl,
   author       = {Pedro Maciel Xavier and Pedro Ripper and Tiago Andrade and Joaquim Dias Garcia and Nelson Maculan and David E. Bernal Neira},
   title        = {{QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}},
-  year         = {2023},
-  eprint       = {2307.02577},
-  archivePrefix = {arXiv},
-  primaryClass = {math.OC},
-  doi          = {10.48550/arXiv.2307.02577},
-  url          = {https://arxiv.org/abs/2307.02577}
+  journal      = {Optimization Methods and Software},
+  year         = {2026},
+  pages        = {1--24},
+  doi          = {10.1080/10556788.2026.2702926},
+  url          = {https://doi.org/10.1080/10556788.2026.2702926}
 }
 ```
+
+The [arXiv preprint](https://arxiv.org/abs/2307.02577) remains available.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -77,7 +77,7 @@ For the broader `QUBO.jl` ecosystem paper, cite the published journal article:
 
 ```tex
 @article{xavier2026qubojl,
-  author       = {Pedro Maciel Xavier and Pedro Ripper and Tiago Andrade and Joaquim Dias Garcia and Nelson Maculan and David E. Bernal Neira},
+  author       = {Maciel Xavier, Pedro and Ripper, Pedro and Andrade, Tiago and Dias Garcia, Joaquim and Maculan, Nelson and Bernal Neira, David E.},
   title        = {{QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}},
   journal      = {Optimization Methods and Software},
   year         = {2026},


### PR DESCRIPTION
## Summary

- add a published-article DOI badge beside the existing arXiv badge in the README
- replace the ecosystem paper's preprint-only BibTeX entry with the published *Optimization Methods and Software* article
- retain an explicit link to the arXiv preprint

Closes #218

## Acceptance criteria

- [x] The README points to the published article.
- [x] The documentation cites the published journal article and DOI.
- [x] The arXiv preprint remains explicitly available.

## Testing

- `julia --project=docs docs/make.jl --skip-deploy`
- `julia --project -e 'using Pkg; Pkg.test()'` (1,780 passed)
- verified the arXiv and DOI badge URLs resolve; verified the journal DOI against Crossref metadata
- `git diff --check`

## Branch Hygiene

- Base branch: `main`
- Source branch point: `9feda34c0fb10a5ed8539dd4add915aa4ff9006c`
- Stacked: no
- Prerequisite PRs: none
- Open-PR overlap: none
