### PR TITLE
Add literature penalty-weight heuristics (UB-positive, max-coefficient, VLM, MOMC, MOC)

### DIFF
--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -115,11 +115,51 @@ positive for minimization models and negative for maximization models, so
 explicit hints should use the same sign as the coefficient you want the
 compiler to apply.
 
+### Literature Penalty Heuristics
+
+Besides the exactness-oriented default, ToQUBO offers the static
+penalty-weight heuristics evaluated by Ayodele
+([arXiv:2206.11040](https://arxiv.org/abs/2206.11040)), selectable through
+[`ToQUBO.Attributes.PenaltyPolicy`](@ref). They typically produce smaller,
+sampler-friendlier coefficients than the certified bound, at the price of not
+guaranteeing exactness. Each computes a bound `λ` on the compiled
+pseudo-Boolean objective and applies it with the same composition as the
+default policy, ``\rho = s \sigma (\lambda + \beta) / \epsilon``:
+
+| Policy | `λ` | Scope |
+|:--|:--|:--|
+| [`ToQUBO.Attributes.UBPositivePenalty`](@ref) | Sum of all non-constant objective coefficients (requires them nonnegative) | global |
+| [`ToQUBO.Attributes.MaxCoefficientPenalty`](@ref) | Largest non-constant objective coefficient | global |
+| [`ToQUBO.Attributes.VLMPenalty`](@ref) | Largest one-flip objective change (Verma–Lewis) | global |
+| [`ToQUBO.Attributes.MOMCPenalty`](@ref) | `max(1, VLM / γ)`, `γ` the smallest positive one-flip change of the penalty function | per penalty function |
+| [`ToQUBO.Attributes.MOCPenalty`](@ref) | `max(1, max abs one-flip objective/penalty ratio)` | per penalty function |
+
+The per-penalty-function policies (MOMC, MOC) infer one coefficient per
+constraint, variable-encoding, and slack-encoding penalty, so different
+constraints receive different weights. One-flip changes generalize the
+quadratic row-sum form of the reference to arbitrary degree by crediting each
+monomial to every variable it contains. When a policy's validity conditions do
+not hold (for example, a negative objective coefficient under
+`UBPositivePenalty`, or a penalty function without a positive one-flip
+change), ToQUBO falls back to [`ToQUBO.Attributes.LegacyPenalty`](@ref) for
+that coefficient and records the reason in
+[`ToQUBO.Attributes.PenaltyPolicyMetadata`](@ref).
+
+```@docs
+ToQUBO.Attributes.UBPositivePenalty
+ToQUBO.Attributes.MaxCoefficientPenalty
+ToQUBO.Attributes.VLMPenalty
+ToQUBO.Attributes.MOMCPenalty
+ToQUBO.Attributes.MOCPenalty
+```
+
 Use the controls according to how much of the model you want to change:
 
 - Use [`ToQUBO.Attributes.PenaltyPolicy`](@ref) to select the automatic
-  inference policy. Set it to [`ToQUBO.Attributes.LegacyPenalty`](@ref) only
-  when you need to reproduce the historical maxgap-based coefficients.
+  inference policy. Choose a literature heuristic above when the certified
+  bound is too conservative for your sampler, or set it to
+  [`ToQUBO.Attributes.LegacyPenalty`](@ref) only when you need to reproduce
+  the historical maxgap-based coefficients.
 - Use [`ToQUBO.Attributes.PenaltyScale`](@ref) and
   [`ToQUBO.Attributes.PenaltyOffset`](@ref) to change all automatically
   inferred penalties while preserving their policy-dependent objective and

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -177,7 +177,9 @@ struct LegacyPenalty <: AutomaticPenaltyPolicy end
 
 Upper-bound heuristic for objectives with nonnegative coefficients (UB,
 Ayodele 2022, Eq. 12): the penalty magnitude is the sum of every non-constant
-objective coefficient, i.e. the objective value at the all-ones point. If any
+objective coefficient, i.e. the non-constant contribution to the objective
+value at the all-ones point (a constant offset does not affect the bound,
+matching Eq. 12's QUBO-matrix formulation). If any
 non-constant coefficient is negative the bound is invalid and ToQUBO falls
 back to [`LegacyPenalty`](@ref) for that coefficient, recording the reason in
 reformulation metadata.

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -172,6 +172,101 @@ be certified.
 """
 struct LegacyPenalty <: AutomaticPenaltyPolicy end
 
+@doc raw"""
+    UBPositivePenalty()
+
+Upper-bound heuristic for objectives with nonnegative coefficients (UB,
+Ayodele 2022, Eq. 12): the penalty magnitude is the sum of every non-constant
+objective coefficient, i.e. the objective value at the all-ones point. If any
+non-constant coefficient is negative the bound is invalid and ToQUBO falls
+back to [`LegacyPenalty`](@ref) for that coefficient, recording the reason in
+reformulation metadata.
+
+Applied as ``\rho = s \sigma (\lambda + \beta) / \epsilon`` like every
+automatic policy, where ``s`` is the penalty scale, ``\sigma`` the sense sign,
+``\beta`` the penalty offset, and ``\epsilon`` the penalty function's positive
+gap.
+
+Reference: M. Ayodele, *Penalty Weights in QUBO Formulations: Permutation
+Problems* (EvoCOP 2022), [arXiv:2206.11040](https://arxiv.org/abs/2206.11040).
+"""
+struct UBPositivePenalty <: AutomaticPenaltyPolicy end
+
+@doc raw"""
+    MaxCoefficientPenalty()
+
+Maximum QUBO coefficient heuristic (MQC, Ayodele 2022, Eq. 13; after Lucas
+2014): the penalty magnitude is the largest non-constant objective
+coefficient. Falls back to [`LegacyPenalty`](@ref) when the objective has no
+non-constant term or its maximum coefficient is not strictly positive.
+
+References: M. Ayodele, [arXiv:2206.11040](https://arxiv.org/abs/2206.11040);
+A. Lucas, *Ising formulations of many NP problems*, Front. Phys. 2:5 (2014).
+"""
+struct MaxCoefficientPenalty <: AutomaticPenaltyPolicy end
+
+@doc raw"""
+    VLMPenalty()
+
+Verma–Lewis method (VLM, Verma & Lewis 2022; Ayodele 2022, Eqs. 14–15): the
+penalty magnitude is the largest possible one-flip change of the objective,
+``\lambda = \max_i \max(W^+_i, W^-_i)``, where for each variable ``i``
+
+```math
+W^+_i = c_{\{i\}} + \sum_{T \ni i,\, |T| \ge 2} \max(c_T, 0), \qquad
+W^-_i = -c_{\{i\}} - \sum_{T \ni i,\, |T| \ge 2} \min(c_T, 0),
+```
+
+with each monomial of the compiled pseudo-Boolean objective credited to every
+variable it contains (the degree-``\ge 2`` generalization of the quadratic
+row-sum form). Falls back to [`LegacyPenalty`](@ref) when the bound is not
+finite and strictly positive.
+
+References: A. Verma and M. Lewis, *Penalty and partitioning techniques to
+improve performance of QUBO solvers*, Discrete Optimization 44 (2022),
+[doi:10.1016/j.disopt.2020.100594](https://doi.org/10.1016/j.disopt.2020.100594);
+M. Ayodele, [arXiv:2206.11040](https://arxiv.org/abs/2206.11040).
+"""
+struct VLMPenalty <: AutomaticPenaltyPolicy end
+
+@doc raw"""
+    MOMCPenalty()
+
+Maximum change in objective over minimum change in constraint (MOMC, Ayodele
+2022, Eqs. 16–18), computed **per penalty function**: with ``\lambda_{VLM}``
+the [`VLMPenalty`](@ref) bound of the objective and ``\gamma`` the smallest
+*strictly positive* one-flip change of this coefficient's penalty function,
+the penalty magnitude is ``\lambda = \max(1, \lambda_{VLM} / \gamma)``. Falls
+back to [`LegacyPenalty`](@ref) when the objective bound is not finite and
+positive or the penalty function has no positive one-flip change.
+
+Unlike the aggregated single-matrix form of the reference, ToQUBO computes one
+coefficient per constraint, variable-encoding, and slack-encoding penalty
+function.
+
+Reference: M. Ayodele, [arXiv:2206.11040](https://arxiv.org/abs/2206.11040).
+"""
+struct MOMCPenalty <: AutomaticPenaltyPolicy end
+
+@doc raw"""
+    MOCPenalty()
+
+Maximum objective-to-constraint ratio (MOC, Ayodele 2022, Eq. 19), computed
+**per penalty function**: pairing the one-flip changes of the objective
+(``W^{c,\pm}_i``) with those of this coefficient's penalty function
+(``W^{g,\pm}_i``) per variable and flip direction, the penalty magnitude is
+
+```math
+\lambda = \max\left(1, \max_{i,\, W^{g}_i > 0} \left| W^{c}_i / W^{g}_i \right| \right).
+```
+
+Falls back to [`LegacyPenalty`](@ref) when the penalty function has no
+strictly positive one-flip change or the objective bound is not finite.
+
+Reference: M. Ayodele, [arXiv:2206.11040](https://arxiv.org/abs/2206.11040).
+"""
+struct MOCPenalty <: AutomaticPenaltyPolicy end
+
 function MOIU.map_indices(::Function, policy::AutomaticPenaltyPolicy)
     return policy
 end

--- a/src/compiler/penalties.jl
+++ b/src/compiler/penalties.jl
@@ -65,6 +65,175 @@ function _objective_range_penalty_factor(
     return scale * sign * ((range + offset) / ϵ)
 end
 
+# One-flip change bounds of a pseudo-Boolean function (Ayodele 2022,
+# arXiv:2206.11040, Eq. 14 generalized to arbitrary degree): every monomial is
+# credited to each variable it contains, so `increase[v]`/`decrease[v]` bound
+# the objective gain/loss of flipping `v` with all other variables free.
+function _flip_values(f::PBO.PBF{VI,T}) where {T}
+    increase = Dict{VI,T}()
+    decrease = Dict{VI,T}()
+
+    for (ω, c) in f
+        isempty(ω) && continue
+
+        if length(ω) == 1
+            v = first(ω)
+            increase[v] = get(increase, v, zero(T)) + c
+            decrease[v] = get(decrease, v, zero(T)) - c
+        else
+            for v in ω
+                if c > zero(T)
+                    increase[v] = get(increase, v, zero(T)) + c
+                else
+                    decrease[v] = get(decrease, v, zero(T)) - c
+                end
+            end
+        end
+    end
+
+    return increase, decrease
+end
+
+function _min_positive_flip(p::PBO.PBF{VI,T}) where {T}
+    increase, decrease = _flip_values(p)
+    γ = typemax(T)
+
+    for w in Iterators.flatten((values(increase), values(decrease)))
+        if w > zero(T)
+            γ = min(γ, w)
+        end
+    end
+
+    return γ
+end
+
+function _objective_penalty_scan(f::PBO.PBF{VI,T}) where {T}
+    coefficient_sum = zero(T)
+    has_negative = false
+    max_coefficient = typemin(T)
+    term_count = 0
+
+    for (ω, c) in f
+        isempty(ω) && continue
+
+        term_count += 1
+        coefficient_sum += c
+        has_negative |= c < zero(T)
+        max_coefficient = max(max_coefficient, c)
+    end
+
+    increase, decrease = _flip_values(f)
+    vlm = typemin(T)
+
+    for w in Iterators.flatten((values(increase), values(decrease)))
+        vlm = max(vlm, w)
+    end
+
+    return (; coefficient_sum, has_negative, max_coefficient, term_count, increase, decrease, vlm)
+end
+
+const _HEURISTIC_PENALTY_POLICIES = Union{
+    Attributes.UBPositivePenalty,
+    Attributes.MaxCoefficientPenalty,
+    Attributes.VLMPenalty,
+    Attributes.MOMCPenalty,
+    Attributes.MOCPenalty,
+}
+
+# Returns `(λ, nothing)` on success or `(nothing, reason)` when the policy's
+# validity conditions do not hold and the coefficient must fall back.
+function _heuristic_penalty_bound(
+    ::Attributes.UBPositivePenalty,
+    scan,
+    ::PBO.PBF{VI,T},
+) where {T}
+    scan.term_count > 0 ||
+        return nothing, "UBPositivePenalty requires a non-constant objective"
+    !scan.has_negative ||
+        return nothing, "UBPositivePenalty requires nonnegative objective coefficients"
+    isfinite(scan.coefficient_sum) ||
+        return nothing, "Objective coefficient sum is not finite"
+
+    return scan.coefficient_sum, nothing
+end
+
+function _heuristic_penalty_bound(
+    ::Attributes.MaxCoefficientPenalty,
+    scan,
+    ::PBO.PBF{VI,T},
+) where {T}
+    scan.term_count > 0 ||
+        return nothing, "MaxCoefficientPenalty requires a non-constant objective"
+    (isfinite(scan.max_coefficient) && scan.max_coefficient > zero(T)) ||
+        return nothing, "Maximum objective coefficient is not strictly positive"
+
+    return scan.max_coefficient, nothing
+end
+
+function _heuristic_penalty_bound(
+    ::Attributes.VLMPenalty,
+    scan,
+    ::PBO.PBF{VI,T},
+) where {T}
+    (isfinite(scan.vlm) && scan.vlm > zero(T)) ||
+        return nothing, "Objective one-flip bound is not strictly positive"
+
+    return scan.vlm, nothing
+end
+
+function _heuristic_penalty_bound(
+    ::Attributes.MOMCPenalty,
+    scan,
+    p::PBO.PBF{VI,T},
+) where {T}
+    (isfinite(scan.vlm) && scan.vlm > zero(T)) ||
+        return nothing, "Objective one-flip bound is not strictly positive"
+
+    γ = _min_positive_flip(p)
+
+    γ < typemax(T) ||
+        return nothing, "Penalty function has no strictly positive one-flip change"
+
+    return max(one(T), scan.vlm / γ), nothing
+end
+
+function _heuristic_penalty_bound(
+    ::Attributes.MOCPenalty,
+    scan,
+    p::PBO.PBF{VI,T},
+) where {T}
+    increase, decrease = _flip_values(p)
+    ratio = zero(T)
+    positive = false
+
+    for (v, w) in increase
+        if w > zero(T)
+            positive = true
+            ratio = max(ratio, abs(get(scan.increase, v, zero(T)) / w))
+        end
+    end
+
+    for (v, w) in decrease
+        if w > zero(T)
+            positive = true
+            ratio = max(ratio, abs(get(scan.decrease, v, zero(T)) / w))
+        end
+    end
+
+    positive ||
+        return nothing, "Penalty function has no strictly positive one-flip change"
+    isfinite(ratio) ||
+        return nothing, "Objective-to-constraint flip ratio is not finite"
+
+    return max(one(T), ratio), nothing
+end
+
+# Same composition as the objective-range policy: the heuristic bound plays
+# the role of the certified objective range.
+function _heuristic_penalty_factor(sign, λ, ϵ, scale, offset)
+    return scale * sign * ((λ + offset) / ϵ)
+end
+
 function _is_integer_valued(p::PBO.PBF)
     for (_ω, coefficient) in p
         isinteger(coefficient) || return false
@@ -84,8 +253,10 @@ end
 function _inferred_penalty_factor(
     model::Virtual.Model,
     context::AbstractDict,
+    scan,
     sign,
     δ,
+    p::PBO.PBF,
     ϵ,
     scale,
     offset,
@@ -96,6 +267,22 @@ function _inferred_penalty_factor(
 
     if policy isa Attributes.LegacyPenalty
         return _legacy_penalty_factor(sign, δ, ϵ, scale, offset)
+    end
+
+    if policy isa _HEURISTIC_PENALTY_POLICIES
+        if !(isfinite(ϵ) && ϵ > zero(ϵ))
+            _fallback!(context, kind, id, "Penalty function positive gap is not finite")
+            return _legacy_penalty_factor(sign, δ, ϵ, scale, offset)
+        end
+
+        λ, reason = _heuristic_penalty_bound(policy, scan, p)
+
+        if isnothing(λ)
+            _fallback!(context, kind, id, reason)
+            return _legacy_penalty_factor(sign, δ, ϵ, scale, offset)
+        end
+
+        return _heuristic_penalty_factor(sign, λ, ϵ, scale, offset)
     end
 
     objective_bounds = context["objective_bounds"]
@@ -168,6 +355,7 @@ end
 function _infer_and_record_penalty_factor(
     model::Virtual.Model,
     context::AbstractDict,
+    scan,
     sign,
     δ,
     p::PBO.PBF,
@@ -181,8 +369,10 @@ function _infer_and_record_penalty_factor(
     ρ = _inferred_penalty_factor(
         model,
         context,
+        scan,
         sign,
         δ,
+        p,
         ϵ,
         scale,
         offset,
@@ -201,6 +391,7 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
     σ = MOI.get(model, MOI.ObjectiveSense()) === MOI.MAX_SENSE ? -1 : 1
 
     δ = PBO.maxgap(model.f)
+    scan = _objective_penalty_scan(model.f)
     context = _penalty_context(model)
 
     for (ci, g) in model.g
@@ -226,6 +417,7 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
             ρ = _infer_and_record_penalty_factor(
                 model,
                 context,
+                scan,
                 σ,
                 δ,
                 g,
@@ -248,6 +440,7 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
             θ = _infer_and_record_penalty_factor(
                 model,
                 context,
+                scan,
                 σ,
                 δ,
                 h,
@@ -270,6 +463,7 @@ function penalties!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
             η = _infer_and_record_penalty_factor(
                 model,
                 context,
+                scan,
                 σ,
                 δ,
                 s,

--- a/test/unit/compiler/penalties.jl
+++ b/test/unit/compiler/penalties.jl
@@ -342,6 +342,188 @@ function test_compiler_slack_variable_encoding_penalty_is_constraint_keyed()
     return nothing
 end
 
+# MAX 3x₁ + x₂ subject to x₁ + x₂ ≤ 1 and 2x₁ + 2x₂ ≤ 3: the two constraint
+# penalty functions have different one-flip structure, so the per-penalty
+# policies (MOMC/MOC) must infer distinct coefficients.
+function _two_constraint_heuristic_model(policy)
+    model = ToQUBO.Optimizer{Float64}()
+    x = [MOI.add_variable(model) for _ = 1:2]
+
+    for xi in x
+        MOI.add_constraint(model, xi, MOI.ZeroOne())
+    end
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(3.0, x[1]),
+                MOI.ScalarAffineTerm{Float64}(1.0, x[2]),
+            ],
+            0.0,
+        ),
+    )
+
+    c1 = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(1.0, x[1]),
+                MOI.ScalarAffineTerm{Float64}(1.0, x[2]),
+            ],
+            0.0,
+        ),
+        MOI.LessThan{Float64}(1.0),
+    )
+    c2 = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(2.0, x[1]),
+                MOI.ScalarAffineTerm{Float64}(2.0, x[2]),
+            ],
+            0.0,
+        ),
+        MOI.LessThan{Float64}(3.0),
+    )
+
+    MOI.set(model, Attributes.PenaltyPolicy(), policy)
+
+    MOI.optimize!(model)
+
+    return model, c1, c2
+end
+
+function test_compiler_penalty_heuristic_policies()
+    # MAX x₁ + x₂ s.t. x₁ + x₂ ≤ 1: objective coefficient sum 2, maximum
+    # coefficient 1, one-flip bound (VLM) 1; the slack-augmented penalty
+    # (x₁ + x₂ + s - 1)² has smallest positive one-flip change γ = 1. With
+    # σ = -1, scale = 1, offset = 1, ϵ = 1: ρ = -(λ + 1).
+    expected = [
+        (Attributes.UBPositivePenalty(), -3.0),
+        (Attributes.MaxCoefficientPenalty(), -2.0),
+        (Attributes.VLMPenalty(), -2.0),
+        (Attributes.MOMCPenalty(), -2.0),
+        (Attributes.MOCPenalty(), -2.0),
+    ]
+
+    for (policy, ρ) in expected
+        model, c = _constraint_penalty_test_model(; policy)
+        metadata = MOI.get(model, Attributes.PenaltyPolicyMetadata())
+        inferred = only(metadata["inferred_penalties"]["constraints"])
+        name = string(nameof(typeof(policy)))
+
+        @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), c) == ρ
+        @test metadata["policy"] == name
+        @test metadata["fallback_count"] == 0
+        @test inferred["selected_policy"] == name
+        @test inferred["penalty"] == ρ
+    end
+
+    return nothing
+end
+
+function test_compiler_penalty_per_constraint_heuristics()
+    # Objective one-flip bound is 3 (from 3x₁). First constraint's penalty
+    # has γ = 1, the second's γ = 5 (slack bits 1 and 2 over range [0, 3]),
+    # so MOMC gives max(1, 3/1) = 3 and max(1, 3/5) = 1. MOC's largest
+    # absolute flip ratio is 3 (x₁ decrease pair 3/1) for the first
+    # constraint and 3/8 < 1 for the second.
+    for policy in (Attributes.MOMCPenalty(), Attributes.MOCPenalty())
+        model, c1, c2 = _two_constraint_heuristic_model(policy)
+        metadata = MOI.get(model, Attributes.PenaltyPolicyMetadata())
+
+        @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), c1) == -4.0
+        @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), c2) == -2.0
+        @test metadata["fallback_count"] == 0
+        @test length(metadata["inferred_penalties"]["constraints"]) == 2
+    end
+
+    return nothing
+end
+
+function test_compiler_penalty_heuristic_fallbacks()
+    # A negative objective coefficient invalidates the UB-positive bound; the
+    # coefficient falls back to LegacyPenalty (δ = maxgap = 2, ϵ = 1, β = 1).
+    model = ToQUBO.Optimizer{Float64}()
+    x = [MOI.add_variable(model) for _ = 1:2]
+
+    for xi in x
+        MOI.add_constraint(model, xi, MOI.ZeroOne())
+    end
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(1.0, x[1]),
+                MOI.ScalarAffineTerm{Float64}(-1.0, x[2]),
+            ],
+            0.0,
+        ),
+    )
+
+    c = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(1.0, x[1]),
+                MOI.ScalarAffineTerm{Float64}(1.0, x[2]),
+            ],
+            0.0,
+        ),
+        MOI.LessThan{Float64}(1.0),
+    )
+
+    MOI.set(model, Attributes.PenaltyPolicy(), Attributes.UBPositivePenalty())
+    MOI.optimize!(model)
+
+    metadata = MOI.get(model, Attributes.PenaltyPolicyMetadata())
+    fallback = only(metadata["fallbacks"])
+    inferred = only(metadata["inferred_penalties"]["constraints"])
+
+    @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), c) == -3.0
+    @test fallback["reason"] == "UBPositivePenalty requires nonnegative objective coefficients"
+    @test inferred["selected_policy"] == "LegacyPenalty"
+
+    # An empty (feasibility-style) objective invalidates the global bounds:
+    # MaxCoefficient and VLM fall back (δ = 0 → θ = 1), while MOC hits its
+    # literature floor λ = 1 without falling back (θ = (1 + 1)/1 = 2, positive
+    # since the model minimizes).
+    for (policy, θ, reason) in (
+        (
+            Attributes.MaxCoefficientPenalty(),
+            1.0,
+            "MaxCoefficientPenalty requires a non-constant objective",
+        ),
+        (
+            Attributes.VLMPenalty(),
+            1.0,
+            "Objective one-flip bound is not strictly positive",
+        ),
+        (Attributes.MOMCPenalty(), 1.0, "Objective one-flip bound is not strictly positive"),
+    )
+        var_model, xv = _variable_penalty_test_model(; policy)
+        var_metadata = MOI.get(var_model, Attributes.PenaltyPolicyMetadata())
+        var_fallback = only(var_metadata["fallbacks"])
+
+        @test MOI.get(var_model, Attributes.VariableEncodingPenalty(), xv) == θ
+        @test var_fallback["reason"] == reason
+    end
+
+    moc_model, xv = _variable_penalty_test_model(; policy = Attributes.MOCPenalty())
+    moc_metadata = MOI.get(moc_model, Attributes.PenaltyPolicyMetadata())
+
+    @test MOI.get(moc_model, Attributes.VariableEncodingPenalty(), xv) == 2.0
+    @test moc_metadata["fallback_count"] == 0
+
+    return nothing
+end
+
 function test_compiler_penalties()
     @testset "Penalty inference" begin
         test_compiler_penalty_default_policy()
@@ -351,6 +533,9 @@ function test_compiler_penalties()
         test_compiler_penalty_scale_and_offset()
         test_compiler_applied_penalty_metadata()
         test_compiler_slack_variable_encoding_penalty_is_constraint_keyed()
+        test_compiler_penalty_heuristic_policies()
+        test_compiler_penalty_per_constraint_heuristics()
+        test_compiler_penalty_heuristic_fallbacks()
     end
 
     return nothing

--- a/test/unit/compiler/penalties.jl
+++ b/test/unit/compiler/penalties.jl
@@ -80,10 +80,11 @@ function _variable_penalty_test_model(; scale = nothing, offset = nothing, polic
     return model, x
 end
 
-function _fractional_gap_penalty_test_model()
+function _fractional_gap_penalty_test_model(; policy = nothing)
     model = ToQUBO.Optimizer{Float64}()
     x = MOI.add_variable(model)
 
+    !isnothing(policy) && MOI.set(model, Attributes.PenaltyPolicy(), policy)
     MOI.set(model, Attributes.Discretize(), false)
     MOI.add_constraint(model, x, MOI.ZeroOne())
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
@@ -524,6 +525,47 @@ function test_compiler_penalty_heuristic_fallbacks()
     return nothing
 end
 
+function test_compiler_penalty_heuristic_slack_bucket()
+    # With a one-hot slack encoding, the slack-encoding penalty χ (one-hot
+    # exactly-one gadget) has smallest positive one-flip change γ = 1, and the
+    # objective one-flip bound is 1, so MOMC infers η = -(1 + 1)/1 = -2.0 for
+    # the slack bucket as well.
+    model, c = _constraint_penalty_test_model(;
+        slack_encoding = Encoding.OneHot(),
+        policy = Attributes.MOMCPenalty(),
+    )
+    metadata = MOI.get(model, Attributes.PenaltyPolicyMetadata())
+    slack_entry = only(metadata["inferred_penalties"]["slack_variables"])
+
+    @test MOI.get(model, Attributes.SlackVariableEncodingPenalty(), c) == -2.0
+    @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), c) == -2.0
+    @test slack_entry["selected_policy"] == "MOMCPenalty"
+    @test slack_entry["penalty"] == -2.0
+    @test metadata["fallback_count"] == 0
+
+    return nothing
+end
+
+function test_compiler_penalty_heuristic_fractional_gap()
+    # Same fractional model as the default-policy test (ϵ = 0.5 via
+    # pbo_mingap): MaxCoefficient's bound is the single objective coefficient
+    # λ = 1, so ρ = (λ + 1)/ϵ = 4.0 — locking the (λ + β)/ϵ composition on
+    # the non-integer penalty path.
+    model, c = _fractional_gap_penalty_test_model(;
+        policy = Attributes.MaxCoefficientPenalty(),
+    )
+    metadata = MOI.get(model, Attributes.PenaltyPolicyMetadata())
+    inferred = only(metadata["inferred_penalties"]["constraints"])
+
+    @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), c) == 4.0
+    @test inferred["epsilon"] == 0.5
+    @test inferred["epsilon_source"] == "pbo_mingap"
+    @test inferred["selected_policy"] == "MaxCoefficientPenalty"
+    @test metadata["fallback_count"] == 0
+
+    return nothing
+end
+
 function test_compiler_penalties()
     @testset "Penalty inference" begin
         test_compiler_penalty_default_policy()
@@ -536,6 +578,8 @@ function test_compiler_penalties()
         test_compiler_penalty_heuristic_policies()
         test_compiler_penalty_per_constraint_heuristics()
         test_compiler_penalty_heuristic_fallbacks()
+        test_compiler_penalty_heuristic_slack_bucket()
+        test_compiler_penalty_heuristic_fractional_gap()
     end
 
     return nothing

--- a/test/unit/compiler/penalties.jl
+++ b/test/unit/compiler/penalties.jl
@@ -525,6 +525,89 @@ function test_compiler_penalty_heuristic_fallbacks()
     return nothing
 end
 
+# MAX x₁coef·x₁ + 10x₂ + 20x₁x₂ subject to x₁ + x₂ ≤ 1: a quadratic,
+# asymmetric objective that locks the higher-degree monomial crediting of the
+# one-flip scan (each nonlinear monomial credits every variable it contains).
+function _quadratic_heuristic_model(policy; x1_coefficient = 1.0)
+    model = ToQUBO.Optimizer{Float64}()
+    x = [MOI.add_variable(model) for _ = 1:2]
+
+    for xi in x
+        MOI.add_constraint(model, xi, MOI.ZeroOne())
+    end
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+        MOI.ScalarQuadraticFunction{Float64}(
+            MOI.ScalarQuadraticTerm{Float64}[
+                MOI.ScalarQuadraticTerm{Float64}(20.0, x[1], x[2]),
+            ],
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(x1_coefficient, x[1]),
+                MOI.ScalarAffineTerm{Float64}(10.0, x[2]),
+            ],
+            0.0,
+        ),
+    )
+
+    c = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(1.0, x[1]),
+                MOI.ScalarAffineTerm{Float64}(1.0, x[2]),
+            ],
+            0.0,
+        ),
+        MOI.LessThan{Float64}(1.0),
+    )
+
+    MOI.set(model, Attributes.PenaltyPolicy(), policy)
+
+    MOI.optimize!(model)
+
+    return model, c
+end
+
+function test_compiler_penalty_heuristic_quadratic_objective()
+    # Objective x₁ + 10x₂ + 20x₁x₂: coefficient sum 31, maximum coefficient
+    # 20; one-flip values credit the 20x₁x₂ monomial to both variables, so
+    # inc(x₁) = 21, inc(x₂) = 30 → VLM bound 30. The slack-augmented penalty
+    # has γ = 1 (MOMC = max(1, 30/1) = 30) and its largest absolute flip
+    # ratio is 10 (x₂ decrease pair 10/1; increase pairs 21/3 and 30/3).
+    # With σ = -1, scale = 1, offset = 1, ϵ = 1: ρ = -(λ + 1).
+    expected = [
+        (Attributes.UBPositivePenalty(), -32.0),
+        (Attributes.MaxCoefficientPenalty(), -21.0),
+        (Attributes.VLMPenalty(), -31.0),
+        (Attributes.MOMCPenalty(), -31.0),
+        (Attributes.MOCPenalty(), -11.0),
+    ]
+
+    for (policy, ρ) in expected
+        model, c = _quadratic_heuristic_model(policy)
+        metadata = MOI.get(model, Attributes.PenaltyPolicyMetadata())
+
+        @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), c) == ρ
+        @test metadata["fallback_count"] == 0
+    end
+
+    # Asymmetric variant -x₁ + 10x₂ + 20x₁x₂: the negative linear term makes
+    # inc(x₁) = 19 while inc(x₂) = 30 stays, so any scan that credits the
+    # quadratic monomial to a single variable computes a different (wrong)
+    # VLM bound; the correct one is still 30.
+    model, c = _quadratic_heuristic_model(
+        Attributes.VLMPenalty();
+        x1_coefficient = -1.0,
+    )
+
+    @test MOI.get(model, Attributes.ConstraintEncodingPenalty(), c) == -31.0
+
+    return nothing
+end
+
 function test_compiler_penalty_heuristic_slack_bucket()
     # With a one-hot slack encoding, the slack-encoding penalty χ (one-hot
     # exactly-one gadget) has smallest positive one-flip change γ = 1, and the
@@ -578,6 +661,7 @@ function test_compiler_penalties()
         test_compiler_penalty_heuristic_policies()
         test_compiler_penalty_per_constraint_heuristics()
         test_compiler_penalty_heuristic_fallbacks()
+        test_compiler_penalty_heuristic_quadratic_objective()
         test_compiler_penalty_heuristic_slack_bucket()
         test_compiler_penalty_heuristic_fractional_gap()
     end


### PR DESCRIPTION
Closes #222

Part of the MQT QAO parity epic: JuliaQUBO/QUBO.jl#69

## Summary

Adds the five literature penalty-weight heuristics named in #222 as `AutomaticPenaltyPolicy` subtypes, selectable via `Attributes.PenaltyPolicy()`:

- `UBPositivePenalty` — sum of non-constant objective coefficients (Ayodele 2022, Eq. 12); valid only for nonnegative coefficients, guarded.
- `MaxCoefficientPenalty` — largest non-constant objective coefficient (Eq. 13, after Lucas 2014).
- `VLMPenalty` — largest one-flip objective change (Verma & Lewis 2022; Eqs. 14–15).
- `MOMCPenalty` — `max(1, VLM/γ)` with `γ` the smallest strictly positive one-flip change of the penalty function (Eqs. 16–18), **per penalty function**.
- `MOCPenalty` — `max(1, max |one-flip objective/penalty ratio|)` over positive penalty flips (Eq. 19), **per penalty function**.

Each bound composes exactly like the default policy (`ρ = s·σ·(λ+β)/ϵ`), applies uniformly to all three penalty buckets (constraints, variable encodings, slack encodings), and falls back per-coefficient to `LegacyPenalty` via the existing `_fallback!` machinery — with a specific reason string recorded in `PenaltyPolicyMetadata` — whenever its validity conditions fail (negative coefficients under UB⁺, empty objective, no positive penalty flip, non-finite ϵ).

## Design notes

- **Formulas follow the literature (Ayodele, arXiv:2206.11040), not MQT QAO's implementation.** Their code deviates from the paper it cites in ways we deliberately do not replicate: the constant offset added into MQC, the missing strictly-positive filter in MOMC's γ (their `min` admits negative flip values, collapsing λ to 1), and the missing absolute value in MOC's ratios. Each is a correctness deviation, verified against `mqt-qao/src/mqt/qao/problem.py:154-402`.
- One-flip values generalize Ayodele's quadratic row-sum form to arbitrary degree by crediting each monomial to every variable it contains — the correct flip bound for the PBF IR (and what makes the policies degree-agnostic).
- MOMC/MOC are per-penalty-function (per constraint/variable/slack), per the issue's acceptance criteria, rather than Ayodele's single aggregated constraint matrix; documented in the docstrings and manual.
- The objective scan is computed once per compile and threaded through `_infer_and_record_penalty_factor`; VI-keyed flip dictionaries deliberately stay out of `PenaltyPolicyMetadata` (which only carries index-free scalars, keeping its `map_indices` copy semantics valid).

## Acceptance criteria (from #222)

- [x] Each policy selectable via `MOI.set(model, Attributes.PenaltyPolicy(), …)` and produces the literature formula — unit tests with hand-computed λ on small instances (`test_compiler_penalty_heuristic_policies`)
- [x] MOMC/MOC yield per-constraint lambdas — two-constraint model with distinct hand-computed coefficients (`test_compiler_penalty_per_constraint_heuristics`)
- [x] `PenaltyPolicyMetadata` records the chosen policy and computed values (asserted in both tests plus fallback-reason coverage)
- [x] Docs list the portfolio with references (`docs/src/manual/4-settings.md`, "Literature Penalty Heuristics" + `@docs` entries with citations)

## Testing

- `julia --project -e 'using Pkg; Pkg.test()'` (Julia 1.10.11): full suite including three new test functions (exact-value, per-constraint distinctness, fallback reasons/values).

## Branch Hygiene

- Base: `main` (default), branched from `origin/main` at `34d2fb0` (post-#228 merge).
- Open sibling PRs #229/#230 are Dependabot workflow-only bumps; no overlap.
