### PR TITLE
Add value-set variable encoding input surface (arbitrary finite sets and non-uniform spacing)

### DIFF
--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -289,8 +289,11 @@ require integer-valued entries. Interval encoding methods (`Encoding.Binary`,
 `Encoding.Unary`, `Encoding.Arithmetic`, `Encoding.Bounded`) reject value sets
 with a compilation error — choose a set encoding for the variable instead.
 For continuous variables, pass the exact grid you want (for example
-`exp10.(range(-1, 2; length = 4))` for logarithmic spacing); decoded solutions
-always land on a grid point.
+`exp10.(range(-1, 2; length = 4))` for logarithmic spacing). Encoding-feasible
+decoded states always land on a grid point; samples that violate the set
+encoding's penalty (for example, an all-zero or multi-hot one-hot state) can
+decode off-grid, so inspect sample feasibility or the penalty value as usual
+when working with raw sample sets.
 
 ```@docs
 ToQUBO.Attributes.VariableEncodingSet

--- a/docs/src/manual/4-settings.md
+++ b/docs/src/manual/4-settings.md
@@ -256,6 +256,46 @@ Very small `ϵ` values or broad objective ranges can produce large penalties.
 Inspect the policy metadata before overriding the policy or pinning explicit
 penalties.
 
+### Value-Set Variable Encoding
+
+Variables restricted to an explicit finite set of values — discrete component
+choices, tariff levels, or a non-uniform (for example, logarithmically spaced)
+grid for a continuous quantity — can be declared directly with
+[`ToQUBO.Attributes.VariableEncodingSet`](@ref) together with a set encoding
+method (`Encoding.OneHot` or `Encoding.DomainWall`):
+
+```@example value-set-encoding
+using JuMP
+using QUBODrivers
+using ToQUBO
+using ToQUBO: Attributes, Encoding
+
+model = Model(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+@variable(model, x, Int)
+@objective(model, Min, x)
+
+set_attribute(x, Attributes.VariableEncodingMethod(), Encoding.OneHot())
+set_attribute(x, Attributes.VariableEncodingSet(), [-1.0, 1.0, 3.0])
+
+optimize!(model)
+
+value(x)
+```
+
+The set replaces the bounds-derived domain, so bounds are optional; when
+explicit bounds are present, every entry must respect them. Integer variables
+require integer-valued entries. Interval encoding methods (`Encoding.Binary`,
+`Encoding.Unary`, `Encoding.Arithmetic`, `Encoding.Bounded`) reject value sets
+with a compilation error — choose a set encoding for the variable instead.
+For continuous variables, pass the exact grid you want (for example
+`exp10.(range(-1, 2; length = 4))` for logarithmic spacing); decoded solutions
+always land on a grid point.
+
+```@docs
+ToQUBO.Attributes.VariableEncodingSet
+```
+
 ### Continuous Variable Resolution
 
 Bounded continuous variables need a finite binary representation before the

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -1267,8 +1267,10 @@ end
 
 Explicit finite value set for a variable, e.g. `[-1.0, 1.0, 3.0]` or a
 non-uniformly spaced grid such as `[0.1, 1.0, 10.0, 100.0]`. The variable is
-encoded so that it can only assume values from the set, replacing the
-bounds-derived domain.
+encoded over the set instead of the bounds-derived domain: every
+encoding-feasible target state decodes to a set member, while samples that
+violate the set encoding's penalty can decode outside the set — inspect
+sample feasibility or the penalty value when consuming raw sample sets.
 
 Requires the variable's [`VariableEncodingMethod`](@ref) to be a set encoding
 (`Encoding.OneHot` or `Encoding.DomainWall`); interval encodings such as

--- a/src/attributes/compiler.jl
+++ b/src/attributes/compiler.jl
@@ -1263,6 +1263,76 @@ function variable_encoding_bits(model::Optimizer, vi::VI)::Union{Integer,Nothing
 end
 
 @doc raw"""
+    VariableEncodingSet()
+
+Explicit finite value set for a variable, e.g. `[-1.0, 1.0, 3.0]` or a
+non-uniformly spaced grid such as `[0.1, 1.0, 10.0, 100.0]`. The variable is
+encoded so that it can only assume values from the set, replacing the
+bounds-derived domain.
+
+Requires the variable's [`VariableEncodingMethod`](@ref) to be a set encoding
+(`Encoding.OneHot` or `Encoding.DomainWall`); interval encodings such as
+`Encoding.Binary`, `Encoding.Unary`, `Encoding.Arithmetic`, and
+`Encoding.Bounded` reject value sets at compile time. Integer variables
+require integer-valued entries, and every entry must respect the variable's
+explicit bounds when such bounds are present. Bounds are otherwise optional:
+the set itself defines the domain.
+
+```julia
+set_attribute(x, ToQUBO.Attributes.VariableEncodingMethod(), ToQUBO.Encoding.OneHot())
+set_attribute(x, ToQUBO.Attributes.VariableEncodingSet(), [-1.0, 1.0, 3.0])
+```
+"""
+struct VariableEncodingSet <: CompilerVariableAttribute end
+
+_attribute_from_key(::Val{:variable_encoding_set}) = VariableEncodingSet
+
+function MOI.get(
+    model::Optimizer{T},
+    ::VariableEncodingSet,
+    vi::VI,
+)::Union{Vector{T},Nothing} where {T}
+    attr = :variable_encoding_set
+
+    if haskey(model.variable_settings, attr)
+        return get(model.variable_settings[attr], vi, nothing)
+    else
+        return nothing
+    end
+end
+
+function MOI.set(
+    model::Optimizer{T},
+    ::VariableEncodingSet,
+    vi::VI,
+    γ::AbstractVector,
+) where {T}
+    attr = :variable_encoding_set
+
+    if !haskey(model.variable_settings, attr)
+        model.variable_settings[attr] = Dict{VI,Any}()
+    end
+
+    model.variable_settings[attr][vi] = Vector{T}(γ)
+
+    return nothing
+end
+
+function MOI.set(model::Optimizer, ::VariableEncodingSet, vi::VI, ::Nothing)
+    attr = :variable_encoding_set
+
+    if haskey(model.variable_settings, attr)
+        delete!(model.variable_settings[attr], vi)
+    end
+
+    return nothing
+end
+
+function variable_encoding_set(model::Optimizer{T}, vi::VI)::Union{Vector{T},Nothing} where {T}
+    return MOI.get(model, VariableEncodingSet(), vi)
+end
+
+@doc raw"""
     VariableEncodingMethod()
 
 Available methods are:

--- a/src/compiler/variables.jl
+++ b/src/compiler/variables.jl
@@ -269,6 +269,13 @@ function _sos1_domain_wall_variables!(
             xi -> xi in binary_variables && !haskey(model.source, xi) && counts[xi] == 1,
             x.variables,
         )
+            # This fast path encodes binary variables before the per-variable
+            # loop, so it must apply the same value-set rejection the loop
+            # would reach through `variable_𝔹!`.
+            for xi in x.variables
+                _reject_value_set!(model, xi, "binary")
+            end
+
             _encode_sos1_domain_wall!(model, ci, x.variables)
         end
     end

--- a/src/compiler/variables.jl
+++ b/src/compiler/variables.jl
@@ -119,7 +119,77 @@ function variables!(model::Virtual.Model{T}, ::AbstractArchitecture) where {T}
 end
 
 function variable_𝔹!(model::Virtual.Model{T}, i::Union{VI,CI}) where {T}
+    _reject_value_set!(model, i, "binary")
+
     return Encoding.encode!(model, i, Encoding.Mirror{T}())
+end
+
+function _reject_value_set!(model::Virtual.Model, i::Union{VI,CI}, kind::String)
+    if i isa VI && !isnothing(Attributes.variable_encoding_set(model, i))
+        compilation_error!(
+            model,
+            "Value sets are not supported for $(kind) variables; found one on variable '$(i)'";
+            status = "Value set on $(kind) variable",
+        )
+    end
+
+    return nothing
+end
+
+# Encodes a variable over an explicit finite value set through a set encoding
+# method (one-hot, domain-wall). The set replaces the bounds-derived domain;
+# explicit bounds, when present, must contain every entry.
+function variable_set!(
+    model::Virtual.Model{T},
+    vi::VI,
+    γ::Vector{T},
+    (a, b)::Tuple{A,B};
+    integer::Bool,
+) where {T,A<:Union{T,Nothing},B<:Union{T,Nothing}}
+    e = Attributes.variable_encoding_method(model, vi)
+
+    if !(e isa Encoding.SetVariableEncodingMethod)
+        compilation_error!(
+            model,
+            "Variable encoding method '$(nameof(typeof(e)))' does not support value sets; " *
+            "choose a set encoding such as 'Encoding.OneHot' or 'Encoding.DomainWall' " *
+            "for variable '$(vi)'";
+            status = "Value set requires a set encoding method",
+        )
+    elseif isempty(γ)
+        compilation_error!(
+            model,
+            "Value set for variable '$(vi)' is empty";
+            status = "Empty value set",
+        )
+    elseif !all(isfinite, γ)
+        compilation_error!(
+            model,
+            "Value set for variable '$(vi)' contains non-finite entries";
+            status = "Non-finite value set",
+        )
+    elseif !allunique(γ)
+        compilation_error!(
+            model,
+            "Value set for variable '$(vi)' contains duplicate entries";
+            status = "Duplicate value set entries",
+        )
+    elseif integer && !all(isinteger, γ)
+        compilation_error!(
+            model,
+            "Value set for integer variable '$(vi)' must contain only integer values";
+            status = "Non-integer value set entries",
+        )
+    elseif (!isnothing(a) && any(v -> v < a, γ)) || (!isnothing(b) && any(v -> v > b, γ))
+        compilation_error!(
+            model,
+            "Value set for variable '$(vi)' has entries outside its declared bounds " *
+            "[$(isnothing(a) ? "-∞" : a), $(isnothing(b) ? "+∞" : b)]";
+            status = "Value set outside variable bounds",
+        )
+    end
+
+    return Encoding.encode!(model, vi, e, γ)
 end
 
 function _sos1_variable_counts(model::Virtual.Model{T}) where {T}
@@ -211,6 +281,8 @@ function variable_semiinteger!(
     vi::VI,
     S::Tuple{T,T},
 ) where {T}
+    _reject_value_set!(model, vi, "semi-integer")
+
     e = Attributes.variable_encoding_method(model, vi)
 
     MOI.set(model, Attributes.Quadratize(), true)
@@ -223,6 +295,8 @@ function variable_semicontinuous!(
     vi::VI,
     S::Tuple{T,T},
 ) where {T}
+    _reject_value_set!(model, vi, "semi-continuous")
+
     e = Attributes.variable_encoding_method(model, vi)
     n = Attributes.variable_encoding_bits(model, vi)
 
@@ -238,6 +312,12 @@ function variable_semicontinuous!(
 end
 
 function variable_ℤ!(model::Virtual.Model{T}, vi::VI, (a, b)::Tuple{A,B}) where {T,A<:Union{T,Nothing},B<:Union{T,Nothing}}
+    let γ = Attributes.variable_encoding_set(model, vi)
+        if !isnothing(γ)
+            return variable_set!(model, vi, γ, (a, b); integer = true)
+        end
+    end
+
     if !isnothing(a) && !isnothing(b)
         let e = Attributes.variable_encoding_method(model, vi)
             S = (a, b)
@@ -266,6 +346,12 @@ function variable_ℤ!(model::Virtual.Model{T}, ci::CI, (a, b)::Tuple{T,T}) wher
 end
 
 function variable_ℝ!(model::Virtual.Model{T}, vi::VI, (a, b)::Tuple{A,B}) where {T,A<:Union{T,Nothing},B<:Union{T,Nothing}}
+    let γ = Attributes.variable_encoding_set(model, vi)
+        if !isnothing(γ)
+            return variable_set!(model, vi, γ, (a, b); integer = false)
+        end
+    end
+
     if !isnothing(a) && !isnothing(b)
         # Tolerance-based bit inference is documented in the Representation
         # Error section of the encoding booklet.

--- a/test/unit/attributes/attributes.jl
+++ b/test/unit/attributes/attributes.jl
@@ -484,6 +484,25 @@ end
 
 function test_encoding_attributes()
     @testset "→ Encoding Attributes" begin
+        @testset "VariableEncodingSet" begin
+            let model = ToQUBO.Optimizer{Float64}()
+                x = MOI.add_variable(model)
+
+                @test MOI.supports(model, Attributes.VariableEncodingSet(), VI)
+                @test MOI.get(model, Attributes.VariableEncodingSet(), x) === nothing
+                @test Attributes.variable_encoding_set(model, x) === nothing
+
+                MOI.set(model, Attributes.VariableEncodingSet(), x, [-1, 1, 3])
+                @test MOI.get(model, Attributes.VariableEncodingSet(), x) ==
+                      [-1.0, 1.0, 3.0]
+                @test MOI.get(model, Attributes.VariableEncodingSet(), x) isa
+                      Vector{Float64}
+
+                MOI.set(model, Attributes.VariableEncodingSet(), x, nothing)
+                @test MOI.get(model, Attributes.VariableEncodingSet(), x) === nothing
+            end
+        end
+
         @testset "DefaultVariableEncodingMethod" begin
             let model = ToQUBO.Optimizer{Float64}()
                 @test MOI.supports(model, Attributes.DefaultVariableEncodingMethod())

--- a/test/unit/compiler/variables.jl
+++ b/test/unit/compiler/variables.jl
@@ -123,6 +123,31 @@ function test_compiler_variables_value_set_continuous()
     return nothing
 end
 
+function test_compiler_variables_value_set_continuous_domain_wall()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch = ToQUBO.Compiler.GenericArchitecture()
+    x = MOI.add_variable(model.source_model)
+    γ = [0.1, 1.0, 10.0] # non-uniform grid through the wall encoding
+
+    MOI.set(model, Attributes.VariableEncodingMethod(), x, Encoding.DomainWall())
+    MOI.set(model, Attributes.VariableEncodingSet(), x, γ)
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    v = model.source[x]
+    y = ToQUBO.Virtual.target(v)
+    ξ = ToQUBO.Virtual.expansion(v)
+
+    @test ToQUBO.Virtual.encoding(v) isa Encoding.DomainWall
+    @test length(y) == 2
+    @test ξ(Dict{VI,Integer}(y[1] => 0, y[2] => 0))[nothing] ≈ 0.1
+    @test ξ(Dict{VI,Integer}(y[1] => 1, y[2] => 0))[nothing] ≈ 1.0
+    @test ξ(Dict{VI,Integer}(y[1] => 1, y[2] => 1))[nothing] ≈ 10.0
+    @test haskey(model.h, x)
+
+    return nothing
+end
+
 function _value_set_error_model(γ; method = Encoding.OneHot(), integer = true, bounds = nothing)
     model = ToQUBO.Virtual.Model{Float64}()
     x = MOI.add_variable(model.source_model)
@@ -139,8 +164,14 @@ end
 function test_compiler_variables_value_set_errors()
     arch = ToQUBO.Compiler.GenericArchitecture()
 
-    # Interval-only encoding methods reject value sets.
-    for method in (nothing, Encoding.Unary(), Encoding.Arithmetic())
+    # Interval-only encoding methods reject value sets, including the
+    # Bounded wrapper around an interval method.
+    for method in (
+        nothing,
+        Encoding.Unary(),
+        Encoding.Arithmetic(),
+        Encoding.Bounded(Encoding.Binary(), 2.0),
+    )
         model = _value_set_error_model([-1.0, 1.0, 3.0]; method)
 
         @test_throws ToQUBO.Compiler.CompilationError ToQUBO.Compiler.variables!(
@@ -233,6 +264,7 @@ function test_compiler_variables()
         test_compiler_variables_value_set_onehot()
         test_compiler_variables_value_set_domain_wall()
         test_compiler_variables_value_set_continuous()
+        test_compiler_variables_value_set_continuous_domain_wall()
         test_compiler_variables_value_set_errors()
         test_compiler_variables_value_set_solve()
     end

--- a/test/unit/compiler/variables.jl
+++ b/test/unit/compiler/variables.jl
@@ -52,10 +52,189 @@ function test_compiler_variables_semicontinuous()
     return nothing
 end
 
+function test_compiler_variables_value_set_onehot()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch = ToQUBO.Compiler.GenericArchitecture()
+    x = MOI.add_variable(model.source_model)
+
+    MOI.add_constraint(model.source_model, x, MOI.Integer())
+    MOI.set(model, Attributes.VariableEncodingMethod(), x, Encoding.OneHot())
+    MOI.set(model, Attributes.VariableEncodingSet(), x, [-1.0, 1.0, 3.0])
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    v = model.source[x]
+    y = ToQUBO.Virtual.target(v)
+
+    @test ToQUBO.Virtual.encoding(v) isa Encoding.OneHot
+    @test length(y) == 3
+    @test ToQUBO.Virtual.expansion(v) ==
+          PBO.PBF{VI,Float64}(y[1] => -1.0, y[2] => 1.0, y[3] => 3.0)
+    @test haskey(model.h, x) # exactly-one penalty registered
+
+    return nothing
+end
+
+function test_compiler_variables_value_set_domain_wall()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch = ToQUBO.Compiler.GenericArchitecture()
+    x = MOI.add_variable(model.source_model)
+
+    MOI.add_constraint(model.source_model, x, MOI.Integer())
+    MOI.set(model, Attributes.VariableEncodingMethod(), x, Encoding.DomainWall())
+    MOI.set(model, Attributes.VariableEncodingSet(), x, [-1.0, 1.0, 3.0])
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    v = model.source[x]
+    y = ToQUBO.Virtual.target(v)
+    ξ = ToQUBO.Virtual.expansion(v)
+
+    @test ToQUBO.Virtual.encoding(v) isa Encoding.DomainWall
+    @test length(y) == 2
+    # The three feasible wall states decode to the three set members.
+    @test ξ(Dict{VI,Integer}(y[1] => 0, y[2] => 0))[nothing] ≈ -1.0
+    @test ξ(Dict{VI,Integer}(y[1] => 1, y[2] => 0))[nothing] ≈ 1.0
+    @test ξ(Dict{VI,Integer}(y[1] => 1, y[2] => 1))[nothing] ≈ 3.0
+    @test haskey(model.h, x) # wall penalty registered
+
+    return nothing
+end
+
+function test_compiler_variables_value_set_continuous()
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch = ToQUBO.Compiler.GenericArchitecture()
+    x = MOI.add_variable(model.source_model)
+    γ = [0.1, 1.0, 10.0, 100.0] # non-uniform (log-spaced) grid
+
+    MOI.set(model, Attributes.VariableEncodingMethod(), x, Encoding.OneHot())
+    MOI.set(model, Attributes.VariableEncodingSet(), x, γ)
+
+    ToQUBO.Compiler.variables!(model, arch)
+
+    v = model.source[x]
+    y = ToQUBO.Virtual.target(v)
+
+    # Unbounded continuous variable: the set itself defines the domain.
+    @test length(y) == 4
+    @test ToQUBO.Virtual.expansion(v) ==
+          PBO.PBF{VI,Float64}([y[i] => γ[i] for i in eachindex(γ)])
+
+    return nothing
+end
+
+function _value_set_error_model(γ; method = Encoding.OneHot(), integer = true, bounds = nothing)
+    model = ToQUBO.Virtual.Model{Float64}()
+    x = MOI.add_variable(model.source_model)
+
+    integer && MOI.add_constraint(model.source_model, x, MOI.Integer())
+    isnothing(bounds) ||
+        MOI.add_constraint(model.source_model, x, MOI.Interval{Float64}(bounds...))
+    isnothing(method) || MOI.set(model, Attributes.VariableEncodingMethod(), x, method)
+    MOI.set(model, Attributes.VariableEncodingSet(), x, γ)
+
+    return model
+end
+
+function test_compiler_variables_value_set_errors()
+    arch = ToQUBO.Compiler.GenericArchitecture()
+
+    # Interval-only encoding methods reject value sets.
+    for method in (nothing, Encoding.Unary(), Encoding.Arithmetic())
+        model = _value_set_error_model([-1.0, 1.0, 3.0]; method)
+
+        @test_throws ToQUBO.Compiler.CompilationError ToQUBO.Compiler.variables!(
+            model,
+            arch,
+        )
+    end
+
+    # Non-integer entries for an integer variable.
+    let model = _value_set_error_model([-1.0, 0.5, 3.0])
+        @test_throws ToQUBO.Compiler.CompilationError ToQUBO.Compiler.variables!(
+            model,
+            arch,
+        )
+    end
+
+    # Entries outside declared bounds.
+    let model = _value_set_error_model([-1.0, 1.0, 3.0]; bounds = (0.0, 2.0))
+        @test_throws ToQUBO.Compiler.CompilationError ToQUBO.Compiler.variables!(
+            model,
+            arch,
+        )
+    end
+
+    # Empty, non-finite, and duplicate sets.
+    for γ in (Float64[], [1.0, NaN], [1.0, 1.0, 3.0])
+        model = _value_set_error_model(γ)
+
+        @test_throws ToQUBO.Compiler.CompilationError ToQUBO.Compiler.variables!(
+            model,
+            arch,
+        )
+    end
+
+    # Binary variables do not accept value sets.
+    let model = ToQUBO.Virtual.Model{Float64}()
+        x = MOI.add_variable(model.source_model)
+
+        MOI.add_constraint(model.source_model, x, MOI.ZeroOne())
+        MOI.set(model, Attributes.VariableEncodingSet(), x, [0.0, 1.0])
+
+        @test_throws ToQUBO.Compiler.CompilationError ToQUBO.Compiler.variables!(
+            model,
+            arch,
+        )
+    end
+
+    return nothing
+end
+
+function test_compiler_variables_value_set_solve()
+    model = Model(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+    @variable(model, x, Int)
+    @objective(model, Min, x)
+
+    set_attribute(x, Attributes.VariableEncodingMethod(), Encoding.OneHot())
+    set_attribute(x, Attributes.VariableEncodingSet(), [-1.0, 1.0, 3.0])
+
+    optimize!(model)
+
+    @test objective_value(model) ≈ -1.0
+    @test value(x) ≈ -1.0
+
+    # Every encoding-feasible sample (exactly one hot bit) decodes to a
+    # member of the set; encoding-violating states are penalized by χ and
+    # decode outside it, which is inherent to one-hot encodings.
+    backend = JuMP.unsafe_backend(model)
+    y = ToQUBO.Virtual.target(backend.source[JuMP.index(x)])
+    encoding_feasible = 0
+
+    for i in 1:result_count(model)
+        hot = sum(MOI.get(backend.optimizer, MOI.VariablePrimal(i), yj) for yj in y)
+
+        if hot ≈ 1.0
+            encoding_feasible += 1
+            @test value(x; result = i) in [-1.0, 1.0, 3.0]
+        end
+    end
+
+    @test encoding_feasible == 3 # one sample per set member
+
+    return nothing
+end
+
 function test_compiler_variables()
     @testset "→ Variables" begin
         test_compiler_variables_semiinteger()
         test_compiler_variables_semicontinuous()
+        test_compiler_variables_value_set_onehot()
+        test_compiler_variables_value_set_domain_wall()
+        test_compiler_variables_value_set_continuous()
+        test_compiler_variables_value_set_errors()
+        test_compiler_variables_value_set_solve()
     end
 
     return nothing

--- a/test/unit/compiler/variables.jl
+++ b/test/unit/compiler/variables.jl
@@ -222,6 +222,32 @@ function test_compiler_variables_value_set_errors()
     return nothing
 end
 
+function test_compiler_variables_value_set_sos1_rejected()
+    # The SOS1 domain-wall fast path runs before the per-variable loop and
+    # must not bypass the binary-variable value-set rejection.
+    model = ToQUBO.Virtual.Model{Float64}()
+    arch = ToQUBO.Compiler.GenericArchitecture()
+    x = [MOI.add_variable(model.source_model) for _ = 1:2]
+
+    for xi in x
+        MOI.add_constraint(model.source_model, xi, MOI.ZeroOne())
+    end
+
+    MOI.add_constraint(
+        model.source_model,
+        MOI.VectorOfVariables(x),
+        MOI.SOS1{Float64}([1.0, 2.0]),
+    )
+    MOI.set(model, Attributes.VariableEncodingSet(), x[1], [-1.0, 3.0])
+
+    @test_throws ToQUBO.Compiler.CompilationError ToQUBO.Compiler.variables!(
+        model,
+        arch,
+    )
+
+    return nothing
+end
+
 function test_compiler_variables_value_set_solve()
     model = Model(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
 
@@ -266,6 +292,7 @@ function test_compiler_variables()
         test_compiler_variables_value_set_continuous()
         test_compiler_variables_value_set_continuous_domain_wall()
         test_compiler_variables_value_set_errors()
+        test_compiler_variables_value_set_sos1_rejected()
         test_compiler_variables_value_set_solve()
     end
 


### PR DESCRIPTION
Closes #221

Part of the MQT QAO parity epic: JuliaQUBO/QUBO.jl#69

## Summary

Adds the missing input surface for variables over explicit finite value sets: a new per-variable compiler attribute `Attributes.VariableEncodingSet` routed by the compiler to the pre-existing γ-vector set encoders (`Encoding.OneHot`, `Encoding.DomainWall`).

```julia
set_attribute(x, Attributes.VariableEncodingMethod(), Encoding.OneHot())
set_attribute(x, Attributes.VariableEncodingSet(), [-1.0, 1.0, 3.0])
```

- **Attribute** (`src/attributes/compiler.jl`): `VariableEncodingSet <: CompilerVariableAttribute`, pattern-copied from `VariableEncodingBits` (per-variable storage, `nothing`-deletion, `variable_encoding_set` helper), values stored as `Vector{T}`.
- **Compiler** (`src/compiler/variables.jl`): `variable_ℤ!`/`variable_ℝ!` branch to a new `variable_set!` before the bounds checks, so a set-valued variable needs no bounds (the set is the domain). Validation with descriptive `CompilationError`s: non-set encoding methods (Binary/Unary/Arithmetic/Bounded) rejected; empty, non-finite, or duplicate sets rejected; non-integer entries rejected for `MOI.Integer` variables; entries outside explicit bounds rejected. Binary and semi-integer/semi-continuous variables reject the attribute outright instead of silently ignoring it.
- **Non-uniform continuous grids**: the same attribute accepts an arbitrary point vector (e.g. `exp10.(range(-1, 2; length = 4))`), covering MQT QAO's geometric/logarithmic distributions — generated by the user, so any spacing works, and without MQT's `np.logspace` misuse (their `variables.py:972` treats min/max as base-10 exponents).
- **Docs**: new "Value-Set Variable Encoding" section in the settings manual with a solvable example and the attribute docstring.

## Design notes

- **No auto-selection of a set encoding**: a value set with an interval method errors rather than silently switching the method, keeping `VariableEncodingMethod` truthful (and matching the issue's error acceptance criterion). The error names OneHot/DomainWall as the fix.
- The virtual layer, decode path, and one-hot/domain-wall penalty registration (`model.h`) needed **no changes** — the γ-vector `Encoding.encode!` entry point existed since the set encoders landed; this PR is purely the input surface, as the issue's verified analysis predicted.
- Encoding-violating samples (e.g. all-zero one-hot state) decode outside the set by construction in any one-hot scheme; the solve test asserts the acceptance criterion on encoding-feasible samples (exactly one hot bit) and that all three set members appear.

## Acceptance criteria (from #221)

- [x] `[-1.0, 1.0, 3.0]` compiles via OneHot and DomainWall and decodes to set members (`test_compiler_variables_value_set_onehot`/`_domain_wall`, exact expansions + wall-state decode checks)
- [x] Interval-only methods raise a descriptive error (`test_compiler_variables_value_set_errors`)
- [x] Non-uniform continuous point vectors round-trip (`test_compiler_variables_value_set_continuous`, log-spaced grid)
- [x] Tests cover both set encodings and error paths; docs section added to `docs/src/manual/4-settings.md`

## Testing

- `julia --project -e 'using Pkg; Pkg.test()'` (Julia 1.10.11): full suite including five new test functions (OneHot/DomainWall/continuous expansions, seven error paths, end-to-end JuMP+ExactSampler solve with optimum −1 over the set).

## Branch Hygiene

- Base: `main` (default), branched from `origin/main` at `ef6fa02` (post-#231 merge).
- Open sibling PRs #229/#230 are Dependabot workflow-only bumps; no overlap.
