### PR TITLE
Adopt successor Zenodo citation policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
         run: |
           python3 -m venv "${RUNNER_TEMP}/cffconvert"
-          "${RUNNER_TEMP}/cffconvert/bin/pip" install --quiet cffconvert
+          "${RUNNER_TEMP}/cffconvert/bin/pip" install --quiet 'cffconvert==2.0.0'
           "${RUNNER_TEMP}/cffconvert/bin/cffconvert" --validate --infile CITATION.cff
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - name: Check release and citation metadata
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        run: julia --project=. scripts/release_check.jl
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Check release and citation metadata
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
         run: julia --project=. scripts/release_check.jl
+      - name: Validate CITATION.cff
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        run: |
+          python3 -m venv "${RUNNER_TEMP}/cffconvert"
+          "${RUNNER_TEMP}/cffconvert/bin/pip" install --quiet cffconvert
+          "${RUNNER_TEMP}/cffconvert/bin/cffconvert" --validate --infile CITATION.cff
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,11 +1,20 @@
-% If you use this software, please cite it as below.
-@software{toqubo:2023,
-  author       = {Pedro Maciel Xavier and Pedro Ripper and Tiago Andrade and Joaquim Dias Garcia and David E. Bernal Neira},
+@article{xavier2026qubojl,
+  author       = {Maciel Xavier, Pedro and Ripper, Pedro and Andrade, Tiago and Dias Garcia, Joaquim and Maculan, Nelson and Bernal Neira, David E.},
+  title        = {{QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}},
+  journal      = {Optimization Methods and Software},
+  year         = {2026},
+  pages        = {1--24},
+  doi          = {10.1080/10556788.2026.2702926},
+  url          = {https://doi.org/10.1080/10556788.2026.2702926}
+}
+
+@software{toqubo:2026,
+  author       = {Maciel Xavier, Pedro and Ripper, Pedro and Andrade, Tiago and Dias Garcia, Joaquim and Bernal Neira, David E.},
   title        = {{ToQUBO.jl}},
-  month        = {feb},
-  year         = {2023},
+  year         = {2026},
   publisher    = {Zenodo},
-  version      = {v0.1.5},
-  doi          = {10.5281/zenodo.7644291},
-  url          = {https://doi.org/10.5281/zenodo.7644291}
+  version      = {v0.6.1},
+  doi          = {10.5281/zenodo.21763526},
+  url          = {https://doi.org/10.5281/zenodo.21763526},
+  note         = {Evergreen concept DOI: 10.5281/zenodo.21763525}
 }

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,6 +1,6 @@
 @article{xavier2026qubojl,
   author       = {Maciel Xavier, Pedro and Ripper, Pedro and Andrade, Tiago and Dias Garcia, Joaquim and Maculan, Nelson and Bernal Neira, David E.},
-  title        = {{QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}},
+  title        = {{QUBO.jl: a Julia ecosystem for quadratic unconstrained binary optimization}},
   journal      = {Optimization Methods and Software},
   year         = {2026},
   pages        = {1--24},

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,23 +1,60 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
-authors:
-- family-names: "Maciel Xavier"
-  given-names: "Pedro"
-  orcid: "https://orcid.org/0000-0002-4678-4942"
-- family-names: "Ripper"
-  given-names: "Pedro"
-  orcid: "https://orcid.org/0000-0002-2227-3689"
-- family-names: "Andrade"
-  given-names: "Tiago"
-  orcid: "https://orcid.org/0000-0000-0000-0000"
-- family-names: "Dias Garcia"
-  given-names: "Joaquim"
-  orcid: "https://orcid.org/0000-0002-7721-8564"
-- family-names: "E. Bernal Neira"
-  given-names: "David"
-  orcid: "https://orcid.org/0000-0002-8308-5016"
+message: "If you use ToQUBO.jl, cite the preferred article; cite the exact software version when reproducibility requires it."
 title: "ToQUBO.jl"
-version: 0.1.5
-doi: 10.5281/zenodo.7644291
-date-released: 2023-02-15
-url: "https://github.com/JuliaQUBO/ToQUBO.jl"
+type: software
+authors:
+  - family-names: "Maciel Xavier"
+    given-names: "Pedro"
+    affiliation: "Purdue University"
+    orcid: "https://orcid.org/0000-0002-4678-4942"
+  - family-names: "Ripper"
+    given-names: "Pedro"
+    orcid: "https://orcid.org/0000-0002-2227-3689"
+  - family-names: "Andrade"
+    given-names: "Tiago"
+  - family-names: "Dias Garcia"
+    given-names: "Joaquim"
+    orcid: "https://orcid.org/0000-0002-7721-8564"
+  - family-names: "Bernal Neira"
+    given-names: "David E."
+    affiliation: "Purdue University"
+    orcid: "https://orcid.org/0000-0002-8308-5016"
+abstract: >-
+  A Julia compiler that transforms constrained polynomial optimization models
+  into quadratic unconstrained binary optimization models.
+repository-code: "https://github.com/JuliaQUBO/ToQUBO.jl"
+url: "https://juliaqubo.github.io/ToQUBO.jl/"
+license: MIT
+version: "0.6.1"
+date-released: 2026-07-21
+doi: "10.5281/zenodo.21763525"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.21763526"
+    description: "Zenodo DOI for version 0.6.1"
+keywords:
+  - Julia
+  - mathematical optimization
+  - quadratic unconstrained binary optimization
+  - QUBO
+preferred-citation:
+  type: article
+  authors:
+    - family-names: "Maciel Xavier"
+      given-names: "Pedro"
+    - family-names: "Ripper"
+      given-names: "Pedro"
+    - family-names: "Andrade"
+      given-names: "Tiago"
+    - family-names: "Dias Garcia"
+      given-names: "Joaquim"
+    - family-names: "Maculan"
+      given-names: "Nelson"
+    - family-names: "Bernal Neira"
+      given-names: "David E."
+  title: "QUBO.jl: a Julia ecosystem for quadratic unconstrained binary optimization"
+  journal: "Optimization Methods and Software"
+  year: 2026
+  start: 1
+  end: 24
+  doi: "10.1080/10556788.2026.2702926"

--- a/README.md
+++ b/README.md
@@ -160,21 +160,25 @@ If you think this list is incomplete, consider creating an [Issue](https://githu
 ## Citing ToQUBO.jl
 <!-- citation-policy:start -->
 For general use of `ToQUBO.jl` and the broader `QUBO.jl` ecosystem, cite the
-[published journal article](https://doi.org/10.1080/10556788.2026.2702926).
+[published journal article](https://doi.org/10.1080/10556788.2026.2702926). The
+earlier [arXiv preprint](https://arxiv.org/abs/2307.02577) remains available,
+but the journal article is the version of record.
 
 For a software citation, use the
 [Zenodo concept DOI](https://doi.org/10.5281/zenodo.21763525). The concept DOI
-is the evergreen identifier for the actively maintained archive. For
-exact-version reproducibility, cite the corresponding version DOI; the archive
-for `v0.6.1` is
+is the evergreen identifier for the actively maintained archive and is the DOI
+recorded in `CITATION.cff`. When reproducibility requires an exact release,
+cite the matching version DOI instead; the archive for `v0.6.1` is
 [10.5281/zenodo.21763526](https://doi.org/10.5281/zenodo.21763526).
 
-The corresponding BibTeX entries are:
+The BibTeX entries below pin that exact release. Replace the `@software` entry's
+`doi` and `url` with the concept DOI when an evergreen software citation is
+preferred:
 
 ```bibtex
 @article{xavier2026qubojl,
   author       = {Maciel Xavier, Pedro and Ripper, Pedro and Andrade, Tiago and Dias Garcia, Joaquim and Maculan, Nelson and Bernal Neira, David E.},
-  title        = {{QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}},
+  title        = {{QUBO.jl: a Julia ecosystem for quadratic unconstrained binary optimization}},
   journal      = {Optimization Methods and Software},
   year         = {2026},
   pages        = {1--24},

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
     <a href="https://JuliaQUBO.github.io/ToQUBO.jl/dev">
         <img src="https://img.shields.io/badge/docs-dev-blue.svg" alt="Docs">
     </a>
-    <a href="https://zenodo.org/badge/latestdoi/430697061">
-        <img src="https://zenodo.org/badge/430697061.svg" alt="DOI">
+    <a href="https://doi.org/10.5281/zenodo.21763525">
+        <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.21763525.svg" alt="ToQUBO.jl Zenodo DOI">
     </a>
 </div>
 
@@ -158,19 +158,49 @@ Engineering*, vol. 53, pp. 3433-3438. Elsevier, 2024.
 If you think this list is incomplete, consider creating an [Issue](https://github.com/JuliaQUBO/ToQUBO.jl/issues) or opening a [Pull Request](https://github.com/JuliaQUBO/ToQUBO.jl/pulls).
 
 ## Citing ToQUBO.jl
-If you use `ToQUBO.jl` in your work, we kindly ask you to include the following citation:
-```tex
-@software{toqubo:2023,
-  author       = {Pedro Maciel Xavier and Pedro Ripper and Tiago Andrade and Joaquim Dias Garcia and David E. Bernal Neira},
+<!-- citation-policy:start -->
+For general use of `ToQUBO.jl` and the broader `QUBO.jl` ecosystem, cite the
+[published journal article](https://doi.org/10.1080/10556788.2026.2702926).
+
+For a software citation, use the
+[Zenodo concept DOI](https://doi.org/10.5281/zenodo.21763525). The concept DOI
+is the evergreen identifier for the actively maintained archive. For
+exact-version reproducibility, cite the corresponding version DOI; the archive
+for `v0.6.1` is
+[10.5281/zenodo.21763526](https://doi.org/10.5281/zenodo.21763526).
+
+The corresponding BibTeX entries are:
+
+```bibtex
+@article{xavier2026qubojl,
+  author       = {Maciel Xavier, Pedro and Ripper, Pedro and Andrade, Tiago and Dias Garcia, Joaquim and Maculan, Nelson and Bernal Neira, David E.},
+  title        = {{QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}},
+  journal      = {Optimization Methods and Software},
+  year         = {2026},
+  pages        = {1--24},
+  doi          = {10.1080/10556788.2026.2702926},
+  url          = {https://doi.org/10.1080/10556788.2026.2702926}
+}
+
+@software{toqubo:2026,
+  author       = {Maciel Xavier, Pedro and Ripper, Pedro and Andrade, Tiago and Dias Garcia, Joaquim and Bernal Neira, David E.},
   title        = {{ToQUBO.jl}},
-  month        = {feb},
-  year         = {2023},
+  year         = {2026},
   publisher    = {Zenodo},
-  version      = {v0.1.5},
-  doi          = {10.5281/zenodo.7644291},
-  url          = {https://doi.org/10.5281/zenodo.7644291}
+  version      = {v0.6.1},
+  doi          = {10.5281/zenodo.21763526},
+  url          = {https://doi.org/10.5281/zenodo.21763526},
+  note         = {Evergreen concept DOI: 10.5281/zenodo.21763525}
 }
 ```
+
+The [historical concept DOI](https://doi.org/10.5281/zenodo.6387591) covers
+releases through `v0.1.6` and remains part of the project's provenance; it is
+not the identifier for current releases. Machine-readable metadata is in
+[`CITATION.cff`](https://github.com/JuliaQUBO/ToQUBO.jl/blob/main/CITATION.cff),
+with BibTeX in
+[`CITATION.bib`](https://github.com/JuliaQUBO/ToQUBO.jl/blob/main/CITATION.bib).
+<!-- citation-policy:end -->
 
 ---
 

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -17,7 +17,8 @@ Release changes live in this repository first. The checks here cover ToQUBO-spec
 5. Update `CITATION.cff` with the release version, date, and reserved version
    DOI. Keep the concept DOI unchanged. Update `CITATION.bib` and the marked
    citation section shared by `README.md` and `docs/src/index.md`.
-6. Validate the Citation File Format schema:
+6. Validate the Citation File Format schema. CI runs this same check on every
+   pull request, so run it locally only to get the answer before pushing:
 
 ```sh
 cffconvert --validate --infile CITATION.cff
@@ -84,6 +85,15 @@ The concept DOI is the evergreen software identifier. The DOI assigned to the
 new Zenodo version identifies only that exact archive. The historical concept
 DOI `10.5281/zenodo.6387591` covers releases through `v0.1.6`; preserve it as
 predecessor provenance, but do not publish new releases under it.
+
+Archiving is manual, so the legacy GitHub-Zenodo integration must stay switched
+off for this repository. The repository still carries the `release` webhook that
+integration installed. If the corresponding Zenodo-side toggle is ever
+re-enabled, tagging a release auto-deposits a new version under the historical
+concept DOI and the package ends up with two live concept records. Before
+tagging, confirm the repository is off in the Zenodo GitHub settings, and after
+publishing confirm that `10.5281/zenodo.6387591` still resolves to the `v0.1.6`
+record rather than the new release.
 
 After publishing:
 

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -10,20 +10,39 @@ Release changes live in this repository first. The checks here cover ToQUBO-spec
    - For `0.Y.Z`, use `0.Y`.
    - For `0.0.Z`, use `0.0.Z`.
    - For `X.Y.Z` with `X > 0`, use `X`.
-4. Run the static release preflight:
+4. In Zenodo, create a **new version** from the existing ToQUBO record under
+   concept DOI `10.5281/zenodo.21763525`; never create a new top-level record
+   for a routine release. Reserve the new version DOI, but leave the deposit
+   unpublished until the matching GitHub release exists.
+5. Update `CITATION.cff` with the release version, date, and reserved version
+   DOI. Keep the concept DOI unchanged. Update `CITATION.bib` and the marked
+   citation section shared by `README.md` and `docs/src/index.md`.
+6. Validate the Citation File Format schema:
+
+```sh
+cffconvert --validate --infile CITATION.cff
+```
+
+7. Run the static release preflight:
 
 ```sh
 julia --project=. scripts/release_check.jl
 ```
 
-5. Run the package and documentation checks:
+8. Run the package and documentation checks:
 
 ```sh
 julia --project=. -e 'import Pkg; Pkg.test()'
 julia --project=docs docs/make.jl --skip-deploy
 ```
 
-6. Open and merge the release PR after CI is green.
+9. Open and merge the release PR after CI is green.
+
+The Zenodo deposit is currently managed by the designated maintainer account
+`bernalde`. Review the single-manager exception annually and whenever package
+maintainership changes; add a backup manager when another active maintainer
+volunteers. Use personal Zenodo accounts and scoped API tokens—never share an
+account password or commit a token.
 
 ## Register
 
@@ -53,6 +72,35 @@ gh run list --workflow TagBot.yml --limit 10
 git ls-remote --tags origin vX.Y.Z
 gh release view vX.Y.Z
 ```
+
+## Publish and Verify Zenodo
+
+After the GitHub release exists, upload its official source archive to the
+reserved Zenodo version. Confirm the tag, package UUID
+`9a412ddf-83fa-43b6-9748-7843c851aa65`, MIT license, creators, repository URL,
+and release relationship before publishing the deposit.
+
+The concept DOI is the evergreen software identifier. The DOI assigned to the
+new Zenodo version identifies only that exact archive. The historical concept
+DOI `10.5281/zenodo.6387591` covers releases through `v0.1.6`; preserve it as
+predecessor provenance, but do not publish new releases under it.
+
+After publishing:
+
+1. Add the exact version DOI to the GitHub release notes.
+2. Confirm both DOI links resolve (Zenodo may need a short indexing delay):
+
+   ```sh
+   curl --fail --location --output /dev/null https://doi.org/<version-doi>
+   curl --fail --location --output /dev/null https://doi.org/10.5281/zenodo.21763525
+   ```
+
+3. Download the Zenodo archive and the official GitHub release archive, compare
+   their SHA-256 checksums, and inspect the archived `Project.toml` to confirm
+   that its version matches the tag.
+4. Confirm the public Zenodo metadata relates the repository, exact GitHub
+   release, historical concept DOI, and QUBO.jl article
+   (`10.1080/10556788.2026.2702926`) as documented.
 
 ## Verify Pkg.add
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,25 +57,20 @@ Application-oriented examples now live in the [Examples in QUBO.jl](@ref)
 section.
 
 ## Citing ToQUBO.jl
+<!-- citation-policy:start -->
+For general use of `ToQUBO.jl` and the broader `QUBO.jl` ecosystem, cite the
+[published journal article](https://doi.org/10.1080/10556788.2026.2702926).
 
-If you use `ToQUBO.jl` in your work, we kindly ask you to include the following citation:
+For a software citation, use the
+[Zenodo concept DOI](https://doi.org/10.5281/zenodo.21763525). The concept DOI
+is the evergreen identifier for the actively maintained archive. For
+exact-version reproducibility, cite the corresponding version DOI; the archive
+for `v0.6.1` is
+[10.5281/zenodo.21763526](https://doi.org/10.5281/zenodo.21763526).
 
-```tex
-@software{toqubo:2023,
-  author       = {Pedro Maciel Xavier and Pedro Ripper and Tiago Andrade and Joaquim Dias Garcia and David E. Bernal Neira},
-  title        = {{ToQUBO.jl}},
-  month        = {feb},
-  year         = {2023},
-  publisher    = {Zenodo},
-  version      = {v0.1.9},
-  doi          = {10.5281/zenodo.7644291},
-  url          = {https://doi.org/10.5281/zenodo.7644291}
-}
-```
+The corresponding BibTeX entries are:
 
-For the broader `QUBO.jl` ecosystem paper, cite the published journal article:
-
-```tex
+```bibtex
 @article{xavier2026qubojl,
   author       = {Maciel Xavier, Pedro and Ripper, Pedro and Andrade, Tiago and Dias Garcia, Joaquim and Maculan, Nelson and Bernal Neira, David E.},
   title        = {{QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}},
@@ -85,6 +80,23 @@ For the broader `QUBO.jl` ecosystem paper, cite the published journal article:
   doi          = {10.1080/10556788.2026.2702926},
   url          = {https://doi.org/10.1080/10556788.2026.2702926}
 }
+
+@software{toqubo:2026,
+  author       = {Maciel Xavier, Pedro and Ripper, Pedro and Andrade, Tiago and Dias Garcia, Joaquim and Bernal Neira, David E.},
+  title        = {{ToQUBO.jl}},
+  year         = {2026},
+  publisher    = {Zenodo},
+  version      = {v0.6.1},
+  doi          = {10.5281/zenodo.21763526},
+  url          = {https://doi.org/10.5281/zenodo.21763526},
+  note         = {Evergreen concept DOI: 10.5281/zenodo.21763525}
+}
 ```
 
-The [arXiv preprint](https://arxiv.org/abs/2307.02577) remains available.
+The [historical concept DOI](https://doi.org/10.5281/zenodo.6387591) covers
+releases through `v0.1.6` and remains part of the project's provenance; it is
+not the identifier for current releases. Machine-readable metadata is in
+[`CITATION.cff`](https://github.com/JuliaQUBO/ToQUBO.jl/blob/main/CITATION.cff),
+with BibTeX in
+[`CITATION.bib`](https://github.com/JuliaQUBO/ToQUBO.jl/blob/main/CITATION.bib).
+<!-- citation-policy:end -->

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,21 +59,25 @@ section.
 ## Citing ToQUBO.jl
 <!-- citation-policy:start -->
 For general use of `ToQUBO.jl` and the broader `QUBO.jl` ecosystem, cite the
-[published journal article](https://doi.org/10.1080/10556788.2026.2702926).
+[published journal article](https://doi.org/10.1080/10556788.2026.2702926). The
+earlier [arXiv preprint](https://arxiv.org/abs/2307.02577) remains available,
+but the journal article is the version of record.
 
 For a software citation, use the
 [Zenodo concept DOI](https://doi.org/10.5281/zenodo.21763525). The concept DOI
-is the evergreen identifier for the actively maintained archive. For
-exact-version reproducibility, cite the corresponding version DOI; the archive
-for `v0.6.1` is
+is the evergreen identifier for the actively maintained archive and is the DOI
+recorded in `CITATION.cff`. When reproducibility requires an exact release,
+cite the matching version DOI instead; the archive for `v0.6.1` is
 [10.5281/zenodo.21763526](https://doi.org/10.5281/zenodo.21763526).
 
-The corresponding BibTeX entries are:
+The BibTeX entries below pin that exact release. Replace the `@software` entry's
+`doi` and `url` with the concept DOI when an evergreen software citation is
+preferred:
 
 ```bibtex
 @article{xavier2026qubojl,
   author       = {Maciel Xavier, Pedro and Ripper, Pedro and Andrade, Tiago and Dias Garcia, Joaquim and Maculan, Nelson and Bernal Neira, David E.},
-  title        = {{QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}},
+  title        = {{QUBO.jl: a Julia ecosystem for quadratic unconstrained binary optimization}},
   journal      = {Optimization Methods and Software},
   year         = {2026},
   pages        = {1--24},

--- a/scripts/release_check.jl
+++ b/scripts/release_check.jl
@@ -70,6 +70,14 @@ function cff_version_doi(citation::String)
     return result === nothing ? nothing : only(result.captures)
 end
 
+function preferred_citation_title(citation::String)
+    parts = split(citation, "preferred-citation:"; limit = 2)
+    length(parts) == 2 || return nothing
+
+    result = match(r"(?m)^\s+title:\s*\"([^\"]+)\"\s*$", parts[2])
+    return result === nothing ? nothing : only(result.captures)
+end
+
 function bibtex_block(section::AbstractString)
     result = match(r"(?ms)```bibtex\s*\n(.*?)\n```", section)
     return result === nothing ? nothing : strip(only(result.captures))
@@ -181,6 +189,13 @@ function main()
         "CITATION.cff preferred citation must identify the published QUBO.jl article.",
     )
 
+    article_title = preferred_citation_title(citation)
+    check!(
+        failures,
+        article_title !== nothing && occursin(article_title, citation_bib),
+        "CITATION.bib must spell the article title exactly as CITATION.cff preferred-citation does.",
+    )
+
     citation_start = "<!-- citation-policy:start -->"
     citation_end = "<!-- citation-policy:end -->"
     readme_citation = marked_section(readme, citation_start, citation_end)
@@ -227,11 +242,6 @@ function main()
         failures,
         occursin("new version", lowercase(release_docs)) && occursin(concept_doi, release_docs),
         "Release documentation must say to create a new version under concept DOI $concept_doi.",
-    )
-    check!(
-        failures,
-        occursin("cffconvert --validate --infile CITATION.cff", release_docs),
-        "Release documentation must require CFF schema validation.",
     )
 
     if isempty(failures)

--- a/scripts/release_check.jl
+++ b/scripts/release_check.jl
@@ -38,6 +38,43 @@ function release_section(news::String, version::VersionNumber)
     return join(lines[start:stop], "\n")
 end
 
+function release_date(news::String, version::VersionNumber)
+    heading = "## v$(version) - "
+    line = findfirst(line -> startswith(line, heading), split(news, '\n'))
+    line === nothing && return nothing
+
+    heading_line = split(news, '\n')[line]
+    return strip(replace(heading_line, heading => ""; count = 1))
+end
+
+function marked_section(document::String, start_marker::String, end_marker::String)
+    start_parts = split(document, start_marker; limit = 2)
+    length(start_parts) == 2 || return nothing
+
+    end_parts = split(start_parts[2], end_marker; limit = 2)
+    length(end_parts) == 2 || return nothing
+
+    return strip(end_parts[1])
+end
+
+function quoted_cff_value(citation::String, key::String)
+    result = match(Regex("(?m)^$(key):\\s*\"([^\"]+)\"\\s*\$"), citation)
+    return result === nothing ? nothing : only(result.captures)
+end
+
+function cff_version_doi(citation::String)
+    result = match(
+        r"(?ms)value:\s*\"(10\.5281/zenodo\.\d+)\"\s*\n\s*description:\s*\"Zenodo DOI for version",
+        citation,
+    )
+    return result === nothing ? nothing : only(result.captures)
+end
+
+function bibtex_block(section::AbstractString)
+    result = match(r"(?ms)```bibtex\s*\n(.*?)\n```", section)
+    return result === nothing ? nothing : strip(only(result.captures))
+end
+
 function main()
     failures = String[]
     warnings = String[]
@@ -100,9 +137,108 @@ function main()
         )
     end
 
+    citation = read(project_file("CITATION.cff"), String)
+    citation_bib = strip(read(project_file("CITATION.bib"), String))
+    readme = read(project_file("README.md"), String)
+    docs_index = read(project_file("docs", "src", "index.md"), String)
+    release_docs = read(project_file("docs", "dev", "release.md"), String)
+
+    concept_doi = "10.5281/zenodo.21763525"
+    historical_concept_doi = "10.5281/zenodo.6387591"
+    obsolete_version_doi = "10.5281/zenodo.7644291"
+    article_doi = "10.1080/10556788.2026.2702926"
+    version_doi = cff_version_doi(citation)
+    news_date = release_date(news, version)
+
+    check!(
+        failures,
+        quoted_cff_value(citation, "version") == string(version),
+        "CITATION.cff version must match Project.toml version $version.",
+    )
+    check!(
+        failures,
+        quoted_cff_value(citation, "doi") == concept_doi,
+        "CITATION.cff must use the successor concept DOI $concept_doi as its evergreen DOI.",
+    )
+    check!(
+        failures,
+        news_date !== nothing && occursin("date-released: $news_date", citation),
+        "CITATION.cff date-released must match the NEWS.md date for v$version.",
+    )
+    check!(
+        failures,
+        version_doi !== nothing && version_doi != concept_doi,
+        "CITATION.cff must identify a distinct Zenodo version DOI.",
+    )
+    check!(
+        failures,
+        occursin("description: \"Zenodo DOI for version $version\"", citation),
+        "CITATION.cff version DOI description must match Project.toml version $version.",
+    )
+    check!(
+        failures,
+        occursin(article_doi, citation),
+        "CITATION.cff preferred citation must identify the published QUBO.jl article.",
+    )
+
+    citation_start = "<!-- citation-policy:start -->"
+    citation_end = "<!-- citation-policy:end -->"
+    readme_citation = marked_section(readme, citation_start, citation_end)
+    docs_citation = marked_section(docs_index, citation_start, citation_end)
+
+    check!(
+        failures,
+        readme_citation !== nothing && readme_citation == docs_citation,
+        "README.md and docs/src/index.md citation sections must remain synchronized.",
+    )
+
+    if readme_citation !== nothing
+        check!(
+            failures,
+            bibtex_block(readme_citation) == citation_bib,
+            "The README/docs BibTeX example must match CITATION.bib.",
+        )
+        for doi in (concept_doi, historical_concept_doi, article_doi)
+            check!(
+                failures,
+                occursin(doi, readme_citation),
+                "The synchronized citation section must document DOI $doi.",
+            )
+        end
+        check!(
+            failures,
+            version_doi !== nothing && occursin(version_doi, readme_citation),
+            "The synchronized citation section must document the current version DOI.",
+        )
+        check!(
+            failures,
+            occursin("`v$version`", readme_citation),
+            "The synchronized citation section must name current version v$version.",
+        )
+    end
+
+    maintained_citations = join((citation, citation_bib, readme, docs_index), "\n")
+    check!(
+        failures,
+        !occursin(obsolete_version_doi, maintained_citations),
+        "Historical version DOI $obsolete_version_doi must not be used by maintained citation metadata.",
+    )
+    check!(
+        failures,
+        occursin("new version", lowercase(release_docs)) && occursin(concept_doi, release_docs),
+        "Release documentation must say to create a new version under concept DOI $concept_doi.",
+    )
+    check!(
+        failures,
+        occursin("cffconvert --validate --infile CITATION.cff", release_docs),
+        "Release documentation must require CFF schema validation.",
+    )
+
     if isempty(failures)
         println("Release preflight passed for ToQUBO v$version.")
         println("Expected docs self-compat: ToQUBO = \"$expected_self_compat\".")
+        println("Citation concept DOI: $concept_doi.")
+        println("Citation version DOI: $version_doi.")
     else
         println(stderr, "Release preflight failed:")
         foreach(message -> println(stderr, "- ", message), failures)

--- a/scripts/release_check.jl
+++ b/scripts/release_check.jl
@@ -78,6 +78,16 @@ function preferred_citation_title(citation::String)
     return result === nothing ? nothing : only(result.captures)
 end
 
+function bibtex_entry(bib::AbstractString, entry_type::AbstractString)
+    result = match(Regex("(?ms)^@$(entry_type)\\{.*?^\\}"), bib)
+    return result === nothing ? nothing : result.match
+end
+
+function bibtex_field(entry::AbstractString, field::AbstractString)
+    result = match(Regex("(?m)^\\s*$(field)\\s*=\\s*\\{(.*)\\},?\\s*\$"), entry)
+    return result === nothing ? nothing : strip(only(result.captures))
+end
+
 function bibtex_block(section::AbstractString)
     result = match(r"(?ms)```bibtex\s*\n(.*?)\n```", section)
     return result === nothing ? nothing : strip(only(result.captures))
@@ -195,10 +205,31 @@ function main()
         article_title !== nothing && occursin(article_title, citation_bib),
         "CITATION.bib must spell the article title exactly as CITATION.cff preferred-citation does.",
     )
+
+    article_entry = bibtex_entry(citation_bib, "article")
+    software_entry = bibtex_entry(citation_bib, "software")
+
+    for (entry, label, doi) in (
+        (article_entry, "@article", article_doi),
+        (software_entry, "@software", version_doi),
+    )
+        check!(
+            failures,
+            entry !== nothing && doi !== nothing && bibtex_field(entry, "doi") == doi,
+            "The CITATION.bib $label entry must set doi = {$doi}.",
+        )
+        check!(
+            failures,
+            entry !== nothing && doi !== nothing &&
+                bibtex_field(entry, "url") == "https://doi.org/$doi",
+            "The CITATION.bib $label entry must set url = {https://doi.org/$doi}.",
+        )
+    end
+
     check!(
         failures,
-        occursin(article_doi, citation_bib),
-        "CITATION.bib must cite the published QUBO.jl article DOI $article_doi.",
+        software_entry !== nothing && occursin(concept_doi, software_entry),
+        "The CITATION.bib @software entry must name the evergreen concept DOI $concept_doi.",
     )
 
     citation_start = "<!-- citation-policy:start -->"

--- a/scripts/release_check.jl
+++ b/scripts/release_check.jl
@@ -195,6 +195,11 @@ function main()
         article_title !== nothing && occursin(article_title, citation_bib),
         "CITATION.bib must spell the article title exactly as CITATION.cff preferred-citation does.",
     )
+    check!(
+        failures,
+        occursin(article_doi, citation_bib),
+        "CITATION.bib must cite the published QUBO.jl article DOI $article_doi.",
+    )
 
     citation_start = "<!-- citation-policy:start -->"
     citation_end = "<!-- citation-policy:end -->"


### PR DESCRIPTION
## Summary

- publish the official `v0.6.1` source archive under a successor Zenodo concept record managed by `bernalde`
- make the QUBO.jl article the preferred general citation while distinguishing the evergreen concept DOI from the exact-version DOI
- preserve the original ToQUBO concept DOI as historical provenance through `v0.1.6`
- synchronize CFF, BibTeX, README, and documentation metadata
- extend the release preflight to reject citation drift, validate `CITATION.cff` against the
  Citation File Format schema in CI, and document the repeatable Zenodo release procedure

## Zenodo archive

- Public record: https://zenodo.org/records/21763526
- Successor concept DOI: https://doi.org/10.5281/zenodo.21763525
- `v0.6.1` DOI: https://doi.org/10.5281/zenodo.21763526
- Historical concept DOI: https://doi.org/10.5281/zenodo.6387591
- Release commit: `9feda34c0fb10a5ed8539dd4add915aa4ff9006c`
- Archive: `ToQUBO.jl-0.6.1.tar.gz` (855,928 bytes)
- SHA-256: `5fd65a342fd2d6a84653730c02a09457dd7c1658dd56fb1195069cb3e9f2a621`
- MD5 reported by Zenodo: `e9d1e5da9550527093c7a0f6bd03c995`
- Julia package UUID: `9a412ddf-83fa-43b6-9748-7843c851aa65`

The public record relates the repository, exact GitHub release, historical concept DOI, and published QUBO.jl article. Its creator order, ORCIDs, version, date, license, and archive checksum were read back from the public Zenodo API after publication. Both the concept and version DOI resolve to the published record.

## Acceptance criteria

- [x] The citation policy and DOI semantics are documented.
- [x] All maintained citation representations agree with that policy.
- [x] The CI release preflight fails when the citation invariant drifts.
- [x] `CITATION.cff` validates against Citation File Format 1.2.0.
- [x] README and documentation citation examples are byte-synchronized and match `CITATION.bib`.
- [x] Future releases have a documented reserve-before-tag, publish-after-release Zenodo workflow.

## Validation

Measured at `b719f4f`, the head this PR opened with. Later heads are covered under
`Review follow-up` below.


- `julia +release --project=/tmp/toqubo-issue-220 /tmp/toqubo-issue-220/scripts/release_check.jl`: passed on Julia 1.12.0
- mutation checks: the preflight failed independently for a mismatched CFF version, README/docs drift, and reintroduction of DOI `10.5281/zenodo.7644291`
- `uvx --cache-dir /tmp/toqubo-uv-cache --from cffconvert cffconvert --validate --infile CITATION.cff`: valid against CFF schema 1.2.0
- `actionlint .github/workflows/ci.yml`: passed
- `julia +release --project=/tmp/toqubo-issue-220 -e 'using Pkg; Pkg.test()'`: 1,928/1,928 passed
- `julia +release --project=/tmp/toqubo-issue-220/docs /tmp/toqubo-issue-220/docs/make.jl --skip-deploy`: passed; deployment intentionally skipped
- public Zenodo API metadata and both DOI redirects: verified after publication

## Review follow-up

### `a4f5ab5` — maintainer review of `b719f4f`


- CI now runs `cffconvert --validate --infile CITATION.cff` in its own step. The preflight
  previously asserted only that `docs/dev/release.md` mentioned that command, which passed an
  invalid CFF and failed on a documentation reword. Verified: setting `license: NOT-A-LICENSE`
  leaves the Julia preflight at exit 0 while `cffconvert` exits 1.
- `CITATION.bib` spells the article title as Crossref records it, matching the
  `CITATION.cff` `preferred-citation`, and the preflight now fails when the two spellings differ.
- The shared citation section states that the BibTeX entries pin `v0.6.1` and that the concept
  DOI replaces them for an evergreen citation, so the prose matches the artifact beneath it.
- `docs/dev/release.md` records that the legacy GitHub-Zenodo integration must stay off; the
  `release` webhook is still installed and would otherwise deposit under historical concept DOI
  `10.5281/zenodo.6387591`.
- The arXiv preprint reference is back in the shared section, matching the README badge.

Additional validation at `a4f5ab5`: preflight passes (exit 0); five mutation probes each fail as
intended (BibTeX title drift, CFF preferred-citation title drift, CFF title removed, CFF version
drift, README/docs desync); `cffconvert --validate` reports valid against schema 1.2.0;
`actionlint` clean; CI green on all seven checks, with the new `Validate CITATION.cff` step
confirmed to have executed in the `Julia 1 - ubuntu-latest - x64` job.

### `4b45c6e` — targeted re-review of `a4f5ab5`

- Pin `cffconvert==2.0.0` in CI. Every action in this workflow is pinned, and an
  unpinned install was the one step whose behavior could change without a commit.
- Fail the preflight when `CITATION.bib` drops the published article DOI. The re-review
  reproduced the gap: stripping that `doi` line and syncing the README/docs block left the
  run green, because the DOI check read only `CITATION.cff` and the synchronized-section
  check was satisfied by the prose link.

Validation at `4b45c6e`: preflight passes (exit 0); the new check fails with the intended
message when the article DOI is stripped from `CITATION.bib`; `cffconvert==2.0.0` installs
into a clean venv and reports the CFF valid against schema 1.2.0; `actionlint` clean.

### `2f7fe13` — targeted re-review of `4b45c6e`

- Bind the `CITATION.bib` DOI checks to the `doi` and `url` fields of the `@article` and
  `@software` entries. The previous checks were whole-file and whole-section substring tests,
  so a wrong `doi` field passed as long as the correct DOI survived elsewhere in the entry.
  Reproduced at `4b45c6e`: replacing either `doi` field with a fake DOI while leaving the
  matching `url` intact left the preflight at exit 0.
- The `@software` entry must now name the concept DOI itself rather than relying on the prose
  link, closing the same gap for the `note` field.

Validation at `2f7fe13`: preflight passes (exit 0); six negative probes each fail with the
intended message and exit 1 — wrong `@article` `doi`, wrong `@software` `doi`, wrong concept
DOI in the `note`, wrong `@article` `url`, wrong `@software` `url`, and a missing `@software`
entry; `git diff --cached --check` clean; CI green on all seven checks, with `Check release and
citation metadata` and `Validate CITATION.cff` both confirmed to have executed.

## Branch Hygiene

- Base branch: `main`
- Source branch: `docs/issue-220-successor-zenodo`
- Branch point: `4fb1532bb8e8679234a07b6e0e674f125287f1f0`
- Stacked: no
- Prerequisite PRs: none
- Open-PR file overlap immediately before push: none
- The unrelated dirty primary checkout was not modified; implementation and verification ran in a clean temporary worktree.

Closes #220

Related ecosystem tracker: JuliaQUBO/QUBO.jl#66



