### PR TITLE
Record removal of the legacy Zenodo release webhook

### DIFF
--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -87,13 +87,14 @@ DOI `10.5281/zenodo.6387591` covers releases through `v0.1.6`; preserve it as
 predecessor provenance, but do not publish new releases under it.
 
 Archiving is manual, so the legacy GitHub-Zenodo integration must stay switched
-off for this repository. The repository still carries the `release` webhook that
-integration installed. If the corresponding Zenodo-side toggle is ever
-re-enabled, tagging a release auto-deposits a new version under the historical
-concept DOI and the package ends up with two live concept records. Before
-tagging, confirm the repository is off in the Zenodo GitHub settings, and after
-publishing confirm that `10.5281/zenodo.6387591` still resolves to the `v0.1.6`
-record rather than the new release.
+off for this repository. Its `release` webhook was removed on 2026-08-03; GitHub
+had recorded no deliveries from it, and no automatic deposit was ever made for
+`v0.6.1`. Toggling the repository back on in Zenodo's GitHub settings recreates
+that webhook, and tagging a release would then auto-deposit a new version under
+the historical concept DOI, leaving the package with two live concept records.
+Before tagging, confirm the repository is still off in the Zenodo GitHub
+settings, and after publishing confirm that `10.5281/zenodo.6387591` still
+resolves to the `v0.1.6` record rather than the new release.
 
 After publishing:
 


### PR DESCRIPTION
## Summary

Correct one sentence in `docs/dev/release.md` that #236 merged and that is no longer true.

The legacy GitHub-Zenodo integration's `release` webhook was deleted from this repository on
2026-08-03. #236 documented the manual archiving policy while that webhook was still installed,
so its text says "The repository still carries the `release` webhook that integration installed."
That now asserts something false in released documentation.

## Evidence for the removal

Before deleting, the webhook was confirmed inert:

- id `349691467`, host `zenodo.org`, single `release` event, created `2022-03-24` — contemporaneous
  with the original concept record `10.5281/zenodo.6387591`
- `last_response.status` was `unused`, so GitHub had never recorded a response from it
- the deliveries endpoint returned zero entries
- no automatic deposit exists for the `v0.6.1` release; `10.5281/zenodo.6387591` still resolves to
  record `7850962` (`v0.1.6`)

`gh api repos/JuliaQUBO/ToQUBO.jl/hooks` now returns an empty list.

## What the doc says instead

The pre-tag check is kept deliberately. Re-enabling the repository in Zenodo's GitHub settings
recreates the webhook, so the risk the paragraph guards against is deferred, not eliminated. The
paragraph now records when and why the webhook was removed, and still requires confirming the
Zenodo-side toggle before tagging and re-checking the historical concept DOI after publishing.

## Validation

- `julia --project=. scripts/release_check.jl`: passes, exit 0 — the preflight reads
  `docs/dev/release.md` and still finds the required "new version" and concept DOI wording
- `git diff --check`: clean; no hyphenated compound wrapped across a line break

## Branch Hygiene

- Base branch: `main`
- Source branch: `docs/zenodo-webhook-removed`
- Branch point: `990fd79` (the merge of #236)
- Stacked: no
- Open-PR file overlap: none — #234 and #235 touch no documentation under `docs/dev/`

Follows up #236. Refs #220.
